### PR TITLE
T-261+T-262: Eliminate std::fill zeroing, memcpy tip loading (8.6% TBR speedup)

### DIFF
--- a/man/SearchControl.Rd
+++ b/man/SearchControl.Rd
@@ -34,6 +34,7 @@ SearchControl(
   sectorMaxSize = 50L,
   fuseInterval = 3L,
   fuseAcceptEqual = FALSE,
+  intraFuse = FALSE,
   poolMaxSize = 100L,
   poolSuboptimal = 0,
   consensusStableReps = 0L,
@@ -148,6 +149,10 @@ sizes for sectorial search.}
 \item{fuseInterval}{Integer; fuse pool trees every \emph{n} replicates.}
 
 \item{fuseAcceptEqual}{Logical; accept equally-scoring fused trees?}
+
+\item{intraFuse}{Logical; fuse the current tree against pool donors
+within each replicate, after TBR polish.  This approximates TNT's
+within-replicate fusing pattern. Default: \code{FALSE}.}
 
 \item{poolMaxSize}{Integer; maximum trees retained in the pool.}
 

--- a/src/ts_tree.cpp
+++ b/src/ts_tree.cpp
@@ -49,14 +49,12 @@ void TreeState::init_from_edge(
 }
 
 void TreeState::load_tip_states(const DataSet& ds) {
-  for (int tip = 0; tip < n_tip; ++tip) {
-    size_t base = static_cast<size_t>(tip) * total_words;
-    for (int w = 0; w < total_words; ++w) {
-      prelim[base + w] = ds.tip_states[base + w];
-      // Tips: final = preliminary (observed states, unchanged by uppass)
-      final_[base + w] = ds.tip_states[base + w];
-    }
-  }
+  // T-262: bulk memcpy replaces per-element loop.  Tip states occupy the
+  // first n_tip * total_words entries of prelim/final_ (contiguous).
+  size_t tip_bytes = static_cast<size_t>(n_tip) * total_words * sizeof(uint64_t);
+  std::memcpy(prelim.data(), ds.tip_states.data(), tip_bytes);
+  std::memcpy(final_.data(), ds.tip_states.data(), tip_bytes);
+
   // Initialise tip subtree_actives: applicable states only (NA word = 0).
   // For {-,X} tips, applicable state bits are preserved here; the
   // tip uppass (Pass 2) will clear them if the tip resolves as NA.
@@ -265,11 +263,16 @@ void TreeState::restore_saved_states() {
 }
 
 void TreeState::reset_states(const DataSet& ds) {
-  std::fill(prelim.begin(), prelim.end(), 0ULL);
-  std::fill(final_.begin(), final_.end(), 0ULL);
-  std::fill(down2.begin(), down2.end(), 0ULL);
-  std::fill(subtree_actives.begin(), subtree_actives.end(), 0ULL);
-  std::fill(local_cost.begin(), local_cost.end(), 0ULL);
+  // T-261: std::fill zeroing removed.  Every array entry that is read by
+  // score_tree() / fitch_na_score() is written before it is read:
+  //   prelim    — internals: pass 1 (bottom-up); tips: load_tip_states
+  //   final_    — root: pass 2 init; internals: pass 2 uppass;
+  //               tips: pass 2 tip loop (NA) or load_tip_states (non-NA)
+  //   down2     — only NA blocks; tips: pass 2 tip loop;
+  //               internals: pass 3 (bottom-up)
+  //   subtree_a — only NA blocks; tips: load_tip_states + pass 2 update;
+  //               internals: pass 1 + pass 3
+  //   local_cost— only standard blocks; written in pass 1
   load_tip_states(ds);
 }
 

--- a/tests/testthat/test-ts-na-incremental.R
+++ b/tests/testthat/test-ts-na-incremental.R
@@ -168,8 +168,12 @@ test_that("Timeout works on NA datasets", {
   ds <- make_ts_data(dataset)
 
   set.seed(1103)
-  result <- ts_driven(ds, maxReplicates = 1000L, targetHits = 1000L,
-                      maxSeconds = 0.5)
+  # maxReplicates/targetHits set unreachably high so that the timeout
+  # is what stops the search, not convergence (Vinther2008 is tiny).
+  # perturbStopFactor = 0 disables the perturbation-count stop rule,
+  # which otherwise fires in ~23ms on fast hardware (46 reps < 0.05s).
+  result <- ts_driven(ds, maxReplicates = 1000000L, targetHits = 1000000L,
+                      maxSeconds = 0.05, perturbStopFactor = 0L)
 
   expect_true(result$timed_out)
   expect_true(result$best_score > 0)


### PR DESCRIPTION
Agent E.

## Changes

**T-261: Remove redundant `std::fill` zeroing in `reset_states()`**

Audited all 5 scoring passes (`prelim`, `final_`, `down2`, `subtree_actives`, `local_cost`). Every entry is written before read by the Fitch downpass/uppass/NA passes. The zeroing was provably redundant. Removed 5 `std::fill(0)` calls from `reset_states()` in `ts_tree.cpp`.

**T-262: Bulk memcpy for tip state loading**

Replaced element-by-element tip copy in `load_tip_states()` with `std::memcpy()` for contiguous tip regions (`prelim` and `final_` arrays).

## Performance

Interleaved A/B benchmark (5 pairs, Dikow2009, 88 tips):
- Baseline median: 14.92s
- Optimized median: 13.64s
- **Speedup: 8.6%**

## Testing

- GHA 23598212017: **PASS** (ARM64 + Windows)
- 10933 tests pass, 0 fail
- Score verification: Vinther2008=83, Longrich2010=131, DeAssis2011=64 (all correct)

Also includes a test robustness fix: `test-ts-na-incremental.R:174` timeout test now disables `perturbStopFactor` to prevent false negative on fast hardware.