### PR TITLE
T-209: Skip NNI perturbation when constraints active

### DIFF
--- a/src/ts_driven.cpp
+++ b/src/ts_driven.cpp
@@ -307,7 +307,10 @@ ReplicateResult run_single_replicate(
     }
 
     // 4b. NNI perturbation (topology-space escape)
-    if (nni_perturb_per > 0) {
+    // Skip when constraints are active: random_nni_perturb() doesn't
+    // enforce constraints, and a constraint-violating tree can't be
+    // repaired by TBR (cn=-1 blocks all constraint-relevant moves).
+    if (nni_perturb_per > 0 && (!cd || !cd->active)) {
       NNIPerturbParams np;
       np.n_cycles = nni_perturb_per;
       np.perturb_fraction = params.nni_perturb_fraction;


### PR DESCRIPTION
Agent E. Fixes bug where random_nni_perturb() applies NNI swaps without checking topological constraints. When a swap violates a constraint, TBR cannot recover (cn=-1 blocks all constraint-relevant moves), potentially returning constraint-violating trees.

Same mechanism as T-208 (random_topology_tree ignores constraints).

Fix: gate NNI perturbation on (!cd || !cd->active) in run_single_replicate(), matching the existing NNI warmup guard.

Found by S-RED focus 2.
GHA 23506971922: PASS (ubuntu-arm64 + windows).