### PR TITLE
F-008: Fix constrained drift constraint staleness (T-279)

### DIFF
--- a/src/ts_drift.cpp
+++ b/src/ts_drift.cpp
@@ -647,6 +647,7 @@ static int drift_phase(TreeState& tree, const DataSet& ds,
           drift_restore_topology(tree, snap);
           tree.build_postorder();
           score = drift_full_rescore(tree, ds);
+          if (constrained) update_constraint(tree, *cd);
         }
       } else {
         // EW: original local_cost-based RFD
@@ -654,7 +655,7 @@ static int drift_phase(TreeState& tree, const DataSet& ds,
 
         drift_restore_topology(tree, snap);
         tree.build_postorder();
-        drift_full_rescore(tree, ds);
+        score = drift_full_rescore(tree, ds);
         old_local_cost = tree.local_cost;
 
         double F = 0, C = 0;
@@ -686,7 +687,8 @@ static int drift_phase(TreeState& tree, const DataSet& ds,
           ++n_accepted;
           if (constrained) update_constraint(tree, *cd);
         } else {
-          score = drift_full_rescore(tree, ds);
+          // score already set when topology was restored above
+          if (constrained) update_constraint(tree, *cd);
         }
       }
     }


### PR DESCRIPTION
Agent F.

**Bug:** In `ts_drift.cpp::drift_phase()`, when a constrained suboptimal move passes the constraint check (updating `cd->constraint_node`), then is rejected by the RFD test, `update_constraint()` was not called on the restored topology. This left `cd->constraint_node` stale — the next clip's `classify_clip_constraints()` used wrong mapping.

**Affected paths:**
- IW reject path (lines 647–649): topology restored but no `update_constraint()`
- EW reject path (line 689): same issue + redundant `full_rescore()` call

**Fix:**
- Added `update_constraint(tree, *cd)` after topology restore in both IW and EW reject paths
- Eliminated redundant `drift_full_rescore()` call in EW path (return value at line 657 was discarded, causing a duplicate rescore at line 689)

**Impact:** Only affects constrained drift (`driftCycles > 0` with constraints). Drift is disabled in all presets since T-255. Same bug class as T-278 (TBR) and E-003 (sector).

GHA 23650290962 PASSED.