### PR TITLE
fix: revert broken inapplicable simplification bypass (T-215)

### DIFF
--- a/src/ts_simplify.cpp
+++ b/src/ts_simplify.cpp
@@ -185,20 +185,16 @@ SimplificationResult simplify_patterns(
     // Build per-tip token bitmasks from the original data
     sp.tip_tokens.resize(n_tips);
     bool has_inapp = false;
-    // A full-? token has all state bits set; it represents missing data,
-    // not genuine inapplicability, so it should not trigger the bypass.
-    uint32_t all_states_mask = (1u << n_states) - 1;
     for (int tip = 0; tip < n_tips; ++tip) {
       int token = tip_data_r[tip + n_tips * p] - 1;  // 1-based to 0-based
       sp.tip_tokens[tip] = token_states[token];
       if (inapp_state >= 0 &&
-          (token_states[token] & (1u << inapp_state)) &&
-          token_states[token] != all_states_mask) {
+          (token_states[token] & (1u << inapp_state))) {
         has_inapp = true;
       }
     }
 
-    // Phase 1: skip genuinely inapplicable characters
+    // Phase 1: skip inapplicable characters entirely
     if (has_inapp) {
       // Count states for metadata only
       uint32_t all = all_applicable_mask(sp.tip_tokens, n_tips, n_states,

--- a/tests/testthat/test-ts-simplify.R
+++ b/tests/testthat/test-ts-simplify.R
@@ -561,22 +561,18 @@ test_that("Mixed degenerate inapplicable/missing patterns score correctly", {
   }
 })
 
-test_that("'All in [0, ?]' characters simplified in inapplicable datasets", {
-  # In an inapplicable dataset, ? tokens include the inapp bit.
-  # Characters where every tip is one applicable state or ? are genuinely
-  # uninformative and should be simplified away (not bypassed).
+test_that("'All in [0, ?]' characters NOT simplified in inapplicable datasets", {
+  # In an inapplicable dataset, ? tokens include the inapp bit. Even when
+  # every tip is one applicable state or ?, the three-pass NA algorithm may
+  # reconstruct ? as inapplicable on some topologies, making the character
+  # topology-dependent. It must NOT be simplified away.
   mat <- matrix(c(
-    "0", "0", "?", "?", "?", "?", "?", "?",  # all-0-or-? -> uninformative
+    "0", "0", "?", "?", "?", "?", "?", "?",  # all-0-or-?: kept (? includes -)
     "0", "0", "1", "1", "-", "-", "?", "?",   # mixed informative
     "0", "0", "0", "0", "1", "1", "1", "1"    # standard informative
   ), nrow = 8, dimnames = list(paste0("t", 1:8), NULL))
   dataset <- MatrixToPhyDat(mat)
   ds <- make_ts_data(dataset)
-  diag <- ts_diag(ds)
-
-  # The all-0-or-? pattern should be identified as uninformative
-  expect_gte(diag$n_patterns_removed, 1L,
-             label = "all-[0,?] pattern should be removed")
 
   # Scores must still match TreeLength on multiple trees
   set.seed(5291)


### PR DESCRIPTION
**Agent D. S-COORD coordination review.**

## Bug

Commit a48bfc4ad ("Simplify 'all-[0,?]' characters in inapplicable datasets") incorrectly allowed simplification of characters where all tips are one applicable state or missing (`?`) in inapplicable datasets.

The `?` token includes the inapplicable bit, so the three-pass NA algorithm may reconstruct `?` as inapplicable on some topologies, making these characters topology-dependent. Simplifying them away caused **score inflation** (e.g. Vinther2008 pectinate EW: 161 vs correct 139).

## Impact

59 test failures across `test-ts-iw.R`, `test-PolEscapa.R`, `test-SearchControl.R`, `test-ts-collapsed.R`, and `test-ts-random-constrained.R`. All IW and EW scores on inapplicable datasets were inflated.

## Fix

Revert: any token with the inapplicable bit set (including `?`) triggers the `has_inapp` bypass, preventing simplification. Update one test to verify the conservative behavior.

GHA: run 23534918452.