### PR TITLE
Rooting in `PlotCharacter()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # TreeSearch 1.6.0.9001 (development)
 - Tweak documentation
 - Handle invariant characters in `PolEscapa()`
-- Improve error reporting in `PlotCharacter()`
+- Handle challenging rootings in `PlotCharacter()`
 
 # TreeSearch 1.6.0 (2025-04-09)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # TreeSearch 1.6.0.9001 (development)
 - Tweak documentation
 - Handle invariant characters in `PolEscapa()`
-- Handle challenging rootings in `PlotCharacter()`
+- Handle challenging root positions in `PlotCharacter()`
 
 # TreeSearch 1.6.0 (2025-04-09)
 

--- a/R/PlotCharacter.R
+++ b/R/PlotCharacter.R
@@ -493,6 +493,16 @@ PlotCharacter.multiPhylo <- function(tree, dataset, char = 1L,
                             Display = function(tree) tree, ...)
   # Check labels: definitely identical, possibly in different sequence
   consTree <- Display(Consensus(tree, p = 1, check.labels = TRUE))
+  consOutgroup <- DescendantTips(consTree[["edge"]][, 1],
+                                 consTree[["edge"]][, 2],
+                                 node = nTip + consTree[["Nnode"]])
+  if (sum(consOutgroup) > nTip / 2) {
+    consOutgroup <- !consOutgroup
+  }
+  .MatchRooting <- function(tr) {
+    RootTree(tr, consOutgroup)
+  }
+  
   .TreeClades <- function(tr) {
     ed <- tr[["edge"]]
     lab <- TipLabels(tr)
@@ -504,7 +514,7 @@ PlotCharacter.multiPhylo <- function(tree, dataset, char = 1L,
   }
   consClades <- .TreeClades(consTree)
   .Recon <- function(i) {
-    matches <- match(consClades, .TreeClades(tree[[i]]))
+    matches <- match(consClades, .TreeClades(.MatchRooting(tree[[i]])))
     if (any(is.na(matches))) {
       stop("Clades from consensus tree not in tree ", i, ":\n  ",
            paste0(gsub(fixed = TRUE, " @||@ ", ", ",

--- a/R/PlotCharacter.R
+++ b/R/PlotCharacter.R
@@ -493,12 +493,12 @@ PlotCharacter.multiPhylo <- function(tree, dataset, char = 1L,
                             Display = function(tree) tree, ...)
   # Check labels: definitely identical, possibly in different sequence
   consTree <- Display(Consensus(tree, p = 1, check.labels = TRUE))
-  consOutgroup <- DescendantTips(consTree[["edge"]][, 1],
-                                 consTree[["edge"]][, 2],
-                                 node = nTip + consTree[["Nnode"]])
+  consEdge <- Preorder(consTree[["edge"]])
+  consOutgroup <- DescendantTips(consEdge[, 1], consEdge[, 2], node = nTip + 2)
   if (sum(consOutgroup) > nTip / 2) {
     consOutgroup <- !consOutgroup
   }
+  consOutgroup <- TipLabels(consTree)[consOutgroup]
   .MatchRooting <- function(tr) {
     RootTree(tr, consOutgroup)
   }

--- a/tests/testthat/test-PlotCharacter.R
+++ b/tests/testthat/test-PlotCharacter.R
@@ -6,16 +6,7 @@ test_that("PlotCharacter.phylo()", {
   expect_error(PlotCharacter(TreeTools::StarTree(12), dataset),
                "bifurcating")
   
-  trs <- c(RootTree(TreeTools::PectinateTree(12), c("t9", "t12")),
-           RootTree(TreeTools::PectinateTree(12), c("t11", "t12")))
-  og <- paste0("t", c(1, 12))
-  Disp <- function(tr) {
-    TreeTools::SortTree(RootTree(tr, og))
-  }
-  expect_error(PlotCharacter(trs, dataset, Display = Disp),
-               "Clades from consensus tree not in tree 2:\n  t10, t11, t12, t9;\n  t10, t11, t12")
-  
-  Character <- function (str, plot = FALSE, edges = FALSE, ...) {
+  Character <- function(str, plot = FALSE, edges = FALSE, ...) {
     tree <- ape::read.tree(text = 
      "((((((a, b), c), d), e), f), (g, (h, (i, (j, (k, l))))));")
     if (edges) {
@@ -47,11 +38,11 @@ test_that("PlotCharacter.phylo()", {
   skip_if_not_installed("vdiffr")
 
   Test <- if (interactive()) {
-    function (str, edges = FALSE, ...) {
+    function(str, edges = FALSE, ...) {
       invisible(Character(str, plot = TRUE, edges = edges, ...))
     }
   } else {
-    function (str, edges = FALSE, ...) {
+    function(str, edges = FALSE, ...) {
       vdiffr::expect_doppelganger(
         paste0("PlotChar_",
                gsub("?", "Q",
@@ -135,18 +126,21 @@ test_that("Edge cases work", {
 
 test_that("PlotCharacter() with wide rootings", {
   trees <- c(
-    ape::read.tree(text = "((c, (a, d)), (e, (f, (g, (h, b)))));"),
-    ape::read.tree(text = "((c, (a, d)), (e, (f, (b, (h, g)))));")
+    ape::read.tree(text = "((c, (a, d)), (g, (h, b)));"),
+    ape::read.tree(text = "((c, (a, d)), (b, (h, g)));")
   )
   rooted <- RootTree(trees, c("a", "b"))
-  PlotCharacter(rooted,
-                TreeTools::StringToPhyDat("00111111", tips = trees[[1]]),
-                plot = FALSE)
+  expect_equal(
+    PlotCharacter(rooted,
+                  TreeTools::StringToPhyDat("001111", tips = trees[[1]]),
+                  plot = FALSE)[, "1"],
+    c(FALSE, FALSE, rep(TRUE, 8))
+  )
 })
 
 test_that("Out-of-sequence works", {
   skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger("PlotChar_out-of-sequence", function () {
+  vdiffr::expect_doppelganger("PlotChar_out-of-sequence", function() {
     PlotCharacter(ape::read.tree(text = "(a, (b, (c, d)));"),
                   TreeTools::StringToPhyDat("1342",
                                             tips = c("a", "c", "d", "b"))

--- a/tests/testthat/test-PlotCharacter.R
+++ b/tests/testthat/test-PlotCharacter.R
@@ -133,6 +133,17 @@ test_that("Edge cases work", {
   }
 })
 
+test_that("PlotCharacter() with wide rootings", {
+  trees <- c(
+    ape::read.tree(text = "((c, (a, d)), (e, (f, (g, (h, b)))));"),
+    ape::read.tree(text = "((c, (a, d)), (e, (f, (b, (h, g)))));")
+  )
+  rooted <- RootTree(trees, c("a", "b"))
+  PlotCharacter(rooted,
+                TreeTools::StringToPhyDat("00111111", tips = trees[[1]]),
+                plot = FALSE)
+})
+
 test_that("Out-of-sequence works", {
   skip_if_not_installed("vdiffr")
   vdiffr::expect_doppelganger("PlotChar_out-of-sequence", function () {

--- a/tests/testthat/test-PlotCharacter.R
+++ b/tests/testthat/test-PlotCharacter.R
@@ -126,15 +126,15 @@ test_that("Edge cases work", {
 
 test_that("PlotCharacter() with wide rootings", {
   trees <- c(
-    ape::read.tree(text = "((c, (a, d)), (g, (h, b)));"),
-    ape::read.tree(text = "((c, (a, d)), (b, (h, g)));")
+    ape::read.tree(text = "((c, (a, d)), (e, (g, (f, b))));"),
+    ape::read.tree(text = "((c, (a, d)), (e, (b, (f, g))));")
   )
   rooted <- RootTree(trees, c("a", "b"))
   expect_equal(
     PlotCharacter(rooted,
-                  TreeTools::StringToPhyDat("001111", tips = trees[[1]]),
+                  TreeTools::StringToPhyDat("0011111", tips = letters[1:7]),
                   plot = FALSE)[, "1"],
-    c(FALSE, FALSE, rep(TRUE, 8))
+    !1:12 %in% c(2, 7)
   )
 })
 


### PR DESCRIPTION
Fixes issue where consensus tree root clade straddles the root in input trees