### PR TITLE
RcppDeepState-action missing system dependency

### DIFF
--- a/.github/workflows/RcppDeepState.yml
+++ b/.github/workflows/RcppDeepState.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: FabrizioSandri/RcppDeepState-action@main
         with:
           fail_ci_if_error: 'true'
+          additional_dependencies: libgsl-dev
           location: '/'
           seed: '-1'
           max_seconds_per_function: '2'


### PR DESCRIPTION
While running RcppDeepState locally, I discovered that the GNU Scientific Library, which is available as the `libgsl-dev` Ubuntu package, is required for the system to use this package. As a result, this pull request adds the missing dependency `libgsl-dev` to the system that executes the RcppDeepState.

The `additional_dependencies` argument allows you to provide extra system packages (Ubuntu packages) that will be installed before RcppDeepState is run. You can find more details in the [README](https://github.com/FabrizioSandri/RcppDeepState-action) file.
