### PR TITLE
test(nni): pin IW score returned by nni_search to independent recompute

### DIFF
--- a/tests/testthat/test-ts-nni-iw-rescore.R
+++ b/tests/testthat/test-ts-nni-iw-rescore.R
@@ -1,0 +1,126 @@
+# Tier 2: skipped on CRAN; see tests/testing-strategy.md
+skip_on_cran()
+
+# Regression test for the IW NNI incremental-rescore bug fixed in 3df90882
+# ("fix(nni): correct IW score computation in incremental rescore").
+#
+# Before the fix, nni_search() in src/ts_search.cpp computed
+#   new_score = best_score + delta
+# unconditionally, where `delta` is an integer EW step count from
+# fitch_incremental_downpass.  Under IW / profile parsimony, `best_score`
+# is a float weighted score, so the addition mixed units and produced
+# garbage; accept/reject comparisons were essentially random and the
+# `score` returned by ts_nni_search did not match the IW score of the
+# returned tree.
+#
+# These tests pin the contract that ts_nni_search's reported score equals
+# the IW score of the returned topology, recomputed independently.
+
+# Helpers from helper-ts.R: make_ts_data, ts_score, validate_result
+
+ts_nni <- function(tree, ds, maxHits = 20L, concavity = Inf,
+                   min_steps = integer(0)) {
+  TreeSearch:::ts_nni_search(tree$edge, ds$contrast, ds$tip_data,
+                             ds$weight, ds$levels,
+                             maxHits = maxHits,
+                             min_steps = min_steps,
+                             concavity = concavity)
+}
+
+test_that("NNI: IW score matches independent recompute (binary)", {
+  set.seed(4815)
+  mat <- matrix(sample(0:1, 12 * 20, replace = TRUE),
+                nrow = 12, dimnames = list(paste0("t", 1:12), NULL))
+  dataset <- MatrixToPhyDat(mat)
+  ds <- make_ts_data(dataset)
+  min_steps <- as.integer(MinimumLength(dataset, compress = TRUE))
+
+  tree <- as.phylo(7, 12)
+
+  result <- ts_nni(tree, ds, concavity = 10.0, min_steps = min_steps,
+                   maxHits = 5L)
+  validate_result(result, 12L)
+
+  rt <- tree
+  rt$edge <- result$edge
+
+  # C++ recompute under same IW configuration
+  c_score <- ts_score(rt, ds, concavity = 10.0, min_steps = min_steps)
+  expect_equal(result$score, c_score, tolerance = 1e-8)
+
+  # R-level TreeLength as second independent oracle
+  r_score <- TreeLength(rt, dataset, concavity = 10)
+  expect_equal(result$score, r_score, tolerance = 1e-8)
+})
+
+test_that("NNI: IW score matches independent recompute (multistate)", {
+  set.seed(2306)
+  mat <- matrix(sample(0:3, 12 * 18, replace = TRUE),
+                nrow = 12, dimnames = list(paste0("t", 1:12), NULL))
+  dataset <- MatrixToPhyDat(mat)
+  ds <- make_ts_data(dataset)
+  min_steps <- as.integer(MinimumLength(dataset, compress = TRUE))
+
+  tree <- as.phylo(123, 12)
+
+  result <- ts_nni(tree, ds, concavity = 10.0, min_steps = min_steps,
+                   maxHits = 5L)
+  validate_result(result, 12L)
+
+  rt <- tree
+  rt$edge <- result$edge
+
+  c_score <- ts_score(rt, ds, concavity = 10.0, min_steps = min_steps)
+  expect_equal(result$score, c_score, tolerance = 1e-8)
+
+  r_score <- TreeLength(rt, dataset, concavity = 10)
+  expect_equal(result$score, r_score, tolerance = 1e-8)
+})
+
+test_that("NNI: IW score matches independent recompute across concavities", {
+  # The bug returned garbage regardless of concavity value; sweep a few to
+  # make sure the fix holds for both tight and loose weighting.
+  set.seed(9182)
+  mat <- matrix(sample(0:1, 12 * 20, replace = TRUE),
+                nrow = 12, dimnames = list(paste0("t", 1:12), NULL))
+  dataset <- MatrixToPhyDat(mat)
+  ds <- make_ts_data(dataset)
+  min_steps <- as.integer(MinimumLength(dataset, compress = TRUE))
+  tree <- as.phylo(31, 12)
+
+  for (k in c(3.0, 10.0, 100.0)) {
+    result <- ts_nni(tree, ds, concavity = k, min_steps = min_steps,
+                     maxHits = 5L)
+    validate_result(result, 12L)
+
+    rt <- tree
+    rt$edge <- result$edge
+    c_score <- ts_score(rt, ds, concavity = k, min_steps = min_steps)
+    expect_equal(result$score, c_score, tolerance = 1e-8,
+                 label = paste0("concavity=", k))
+  }
+})
+
+test_that("NNI: IW score matches independent recompute with NA tokens", {
+  # Combine IW with inapplicable tokens — exercises the IW accept-path on
+  # the NA-aware scoring branch.
+  set.seed(7401)
+  mat <- matrix(sample(c("0", "1", "-"), 12 * 20, replace = TRUE,
+                       prob = c(0.45, 0.45, 0.10)),
+                nrow = 12, dimnames = list(paste0("t", 1:12), NULL))
+  dataset <- MatrixToPhyDat(mat)
+  ds <- make_ts_data(dataset)
+  min_steps <- as.integer(MinimumLength(dataset, compress = TRUE))
+
+  tree <- as.phylo(55, 12)
+
+  result <- ts_nni(tree, ds, concavity = 10.0, min_steps = min_steps,
+                   maxHits = 5L)
+  validate_result(result, 12L)
+
+  rt <- tree
+  rt$edge <- result$edge
+
+  c_score <- ts_score(rt, ds, concavity = 10.0, min_steps = min_steps)
+  expect_equal(result$score, c_score, tolerance = 1e-8)
+})


### PR DESCRIPTION
## Summary

Closes the test coverage gap that allowed the IW NNI rescore bug (3df90882) to be committed without detection. The existing IW NNI test only asserted `result$score >= 0` and topology shape — it never cross-checked that the returned score matched the IW score of the returned topology.

Pre-fix, `nni_search` did `new_score = best_score + integer_delta` unconditionally, mixing a float IW score with an integer EW step count. The returned `result$score` was the accumulated garbage value. The existing test would still pass because the assertions were weak.

## Changes

- Added `tests/testthat/test-ts-nni-iw-rescore.R` with 4 test cases and 20 assertions:
  - Binary characters under concavity=10 with independent IW score recompute via `ts_fitch_score` and `TreeLength`
  - Multistate (0–3) characters under IW
  - Sweep across concavity values (3, 10, 100) to verify fix is general
  - Binary+NA (inapplicable tokens) under IW

All tests pass with the fix in place; the pattern (assert `result$score == ts_score(rt, ds, concavity=10)`) would have caught the pre-fix bug because integer EW deltas don't translate to IW score changes.

## Notes

Profile parsimony isn't directly testable here because `ts_nni_search`'s Rcpp bridge doesn't forward `infoAmounts`. However, the IW path exercises the same `compute_weighted_score` dispatch that the fix unified for both modes, so this closes the C++ entry-point gap.