### PR TITLE
T-208: Fix random_topology_tree ignoring constraints

### DIFF
--- a/src/ts_driven.cpp
+++ b/src/ts_driven.cpp
@@ -109,7 +109,13 @@ ReplicateResult run_single_replicate(
         break;
       }
       case StartStrategy::RANDOM_TREE:
-        random_topology_tree(result.tree, ds);
+        // random_topology_tree() does not enforce constraints;
+        // fall back to Wagner when constraints are active (T-208)
+        if (cd && cd->active) {
+          random_wagner_tree(result.tree, ds, cd);
+        } else {
+          random_topology_tree(result.tree, ds);
+        }
         break;
       default:  // WAGNER_RANDOM (and pool-based fallback)
         random_wagner_tree(result.tree, ds, cd);

--- a/tests/testthat/test-ts-constraint-small.R
+++ b/tests/testthat/test-ts-constraint-small.R
@@ -133,3 +133,19 @@ test_that("different fully-resolving constraints on 5 tips", {
     )
   }
 })
+
+test_that("T-208: adaptiveStart with constraints respects constraint", {
+  ds5 <- make_ds5()
+  cons <- ape::read.tree(text = "((t1,t2),(t3,(t4,t5)));")
+
+  set.seed(7293)
+  result <- MaximizeParsimony(ds5, constraint = cons,
+                              maxReplicates = 8L, targetHits = 4L,
+                              verbosity = 0L,
+                              control = SearchControl(adaptiveStart = TRUE))
+  expect_s3_class(result, "multiPhylo")
+  for (i in seq_along(result)) {
+    expect_true(check_constraint(result[[i]], cons),
+                info = paste("tree", i, "violates constraint"))
+  }
+})


### PR DESCRIPTION
Agent G.

**Bug:** When `adaptiveStart=TRUE` (thorough preset) and constraints active, the bandit could select `RANDOM_TREE`, which calls `random_topology_tree()` without `ConstraintData`. The resulting starting tree may violate constraints, causing TBR to block all constraint-relevant moves (`cn=-1`). Could return constraint-violating trees.

**Fix:** Fall back to `random_wagner_tree(tree, ds, cd)` when `RANDOM_TREE` is selected and `cd->active` is true. Preserves random-start exploration intent while respecting constraints.

**Test:** Added `adaptiveStart + constraint` test (8 replicates, 4 target hits).

**GHA:** Run 23506900264 — PASS (Ubuntu ARM64 + Windows).