### PR TITLE
perf(tbr): IW/XPIWE/NA x4 reroot batch + dirty-region (default-OFF, opt-in)

### DIFF
--- a/dev/benchmarks/bench_iw_na_element_cell.R
+++ b/dev/benchmarks/bench_iw_na_element_cell.R
@@ -1,0 +1,67 @@
+# NA-IW x4 ELEMENT-level A/B cell (dilution-free): times a direct ts_tbr_search
+# climb from a RANDOM (poor) start to convergence -- the regime that exercises the
+# full reroot loop where the 4-wide batch fires, with NO Wagner/ratchet/sectorial
+# overhead to dilute it. This is the NA analog of bench_iw_realized.R and the
+# decisive test of whether the NA-IW x4 is a real ELEMENT lever (like the no-NA
+# x4's 1.1-1.2x direct-climb win) or genuinely at-limit even at the kernel.
+#
+# Paired arms on identical work (same start, set.seed before EACH call => byte-
+# identical trajectory): off = TS_IW_X4 unset (scalar), on = TS_IW_X4=1 (x4). Native NA,
+# IW (concavity=10); the x4 kernel is shared by IW/XPIWE so IW-NA is representative.
+# Each arm = median of TS_REPS repeated identical climbs (timing stability).
+#
+# Cell index: arg[1] or $SLURM_ARRAY_TASK_ID into expand.grid(dataset, startseed).
+# Local test: TS_REPS=2 TS_DATASETS=Zhu2013 TS_SEEDS=1 Rscript dev/benchmarks/bench_iw_na_element_cell.R 0
+suppressMessages({
+  library(TreeSearch, lib.loc = normalizePath(Sys.getenv("TS_LIB", ".agent-tbr"),
+                                              winslash = "/"))
+  library(TreeTools)
+})
+args <- commandArgs(trailingOnly = TRUE)
+idx  <- as.integer(if (length(args) >= 1L) args[[1]] else Sys.getenv("SLURM_ARRAY_TASK_ID", "0"))
+reps <- as.integer(Sys.getenv("TS_REPS", "5"))
+seeds <- as.integer(strsplit(trimws(Sys.getenv("TS_SEEDS", "1 2 3 4 5")), "\\s+")[[1]])
+dsN  <- strsplit(trimws(Sys.getenv("TS_DATASETS",
+          "Dikow2009 Giles2015 Zanol2014 Zhu2013")), "\\s+")[[1]]
+partdir <- Sys.getenv("PARTIAL_DIR", "dev/benchmarks/partials_iw_na_elem")
+
+grid <- expand.grid(dataset = dsN, startseed = seeds, stringsAsFactors = FALSE)
+if (idx < 0L || idx >= nrow(grid))
+  stop(sprintf("cell index %d out of range [0, %d)", idx, nrow(grid)))
+row <- grid[idx + 1L, ]
+
+data("inapplicable.phyData", package = "TreeSearch")
+phy <- inapplicable.phyData[[row$dataset]]    # NATIVE NA
+ct  <- attr(phy, "contrast"); lv <- attr(phy, "levels")
+tip <- matrix(unlist(phy, use.names = FALSE), nrow = length(phy), byrow = TRUE)
+wt  <- attr(phy, "weight")
+mins <- as.integer(MinimumLength(phy, compress = TRUE))
+set.seed(row$startseed)
+redge <- RandomTree(names(phy), root = TRUE)$edge
+
+time_arm <- function(x4on) {
+  if (x4on) Sys.setenv(TS_IW_X4 = "1") else Sys.unsetenv("TS_IW_X4")
+  walls <- numeric(reps); sc <- NA_real_
+  for (r in seq_len(reps)) {
+    set.seed(row$startseed)                   # identical trajectory each rep & arm
+    t <- system.time(res <- TreeSearch:::ts_tbr_search(
+           redge, ct, tip, wt, lv, maxHits = 1L, min_steps = mins, concavity = 10))
+    walls[r] <- as.numeric(t[["elapsed"]]); sc <- res$score
+  }
+  Sys.unsetenv("TS_IW_X4")
+  list(score = sc, wall = median(walls))
+}
+off <- time_arm(FALSE)
+on  <- time_arm(TRUE)
+
+out <- data.frame(dataset = row$dataset, startseed = row$startseed, reps = reps,
+                  score_off = off$score, score_on = on$score,
+                  wall_off = off$wall, wall_on = on$wall,
+                  speedup = off$wall / on$wall,
+                  identical = isTRUE(all.equal(off$score, on$score)),
+                  stringsAsFactors = FALSE)
+dir.create(partdir, showWarnings = FALSE, recursive = TRUE)
+write.csv(out, file.path(partdir, sprintf("naelem_%04d.csv", idx)), row.names = FALSE)
+cat(sprintf("cell %d: %s start %d | score %.4f/%.4f (%s) | wall %.2f/%.2f s => %.3fx\n",
+            idx, row$dataset, row$startseed, off$score, on$score,
+            if (out$identical) "ok" else "DIFF", off$wall, on$wall, out$speedup))

--- a/dev/benchmarks/bench_iw_na_wall_cell.R
+++ b/dev/benchmarks/bench_iw_na_wall_cell.R
@@ -1,0 +1,64 @@
+# NA-IW x4 mission-wall A/B cell runner (Hamilton job-array; also local-testable).
+#
+# Measures whether the NA-IW 4-wide reroot batch (indirect_na_iw_cached_flat_x4,
+# commit b34df50a) translates to WALL on the production MaximizeParsimony pipeline
+# over the NATIVE inapplicable-bearing corpus. Runs BOTH arms per cell (same node,
+# same seed) to control machine variance:
+#   off = TS_IW_X4 unset (x4 disabled -> scalar indirect_na_iw_length_cached)
+#   on  = TS_IW_X4=1     (x4 batch active; default-off opt-in)
+#
+# DELIBERATELY NATIVE NA (no "-"->"?" recode): the x4 NA branch is the whole point
+# -- recoding would measure the no-NA path instead. The dirty-region opt is
+# !has_na-gated so it is INACTIVE here; toggling TS_IW_X4 alone isolates the x4
+# kernel cleanly (unlike the entangled no-NA x4+dirty A/B). concavity=10; the
+# MaximizeParsimony default is extended IW => ScoringMode::XPIWE = the production
+# path. Bounded by maxReplicates (fixed work, deterministic) so identical score
+# validates byte-identity at scale and the wall ratio is the realized speedup.
+#
+# Cell index: arg[1] or $SLURM_ARRAY_TASK_ID (0-based) into expand.grid(dataset, seed).
+# Env: TS_LIB, TS_DATASETS, TS_SEEDS, TS_REPS, PARTIAL_DIR.
+# Local test: TS_REPS=1 TS_DATASETS=Zanol2014 TS_SEEDS=1 Rscript dev/benchmarks/bench_iw_na_wall_cell.R 0
+suppressMessages({
+  library(TreeSearch, lib.loc = normalizePath(Sys.getenv("TS_LIB", ".agent-tbr"),
+                                              winslash = "/"))
+  library(TreeTools)
+})
+args <- commandArgs(trailingOnly = TRUE)
+idx  <- as.integer(if (length(args) >= 1L) args[[1]] else Sys.getenv("SLURM_ARRAY_TASK_ID", "0"))
+reps <- as.integer(Sys.getenv("TS_REPS", "8"))
+seeds <- as.integer(strsplit(trimws(Sys.getenv("TS_SEEDS", "1 2 3 4 5")), "\\s+")[[1]])
+dsN  <- strsplit(trimws(Sys.getenv("TS_DATASETS",
+          "Dikow2009 Giles2015 Zanol2014 Zhu2013")), "\\s+")[[1]]
+partdir <- Sys.getenv("PARTIAL_DIR", "dev/benchmarks/partials_iw_na")
+
+grid <- expand.grid(dataset = dsN, seed = seeds, stringsAsFactors = FALSE)
+if (idx < 0L || idx >= nrow(grid))
+  stop(sprintf("cell index %d out of range [0, %d)", idx, nrow(grid)))
+row <- grid[idx + 1L, ]
+
+data("inapplicable.phyData", package = "TreeSearch")
+d <- inapplicable.phyData[[row$dataset]]   # NATIVE NA -- do NOT recode
+
+run_arm <- function(arm) {
+  if (arm == "off") Sys.unsetenv("TS_IW_X4") else Sys.setenv(TS_IW_X4 = "1")
+  set.seed(row$seed)
+  t <- system.time(r <- suppressWarnings(MaximizeParsimony(
+        d, concavity = 10, maxReplicates = reps, targetHits = 999L,
+        maxSeconds = 0, nThreads = 1L, verbosity = 0L)))
+  Sys.unsetenv("TS_IW_X4")
+  list(score = min(attr(r, "score")), wall = as.numeric(t[["elapsed"]]))
+}
+off <- run_arm("off")
+on  <- run_arm("on")
+
+out <- data.frame(dataset = row$dataset, seed = row$seed, reps = reps,
+                  score_off = off$score, score_on = on$score,
+                  wall_off = off$wall, wall_on = on$wall,
+                  speedup = off$wall / on$wall,
+                  identical = isTRUE(all.equal(off$score, on$score)),
+                  stringsAsFactors = FALSE)
+dir.create(partdir, showWarnings = FALSE, recursive = TRUE)
+write.csv(out, file.path(partdir, sprintf("nacell_%04d.csv", idx)), row.names = FALSE)
+cat(sprintf("cell %d: %s seed %d | score %.4f/%.4f (%s) | wall %.1f/%.1f s => %.3fx\n",
+            idx, row$dataset, row$seed, off$score, on$score,
+            if (out$identical) "ok" else "DIFF", off$wall, on$wall, out$speedup))

--- a/dev/benchmarks/bench_iw_realized.R
+++ b/dev/benchmarks/bench_iw_realized.R
@@ -1,0 +1,50 @@
+# IW realized-cost isolation: the PRODUCTION tbr_search loop (real bail logic +
+# EW x4-flat vs IW scalar), instrumented via env TS_IW_TIMING. Prints per regime:
+#   per_clip_us  = bail-INDEPENDENT IW precompute (extract_char_steps + iw_delta)
+#   per_cand_ns  = bail-DEPENDENT realized per-candidate scan
+# EW per_clip_us ~ 0 (no IW block); the EW/IW per_cand_ns ratio is the realized
+# (not unbounded) per-candidate penalty that gates whether the gather/batching
+# is a mission lever or a worst-case artifact.
+#
+# Usage: Rscript dev/benchmarks/bench_iw_realized.R [lib] [concavity]
+suppressMessages(suppressWarnings({
+  args <- commandArgs(trailingOnly = TRUE)
+  LIB  <- if (length(args) >= 1) args[[1]] else
+    "C:/Users/pjjg18/GitHub/worktrees/TreeSearch/confident-gates-0f627e/.agent-tbr"
+  CONC <- if (length(args) >= 2) as.numeric(args[[2]]) else 10
+  # mode: "pure" (recode -> ?, has_na=FALSE, EW-comparable) or "native" (raw,
+  # has_na=TRUE => NA+IW path, the datasets' real default).
+  MODE <- if (length(args) >= 3) args[[3]] else "pure"
+  library(TreeSearch, lib.loc = LIB); library(TreeTools)
+}))
+data("inapplicable.phyData", package = "TreeSearch")
+Sys.setenv(TS_IW_TIMING = "1")
+
+recode_na_off <- function(phy) {
+  at <- attributes(phy); ct <- at$contrast; lv <- at$levels; al <- at$allLevels
+  inapp_col <- which(lv == "-"); dash_row <- which(al == "-")
+  if (length(dash_row)) ct[dash_row, ] <- 1
+  if (length(inapp_col)) { ct <- ct[, -inapp_col, drop = FALSE]; lv <- lv[-inapp_col] }
+  attr(phy, "contrast") <- ct; attr(phy, "levels") <- lv; phy
+}
+prep <- function(phy) {
+  at <- attributes(phy)
+  list(contrast = at$contrast,
+       tip = matrix(unlist(phy, use.names = FALSE), nrow = length(phy), byrow = TRUE),
+       weight = at$weight, levels = at$levels, n = length(phy), ns = ncol(at$contrast))
+}
+
+DATASETS <- c("Vinther2008", "Wortley2006", "Zanol2014", "Giles2015", "Dikow2009")
+for (nm in DATASETS) {
+  raw <- inapplicable.phyData[[nm]]
+  phy <- if (identical(MODE, "native")) raw else recode_na_off(raw)
+  p <- prep(phy)
+  set.seed(7294)
+  redge <- RandomTree(names(inapplicable.phyData[[nm]]), root = TRUE)$edge
+  for (regime in c("EW", "IW")) {
+    conc <- if (regime == "EW") -1.0 else CONC
+    message(sprintf("=== %s n=%d ns=%d %s ===", nm, p$n, p$ns, regime))
+    invisible(TreeSearch:::ts_tbr_search(redge, p$contrast, p$tip, p$weight,
+                p$levels, maxHits = 1L, concavity = conc))
+  }
+}

--- a/dev/benchmarks/data-na/Sun2018.nex
+++ b/dev/benchmarks/data-na/Sun2018.nex
@@ -1,0 +1,3340 @@
+#NEXUS
+
+[ File output by Morphobank v3.0 (http://www.morphobank.org); 2018-06-19 07.44.41 ]
+
+BEGIN TAXA;
+	DIMENSIONS NTAX=54;
+	TAXLABELS
+		'Namacalathus'
+		'Cupitheca holocyclata'
+		'Bactrotheca'
+		'Conotheca'
+		'Haplophrentis carinatus'
+		'Maxilites'
+		'Paramicrocornus'
+		'Pauxillites'
+		'Pedunculotheca diania'
+		'Cotyledion tylodes'
+		'Loxosomella'
+		'Flustra'
+		'Amathia'
+		'Novocrania'
+		'Pelagodiscus atlanticus'
+		'Lingula'
+		'Terebratulina'
+		'Phoronis'
+		'Sipunculus'
+		'Serpula'
+		'Tonicella'
+		'Dentalium'
+		'Wiwaxia corrugata'
+		'Halkieria evangelista'
+		'Dailyatia'
+		'Acanthotretella spinosa'
+		'Alisina'
+		'Askepasma toddense'
+		'Micromitra'
+		'Antigonambonites planus'
+		'Botsfordia'
+		'Clupeafumosus socialis'
+		'Coolinia pecten'
+		'Craniops'
+		'Eccentrotheca'
+		'Eoobolus'
+		'Gasconsia'
+		'Glyptoria'
+		'Heliomedusa orienta'
+		'Kutorgina chengjiangensis'
+		'Lingulosacculus'
+		'Lingulellotreta malongensis'
+		'Longtancunella chengjiangensis'
+		'Micrina'
+		'Mickwitzia muralensis'
+		'Mummpikia nuda'
+		'Nisusia sulcata'
+		'Orthis'
+		'Paterimitra'
+		'Salanygolina'
+		'Siphonobolus priscus'
+		'Tomteluva perturbata'
+		'Ussunia'
+		'Yuganotheca elegans'
+	;
+ENDBLOCK;
+
+
+
+BEGIN CHARACTERS;
+	DIMENSIONS NCHAR=225;
+	FORMAT DATATYPE=STANDARD MISSING=? GAP=- SYMBOLS="012345";
+
+	CHARLABELS
+		 [1] 'Brephic shell: Embryonic shell'
+		 [2] 'Brephic shell: Morphology'
+		 [3] 'Brephic shell: Embryonic shell extended in larvae'
+		 [4] 'Brephic shell: Surface ornament'
+		 [5] 'Brephic shell: Larval attachment structure'
+		 [6] 'Brephic shell: Setulose'
+		 [7] 'Brephic shell: Setal sacs'
+		 [8] 'Brephic shell: Setal sacs: Number'
+		 [9] 'Larval chaetae: Paired bundles'
+		 [10] 'Adult setae'
+		 [11] 'Adult setae: Secretion'
+		 [12] 'Adult setae: Secretion: Microvillar diameter'
+		 [13] 'Adult setae: Secretion: Microvillar canal aspect'
+		 [14] 'Adult setae: Composition'
+		 [15] 'Adult setae: Enamel'
+		 [16] 'Adult setae: Distribution'
+		 [17] 'Adult setae: Constitution'
+		 [18] 'Adult setae: Projecting knobs'
+		 [19] 'Adult setae: Circling coronae'
+		 [20] 'Body organization: Serial repetition'
+		 [21] 'Body organization: Foot'
+		 [22] 'Body organization: Coelom'
+		 [23] 'Body organization: Coelomoducts: Number'
+		 [24] 'Body organization: Gills'
+		 [25] 'Body organization: Circulatory system'
+		 [26] 'Pedicle: Presence'
+		 [27] 'Pedicle: Constitution'
+		 [28] 'Pedicle: Biomineralization'
+		 [29] 'Pedicle: Bulb'
+		 [30] 'Pedicle: Distal rootlets'
+		 [31] 'Pedicle: Tapering'
+		 [32] 'Pedicle: Coelomic region'
+		 [33] 'Pedicle: Surface ornament'
+		 [34] 'Pedicle: Nerve impression'
+		 [35] 'Mantle canals: Presence'
+		 [36] 'Mantle canals: Morphology'
+		 [37] 'Mantle canals: vascula lateralia'
+		 [38] 'Mantle canals: vascula media'
+		 [39] 'Mantle canals: vascula terminalia'
+		 [40] 'Perioral tentacular apparatus: Presence'
+		 [41] 'Perioral tentacular apparatus: Origin'
+		 [42] 'Perioral tentacular apparatus: Tentacle disposition'
+		 [43] 'Perioral tentacular apparatus: Tentacle rows per side in trocholophe stage'
+		 [44] 'Perioral tentacular apparatus: Tentacle rows per side in post-trocholophe stage'
+		 [45] 'Perioral tentacular apparatus: Median tentacle in early development'
+		 [46] 'Perioral tentacular apparatus: Site of tentacle addition'
+		 [47] 'Perioral tentacular apparatus: Innervation'
+		 [48] 'Perioral tentacular apparatus: Inner nerve ring'
+		 [49] 'Perioral tentacular apparatus: Outer nerve ring'
+		 [50] 'Perioral tentacular apparatus: Musculature'
+		 [51] 'Perioral tentacular apparatus: Forms closed loop'
+		 [52] 'Perioral tentacular apparatus: Coiling direction'
+		 [53] 'Perioral tentacular apparatus: Adjustor muscle'
+		 [54] 'Digestive tract: Prominent pharynx'
+		 [55] 'Digestive tract: Radula'
+		 [56] 'Digestive tract: Oesophageal folds'
+		 [57] 'Digestive tract: Oral sphincter'
+		 [58] 'Digestive tract: Foregut: Locomotory cilia'
+		 [59] 'Digestive tract: Midgut: Subdivisions'
+		 [60] 'Digestive tract: Midgut: Glands'
+		 [61] 'Digestive tract: Anus: Presence'
+		 [62] 'Digestive tract: Anus: Location'
+		 [63] 'Digestive tract: Anus: Migration: Within ring of tentacles'
+		 [64] 'Digestive tract: Anus: Migration: Position'
+		 [65] 'Sclerites: Present in adult'
+		 [66] 'Sclerites: Periodically shed and replaced'
+		 [67] 'Sclerites: Bivalved'
+		 [68] 'Sclerites: Accessory sclerites: Reduced'
+		 [69] 'Sclerites: Accessory sclerites: Arrangement'
+		 [70] 'Sclerites: Accessory sclerites: Symmetry'
+		 [71] 'Sclerites: Bivalved: Hinge line shape'
+		 [72] 'Sclerites: Bivalved: Enclosing filtration chamber'
+		 [73] 'Sclerites: Bivalved: Commissure: Exact correspondence of valve margins'
+		 [74] 'Sclerites: Bivalved: Commissure: Sulcate'
+		 [75] 'Sclerites: Bivalved: Commissure: Circular'
+		 [76] 'Sclerites: Bivalved: Commissure: Lateral margins'
+		 [77] 'Sclerites: Bivalved: Apophyses'
+		 [78] 'Sclerites: Bivalved: Apophyses: Morphology'
+		 [79] 'Sclerites: Bivalved: Apophyses: Dental plates'
+		 [80] 'Sclerites: Bivalved: Sockets'
+		 [81] 'Sclerites: Bivalved: Socket ridges'
+		 [82] 'Sclerites: Bivalved: Muscle scars: Ventral '
+		 [83] 'Sclerites: Bivalved: Muscle scars: Ventral: Position'
+		 [84] 'Sclerites: Bivalved: Muscle scars: Adjustor'
+		 [85] 'Sclerites: Bivalved: Muscle scars: Dorsal adductors'
+		 [86] 'Sclerites: Bivalved: Muscle scars: Adductors: Position'
+		 [87] 'Sclerites: Bivalved: Muscle scars: Dermal muscles'
+		 [88] 'Sclerites: Bivalved: Muscle scars: Unpaired median (levator ani)'
+		 [89] 'Sclerites: Bivalved: Muscle scars: Dorsal diductor'
+		 [90] 'Sclerites: Bivalved: Muscle scars: Dorsal diductor: Position'
+		 [91] 'Sclerites: Dorsal valve: Growth direction'
+		 [92] 'Sclerites: Dorsal valve: Posterior surface: Differentiated'
+		 [93] 'Sclerites: Dorsal valve: Differentiated posterior surface: Morphology'
+		 [94] 'Sclerites: Dorsal valve: Posterior surface: Medial groove'
+		 [95] 'Sclerites: Dorsal valve: Posterior surface: Notothyrium'
+		 [96] 'Sclerites: Dorsal valve: Posterior surface: Notothyrium: Shape'
+		 [97] 'Sclerites: Dorsal valve: Posterior surface: Notothyrium: Chilidial plates'
+		 [98] 'Sclerites: Dorsal valve: Notothyrial platform'
+		 [99] 'Sclerites: Dorsal valve: Medial septum'
+		 [100] 'Sclerites: Dorsal valve: Cardinal shield'
+		 [101] 'Sclerites: Dorsal valve: Cardinal processes'
+		 [102] 'Sclerites: Dorsal valve: Cardinal teeth'
+		 [103] 'Sclerites: Dorsal valve: Clavicles'
+		 [104] 'Sclerites: Dorsal valve: Clavicles: Type of clavicles'
+		 [105] 'Sclerites: Ventral valve: Growth direction'
+		 [106] 'Sclerites: Ventral valve: Relative size'
+		 [107] 'Sclerites: Ventral valve: Posterior surface: Differentiated'
+		 [108] 'Sclerites: Ventral valve: Posterior margin growth direction'
+		 [109] 'Sclerites: Ventral valve: Posterior surface: Planar'
+		 [110] 'Sclerites: Ventral valve: Ligula'
+		 [111] 'Sclerites: Ventral valve: Posterior surface: Extent'
+		 [112] 'Sclerites: Ventral valve: Posterior surface: Delthyrium'
+		 [113] 'Sclerites: Ventral valve: Posterior surface: Delthyrium: Shape'
+		 [114] 'Sclerites: Ventral valve: Posterior surface: Delthyrium: Shape: Aspect of rounded opening'
+		 [115] 'Sclerites: Ventral valve: Posterior surface: Delthyrium: Cover'
+		 [116] 'Sclerites: Ventral valve: Posterior surface: Delthyrium: Cover: Extent'
+		 [117] 'Sclerites: Ventral valve: Posterior surface: Delthyrium: Cover: Identity'
+		 [118] 'Sclerites: Ventral valve: Posterior surface: Delthyrium: Pseudodeltidium: Shape'
+		 [119] 'Sclerites: Ventral valve: Posterior surface: Delthyrium: Pseudodeltidium: Hinge furrows'
+		 [120] 'Sclerites: Ventral valve: Umbonal perforation'
+		 [121] 'Sclerites: Ventral valve: Umbonal perforation: Shape'
+		 [122] 'Sclerites: Ventral valve: Colleplax, cicatrix or pedicle sheath'
+		 [123] 'Sclerites: Ventral valve: Median septum'
+		 [124] 'Sclerites: Ornament: Concentric ornament'
+		 [125] 'Sclerites: Ornament: Concentric ornament: Symmetry'
+		 [126] 'Sclerites: Ornament: Radial ornament'
+		 [127] 'Sclerites: Ornament: Shell-penetrating spines'
+		 [128] 'Sclerites: Composition: Mineralogy'
+		 [129] 'Sclerites: Composition: Cuticle or organic matrix'
+		 [130] 'Sclerites: Composition: Incorporation of sedimentary particles'
+		 [131] 'Sclerites: Composition: Periostracum: Flexibility'
+		 [132] 'Sclerites: Composition: Microstructure: Number of distinct layers'
+		 [133] 'Sclerites: Composition: Microstructure: Format'
+		 [134] 'Sclerites: Structure: Stratiform lamellae expressed at surface'
+		 [135] 'Sclerites: Structure: Stratiform laminae separated'
+		 [136] 'Sclerites: Structure: Stratiform laminae with polygonal ornament'
+		 [137] 'Sclerites: Structure: Canals'
+		 [138] 'Sclerites: Structure: Punctae'
+		 [139] 'Sclerites: Structure: Pseudopunctae'
+		 [140] 'Sclerites: Structure: External polygonal ornament'
+		 [141] 'Gametes: Gonocoel'
+		 [142] 'Gametes: Ovary wall saccular'
+		 [143] 'Gametes: Testis wall saccular'
+		 [144] 'Gametes: Asexual reproduction'
+		 [145] 'Gametes: Sexes'
+		 [146] 'Gametes: Fertilization'
+		 [147] 'Gametes: Egg: Size'
+		 [148] 'Gametes: Egg: Protective membrane'
+		 [149] 'Gametes: Egg: Site of maturation'
+		 [150] 'Gametes: Spermatozoa: Nucleus: Shape'
+		 [151] 'Gametes: Spermatozoa: Anterior nuclear fossa'
+		 [152] 'Gametes: Spermatozoa: Acrosome: Shape'
+		 [153] 'Gametes: Spermatozoa: Acrosome: Differentiated internally'
+		 [154] 'Gametes: Spermatozoa: Acrosome: Sub-acrosomal space'
+		 [155] 'Gametes: Spermatozoa: Mid-piece'
+		 [156] 'Gametes: Spermatozoa: Centrioles: Orientation'
+		 [157] 'Gametes: Spermatozoa: Centrioles: Fusion'
+		 [158] 'Gametes: Spermatozoa: Satellite fibre complex'
+		 [159] 'Gametes: Spermatozoa: Mitochondria: Shape'
+		 [160] 'Gametes: Spermatozoa: Mitochondria: Cristae: Configuration'
+		 [161] 'Gametes: Spermatozoa: Mitochondria: Midpiece'
+		 [162] 'Embryo: Micromere size'
+		 [163] 'Embryo: Cleavage: Equal'
+		 [164] 'Embryo: Cleavage: Cross pattern'
+		 [165] 'Embryo: Cleavage: Polar lobe formation'
+		 [166] 'Embryo: Cleavage: Spiral'
+		 [167] 'Embryo: Origin of mesoderm'
+		 [168] 'Larva: Apical organ: Muscles extending to the hyposphere'
+		 [169] 'Larva: Apical organ: Serotonergic cells'
+		 [170] 'Larva: Apical organ: Develops into adult brain'
+		 [171] 'Larva: Brain persists into adulthood'
+		 [172] 'Larva: Origin of body cavity'
+		 [173] 'Larva: Formation of coelomoducts'
+		 [174] 'Larva: Foot'
+		 [175] 'Larva: Foot: Pedal gland'
+		 [176] 'Larva: Coelom: Paired'
+		 [177] 'Larva: Coelom: Paried: Includes pericardium'
+		 [178] 'Larva: Feeding'
+		 [179] 'Larva: Cilia: Metatroch'
+		 [180] 'Larva: Cilia: Telotroch'
+		 [181] 'Larva: Cilia: Ciliated food groove'
+		 [182] 'Larva: Cilia: Ciliary bands: Downstream'
+		 [183] 'Larva: Cilia: Ciliary bands: Upstream'
+		 [184] 'Larva: Cilia: Adoral ciliary band'
+		 [185] 'Larva: Cilia: Nerve ring underlying ciliated larval swimming organ'
+		 [186] 'Ciliary ultrastructure: Accessory centriole'
+		 [187] 'Ciliary ultrastructure: Aggregation of granules below basal plate'
+		 [188] 'Ciliary ultrastructure: Basal foot: Radiating tubular fibres'
+		 [189] 'Ciliary ultrastructure: Basal plate'
+		 [190] 'Ciliary ultrastructure: Brushborder of microvilli'
+		 [191] 'Ciliary ultrastructure: Centriolar triplet derivative in basal body'
+		 [192] 'Ciliary ultrastructure: Ciliary necklace with connecting strands'
+		 [193] 'Ciliary ultrastructure: Compound cilia: Presence'
+		 [194] 'Ciliary ultrastructure: Compound cilia: Origin'
+		 [195] 'Ciliary ultrastructure: Glycocalyx ultrastructure'
+		 [196] 'Ciliary ultrastructure: Microvilli on epidermal surface: Branched'
+		 [197] 'Ciliary ultrastructure: Vertical ciliary rootlet: Length'
+		 [198] 'Ciliary ultrastructure: Vertical ciliary rootlet: Shape'
+		 [199] 'Ciliary ultrastructure: Secondary ciliary rootlet: Presence'
+		 [200] 'Ciliary ultrastructure: Secondary ciliary rootlet: Length'
+		 [201] 'Ciliary ultrastructure: Secondary ciliary rootlet: Shape'
+		 [202] 'Nephridia: Podocytes'
+		 [203] 'Nephridia: Rhogocytes'
+		 [204] 'Nephridia: Serve as excretory organs'
+		 [205] 'Nephridia: Protonephridia'
+		 [206] 'Nephridia: Metanephridia'
+		 [207] 'Cuticle: Layers'
+		 [208] 'Cuticle: Composition'
+		 [209] 'Cuticle: Fibrous layer with thick fibrils'
+		 [210] 'Cuticle: Homogeneous layer'
+		 [211] 'Cuticle: Resilience'
+		 [212] 'Cuticle: Microvilli'
+		 [213] 'Muscles: Cytology'
+		 [214] 'Muscles: Histology'
+		 [215] 'Glands: Pedal gland'
+		 [216] 'Glands: Paired pharyngeal diverticulae'
+		 [217] 'Nervous system: Orthogonal'
+		 [218] 'Nervous system: Glial system'
+		 [219] 'Nervous system: Buccal nerve ring'
+		 [220] 'Nervous system: Anterior nerve loop'
+		 [221] 'Nervous system: Formation of ganglia'
+		 [222] 'Nervous system: Cerebral ganglia: Presence'
+		 [223] 'Nervous system: Cerebral gangila: Fused'
+		 [224] 'Nervous system: Nerve cords'
+		 [225] 'Nervous system: Ventral longitudinal nerves'
+	;
+
+	STATELABELS
+		1
+		'Absent'
+		'Present'
+		,
+		2
+		'[Transformational character]'
+		'Flat, disc-like (cf. Micrina)'
+		'Three prominent lobes forming a Y (cf. Paterimitra)'
+		'Spherical'
+		'Fusiform'
+		,
+		3
+		'[Transformational character]'
+		'Not extended; embryonic shell contiguous with adult shell'
+		'Extended into larval shell, separated from adult shell by prominent nick'
+		,
+		4
+		'[Transformational character]'
+		'Smooth'
+		'Rounded pits'
+		'Polygonal impressions'
+		'Pustulose'
+		,
+		5
+		'[Transformational character]'
+		'Without evidence of pedicle'
+		'With evidence of pedicle'
+		,
+		6
+		'No evidence of setae in embryonic shell'
+		'Setae present'
+		,
+		7
+		'Absent'
+		'Present'
+		,
+		8
+		'[Transformational character]'
+		'One pair'
+		'Two pairs'
+		'Three pairs'
+		,
+		9
+		'Absent'
+		'Present'
+		,
+		10
+		'Absent'
+		'Present'
+		,
+		11
+		'[Transformational character]'
+		'By basal microvilli'
+		'Epicuticular'
+		,
+		12
+		'[Transformational character]'
+		'Uniform'
+		'Decreasing towards seta margin'
+		,
+		13
+		'[Transformational character]'
+		'Round'
+		'Polygonal; close-packed'
+		,
+		14
+		'[Transformational character]'
+		'Chitin'
+		'Horny protein'
+		,
+		15
+		'Absent'
+		'Present'
+		,
+		16
+		'[Transformational character]'
+		'Uniform '
+		'Only present at margins of shell'
+		'In bundles, repeated on each metamere if serial repetition present'
+		'In digestive tract'
+		,
+		17
+		'[Transformational character]'
+		'Solid, blade-like'
+		'Basal invagination'
+		,
+		18
+		'Absent'
+		'Individual peripheral projections present'
+		,
+		19
+		'Absent'
+		'Present'
+		,
+		20
+		'Absent'
+		'Present'
+		,
+		21
+		'Absent'
+		'Present'
+		,
+		22
+		'Absent: adults acoelomate'
+		'Present: true coelomic cavities differentiated'
+		,
+		23
+		'[Transformational character]'
+		'Single'
+		'Multiple'
+		,
+		24
+		'Absent'
+		'Present'
+		,
+		25
+		'[Transformational character]'
+		'Epithelially lined'
+		'Poorly defined, involving sinuses and lacunae'
+		'Closed circulatory system'
+		,
+		26
+		'Absent'
+		'Present'
+		,
+		27
+		'[Transformational character]'
+		'Massive or uniform'
+		'Densely stacked tabular discs'
+		,
+		28
+		'[Transformational character]'
+		'Absent'
+		'Present'
+		,
+		29
+		'Absent'
+		'Present'
+		,
+		30
+		'Absent'
+		'Present'
+		,
+		31
+		'[Transformational character]'
+		'Uniform thickness'
+		'Tapering'
+		,
+		32
+		'[Transformational character]'
+		'Absent'
+		'Present'
+		,
+		33
+		'[Transformational character]'
+		'Smooth'
+		'Regular annulations'
+		'Irregular wrinkles'
+		,
+		34
+		'Absent'
+		'Present'
+		,
+		35
+		'Absent'
+		'Present'
+		,
+		36
+		'[Transformational character]'
+		'Pinnate (=lemniscate)'
+		'Bifurcate'
+		'Baculate'
+		'Saccate'
+		,
+		37
+		'Absent'
+		'Present'
+		,
+		38
+		'Absent'
+		'Present (in dorsal valve)'
+		,
+		39
+		'[Transformational character]'
+		'Exclusively marginal (peripheral)'
+		'Directed peripherally and (intero)medially'
+		,
+		40
+		'Absent'
+		'Present'
+		,
+		41
+		'[Transformational character]'
+		'Prostomium (i.e. anterior of larval prototroch)'
+		'Second pair of coelomic sacs, at metamorphosis'
+		'Mid-trunk, prior to metamorphosis'
+		,
+		42
+		'[Transformational character]'
+		'Single side'
+		'Both sides'
+		,
+		43
+		'No additional ablabial row'
+		'Adlabial and ablabial row'
+		,
+		44
+		'No additional ablabial row'
+		'Adlabial and ablabial row'
+		,
+		45
+		'Absent'
+		'Present'
+		,
+		46
+		'[Transformational character]'
+		'At two points located behind the mouth'
+		'At the tip of each lophophore arm'
+		,
+		47
+		'[Transformational character]'
+		'Extensions of a circumoral nerve ring'
+		'Nerve rings within the tentacle ring itself'
+		,
+		48
+		'Not reduced (whether present or absent due to absence of lophophore nerve rings)'
+		'Reduced, weakly developed or absent in adults'
+		,
+		49
+		'Not reduced (whether present or absent due to absence of lophophore nerve rings)'
+		'Reduced, weakly developed or absent in adults'
+		,
+		50
+		'[Transformational character]'
+		'Outer main tentacle muscle; two pairs of inner longitudinal muscles'
+		'Peripheral muscle fibres'
+		'Core of longitudinal muscle fibres surrounded by circular muscles'
+		,
+		51
+		'[Transformational character]'
+		'Diverging laterally'
+		'Closed loop'
+		,
+		52
+		'[Transformational character]'
+		'Anteriad'
+		'Posteriad'
+		,
+		53
+		'Absent'
+		'Present'
+		,
+		54
+		'Absent'
+		'Present'
+		,
+		55
+		'Absent'
+		'Present'
+		,
+		56
+		'Absent'
+		'Present'
+		,
+		57
+		'Absent'
+		'Present'
+		,
+		58
+		'Absent'
+		'Present'
+		,
+		59
+		'Not subdivided'
+		'Functional subdivisions'
+		,
+		60
+		'Absent'
+		'Present'
+		,
+		61
+		'Anus present: through-gut'
+		'Anus lost: digestive tract is blind sac'
+		,
+		62
+		'[Transformational character]'
+		'Straight gut with [dorso] posterior anus'
+		'Anus migrated posteriad to create U-shaped gut'
+		'Anus opening to rear of pedal sole, causing slight U-shape to gut'
+		,
+		63
+		'[Transformational character]'
+		'Not within ring of tentacles'
+		'Anterior - within ring of feeding tentacles'
+		,
+		64
+		'[Transformational character]'
+		'Left'
+		'Right'
+		'Dorsally'
+		'Ventrally'
+		,
+		65
+		'Absent'
+		'Present'
+		,
+		66
+		'Absent'
+		'Present'
+		,
+		67
+		'Scleritomous: without differentiated dorsal and ventral valves'
+		'Bivalved: scleritome dominated by prominent dorsal and ventral valve'
+		,
+		68
+		'[Transformational character]'
+		'Accessory sclerites not reduced'
+		'Accessory sclerites absent: two valves only'
+		,
+		69
+		'Single field'
+		'Peripheral and medial fields with distinct sclerite arrangements'
+		,
+		70
+		'Dextral and sinistral forms absent'
+		'Occuring in dextral and sinistral forms'
+		,
+		71
+		'[Transformational character]'
+		'Astrophic'
+		'Strophic'
+		,
+		72
+		'No filtration chamber, or open chamber'
+		'Shells close to form enclosed filtration chamber'
+		,
+		73
+		'[Transformational character]'
+		'Margins align exactly when valves closed'
+		'Margins of different shape or size'
+		,
+		74
+		'[Transformational character]'
+		'Rectimarginate'
+		'Uniplicate'
+		'Sulcate'
+		,
+		75
+		'[Transformational character]'
+		'Continuous round outline with no corners (save at the hinge); '
+		'Lateral margins linear'
+		,
+		76
+		'[Transformational character]'
+		'Subparallel'
+		'Diverging'
+		'Initially diverging, becoming subparallel'
+		,
+		77
+		'Absent'
+		'Present'
+		,
+		78
+		'[Transformational character]'
+		'Deltidiodont'
+		'Cyrtomatodont'
+		'Pseudodont'
+		,
+		79
+		'Absent'
+		'Present'
+		,
+		80
+		'Absent'
+		'Present'
+		,
+		81
+		'Absent'
+		'Present'
+		,
+		82
+		'Absent'
+		'Present'
+		,
+		83
+		'[Transformational character]'
+		'Posterolateral and medial attachments'
+		'Medial attachments only'
+		,
+		84
+		'Absent'
+		'Present'
+		,
+		85
+		'[Transformational character]'
+		'Dispersed'
+		'Radially arranged'
+		'Quadripartite'
+		,
+		86
+		'[Transformational character]'
+		'Oblique'
+		'At high angle'
+		,
+		87
+		'Absent or weakly developed'
+		'Strongly developed'
+		,
+		88
+		'Absent'
+		'Present'
+		,
+		89
+		'Absent'
+		'Present'
+		,
+		90
+		'[Transformational character]'
+		'Close to commissural plane'
+		'Oblique to commissural plane'
+		'At high angle to commissural plane'
+		,
+		91
+		'[Transformational character]'
+		'Holoperipheral'
+		'Mixoperipheral'
+		'Hemiperipheral'
+		,
+		92
+		'Posterior face of dorsal valve not differentiated'
+		'Posterior face of dorsal valve forms distinct cardinal area or pseudointerarea'
+		,
+		93
+		'Curved lateral profile'
+		'Planar lateral profile'
+		,
+		94
+		'Absent'
+		'Present'
+		,
+		95
+		'Absent'
+		'Present'
+		,
+		96
+		'[Transformational character]'
+		'Parallel-sided cleft'
+		'Triangular'
+		,
+		97
+		'[Transformational character]'
+		'Open'
+		'Covered by chilidial plates'
+		,
+		98
+		'Absent'
+		'Present'
+		,
+		99
+		'Absent'
+		'Present'
+		,
+		100
+		'Absent'
+		'Present'
+		,
+		101
+		'Absent'
+		'Present'
+		,
+		102
+		'Absent'
+		'Present'
+		,
+		103
+		'Absent'
+		'Present'
+		,
+		104
+		'[Transformational character]'
+		'Monoclavicle'
+		'Triclavicle'
+		,
+		105
+		'[Transformational character]'
+		'Holoperipheral'
+		'Mixoperipheral'
+		'Hemiperipheral'
+		,
+		106
+		'[Transformational character]'
+		'Ventral valve markedly larger than dorsal valve (ventribiconvex)'
+		'Equivalve (subequally biconvex)'
+		'Dorsal valve markedly larger than ventral valve (dorsibiconvex)'
+		,
+		107
+		'Posterior surface of shell not differentiated'
+		'Posterior surface of shell forms distinct cardinal area or pseudointerarea'
+		,
+		108
+		'[Transformational character]'
+		'Inward-growing'
+		'Outward-growing'
+		,
+		109
+		'Curved lateral profile'
+		'Planar lateral profile'
+		,
+		110
+		'Absent'
+		'Present'
+		,
+		111
+		'[Transformational character]'
+		'Low: Wider than deep'
+		'High: Deeper than wide'
+		,
+		112
+		'Absent'
+		'Present'
+		,
+		113
+		'[Transformational character]'
+		'Parallel sided'
+		'Triangular'
+		'Round'
+		,
+		114
+		'[Transformational character]'
+		'Elongate: oval to rhombic'
+		'Essentially circular'
+		'Wider than long'
+		,
+		115
+		'[Transformational character]'
+		'Open'
+		'Covered, at least in part'
+		,
+		116
+		'[Transformational character]'
+		'Covered only partially; partially open'
+		'Completely covered'
+		,
+		117
+		'[Transformational character]'
+		'Pseudodeltidium'
+		'Deltidial plate(s)'
+		'Continuation of shell'
+		,
+		118
+		'[Transformational character]'
+		'Concave'
+		'Convex'
+		,
+		119
+		'Absent'
+		'Present'
+		,
+		120
+		'Umbo imperforate (or ventral valve absent)'
+		'Umbonal perforation'
+		,
+		121
+		'[Transformational character]'
+		'Circular (or subcircular)'
+		'Rhombic to oval'
+		'Arising through decollation'
+		,
+		122
+		'Absent'
+		'Present'
+		,
+		123
+		'Absent'
+		'Present'
+		,
+		124
+		'[Transformational character]'
+		'Smooth, or growth lines only'
+		'Concentric ornament present'
+		,
+		125
+		'[Transformational character]'
+		'Asymmetric fila, with outer faces'
+		'Symmetric fila'
+		,
+		126
+		'Absent'
+		'Present'
+		,
+		127
+		'Absent'
+		'Present'
+		,
+		128
+		'[Transformational character]'
+		'Organic (non-mineralized)'
+		'Phosphatic'
+		'Calcitic'
+		'Aragonitic'
+		,
+		129
+		'[Transformational character]'
+		'GAGs, chitin and collagen'
+		'Glycoprotein'
+		,
+		130
+		'Absent'
+		'Present'
+		,
+		131
+		'[Transformational character]'
+		'Flexible'
+		'Inflexible'
+		,
+		132
+		'[Transformational character]'
+		'Single microstructural layer'
+		'Two microstructurally differentiated layers'
+		'Inner and outer laminae enclosing medial void'
+		'Three microstrurally differentiated layers'
+		,
+		133
+		'[Transformational character]'
+		'Laminated'
+		'Fibrous bundles'
+		'Nacreous / crossed lamellar'
+		,
+		134
+		'[Transformational character]'
+		'Lamellae not expressed at surface'
+		'Lamellae correspond to external shell ornament'
+		,
+		135
+		'[Transformational character]'
+		'Contiguous stratified layer'
+		'Laminae separated by organic layers or voids'
+		,
+		136
+		'[Transformational character]'
+		'Absent'
+		'Present'
+		,
+		137
+		'Absent'
+		'Present'
+		,
+		138
+		'Absent'
+		'Present'
+		,
+		139
+		'Absent'
+		'Present'
+		,
+		140
+		'Absent'
+		'Present'
+		,
+		141
+		'Absent'
+		'Retroperineal gonads'
+		,
+		142
+		'Plain'
+		'Saccular'
+		,
+		143
+		'Plain'
+		'Saccular'
+		,
+		144
+		'Never exhibited'
+		'Frequently exhibited'
+		,
+		145
+		'[Transformational character]'
+		'Gonochoristic'
+		'Hermaphroditic'
+		,
+		146
+		'[Transformational character]'
+		'External'
+		'Internal'
+		,
+		147
+		'[Transformational character]'
+		'Small: < 100 um, little yolk'
+		'Large: > 110 um, much yolk'
+		,
+		148
+		'Absent'
+		'Present'
+		,
+		149
+		'[Transformational character]'
+		'Body cavity'
+		'Mantle canals'
+		'Ovicell'
+		,
+		150
+		'Equant: length comparable to width'
+		'Elongate: length exaggerated relative to width'
+		,
+		151
+		'Absent'
+		'Present'
+		,
+		152
+		'[Transformational character]'
+		'Pear-shaped'
+		'Needle-shaped'
+		'Disc-shaped'
+		'Conical'
+		,
+		153
+		'No internal differentiation'
+		'Acrosome differentiated internally'
+		,
+		154
+		'Absent'
+		'Present'
+		,
+		155
+		'Multiple mitochondria'
+		'Single ring-shaped mitochondrion'
+		,
+		156
+		'Orthogonal'
+		'Parallel'
+		,
+		157
+		'Discrete'
+		'Fused'
+		,
+		158
+		'Annulus not associated with satellite fibres'
+		'Annulus associated with satellite fibres'
+		,
+		159
+		'[Transformational character]'
+		'Spherical to subspherical'
+		'Rods'
+		'Elongate, sac-like'
+		,
+		160
+		'Unmodified'
+		'Arranged in parallel plates'
+		,
+		161
+		'[Transformational character]'
+		'Extremely short'
+		'Long'
+		'Forms continuous sheath'
+		,
+		162
+		'[Transformational character]'
+		'Similar to macomeres'
+		'Small relative to macromeres'
+		,
+		163
+		'[Transformational character]'
+		'Unequal'
+		'Equal'
+		,
+		164
+		'Absent'
+		'Cross, whether "molluscan" or "annelid"'
+		,
+		165
+		'[Transformational character]'
+		'Absent'
+		'Present'
+		,
+		166
+		'[Transformational character]'
+		'Absent'
+		'Present'
+		,
+		167
+		'[Transformational character]'
+		' 4d cell, from the blastopore ridge, or as ectomesoderm'
+		'Archenteron'
+		,
+		168
+		'Absent'
+		'Present'
+		,
+		169
+		'[Transformational character]'
+		'Two flask-shaped cells'
+		'Four flask-shaped cells'
+		'Cluster of c. eight flask-shaped cells'
+		'Aggregation of multiple cells of multiple types'
+		,
+		170
+		'Brain has other origin'
+		'Adult brain derived from larval apical organ / apical pole'
+		'[Transformational character]'
+		,
+		171
+		'[Transformational character]'
+		'Brain lost'
+		'Brain retained to adulthood'
+		,
+		172
+		'[Transformational character]'
+		'Mesenchyme'
+		'Coelom'
+		,
+		173
+		'[Transformational character]'
+		'Outgrowth'
+		'Ingrowth'
+		,
+		174
+		'Absent'
+		'Present'
+		,
+		175
+		'Absent'
+		'Present'
+		,
+		176
+		'Absent'
+		'Paired coelom originating from two teloblasts derived from 4d'
+		,
+		177
+		'Paired coelom absent, or does not include pericardium'
+		'Paired coelom includes pericardium'
+		,
+		178
+		'[Transformational character]'
+		'Lecithotrophic (or otherwise non-feeding)'
+		'Planktotrophic (or otherwise feeding)'
+		,
+		179
+		'Absent'
+		'Present'
+		,
+		180
+		'Absent'
+		'Present'
+		,
+		181
+		'Absent'
+		'Present'
+		,
+		182
+		'Absent'
+		'Present'
+		,
+		183
+		'Absent'
+		'Present'
+		,
+		184
+		'Absent'
+		'Present'
+		,
+		185
+		'Absent'
+		'Present'
+		,
+		186
+		'Absent'
+		'Present'
+		,
+		187
+		'Absent'
+		'Present'
+		,
+		188
+		'Absent'
+		'Present'
+		,
+		189
+		'[Transformational character]'
+		'Thin'
+		'Blurry'
+		,
+		190
+		'Absent'
+		'Present'
+		,
+		191
+		'[Transformational character]'
+		'9 + 2 pattern'
+		'9 + 3 pattern'
+		,
+		192
+		'Absent'
+		'Present'
+		,
+		193
+		'Absent'
+		'Present'
+		,
+		194
+		'[Transformational character]'
+		'Several monociliate cells'
+		'On multiciliated cell'
+		,
+		195
+		'[Transformational character]'
+		'Homogeneous'
+		'Layered'
+		,
+		196
+		'Unbranched'
+		'Branched'
+		,
+		197
+		'[Transformational character]'
+		'Short'
+		'Long'
+		,
+		198
+		'[Transformational character]'
+		'Conical'
+		'Flat'
+		,
+		199
+		'Absent'
+		'Present'
+		,
+		200
+		'[Transformational character]'
+		'Short'
+		'Long'
+		,
+		201
+		'[Transformational character]'
+		'Conical'
+		'Flat'
+		,
+		202
+		'Absent'
+		'Present'
+		,
+		203
+		'Absent'
+		'Present'
+		,
+		204
+		'No'
+		'Yes'
+		,
+		205
+		'Absent'
+		'Present'
+		,
+		206
+		'Absent'
+		'Present'
+		,
+		207
+		'Simple (i.e. glycocalyx)'
+		'Distinct epicuticle and endocuticle'
+		,
+		208
+		'[Transformational character]'
+		'Chitinous'
+		'Collagen'
+		,
+		209
+		'Absent'
+		'Present'
+		,
+		210
+		'Absent'
+		'Present'
+		,
+		211
+		'Labile'
+		'Robust'
+		'[Transformational character]'
+		,
+		212
+		'Absent'
+		'Microvilli present in the cuticle'
+		,
+		213
+		'[Transformational character]'
+		'Smooth'
+		'Obliquely striated'
+		'Smooth on abfrontal face; striated on frontal face'
+		,
+		214
+		'Fibre-type'
+		'Epithelially organized'
+		'[Transformational character]'
+		,
+		215
+		'Absent'
+		'Present'
+		,
+		216
+		'Absent'
+		'Present'
+		,
+		217
+		'Not orthogonal'
+		'Orthogonal'
+		,
+		218
+		'Absent'
+		'Present'
+		,
+		219
+		'Absent'
+		'Present'
+		,
+		220
+		'Absent'
+		'Present'
+		,
+		221
+		'[Transformational character]'
+		'From cerebral region'
+		'In situ'
+		'Invagination of epithelium'
+		,
+		222
+		'Absent'
+		'Present'
+		,
+		223
+		'[Transformational character]'
+		'Pair of distinct ganglia'
+		'Single ganglion, or fused ganglia'
+		,
+		224
+		'[Transformational character]'
+		'Ventral nerve cords only'
+		'Tetraneury: one pair of ventral and one pair of lateral nerve cords'
+		,
+		225
+		'Separate'
+		'Paired or secondarily fused'
+		
+	;
+
+	MATRIX
+	'Namacalathus'		                            ?????????0----0--0?00????0--00---00-00-?????????????????????????000-00-0----0-0000-0--000--0000--000000---0-00-0------00-00--003?0-311111000???1?????????????????????????????????????????????????????????????????????????????????
+	'Cupitheca holocyclata'		                   1121100-0?????????????-??0--00---00-00-?????????????????????????10120011(1,2)11-0-00??????????11000--001?00-110-00-0------0130022004?0?22---1000???0?????????????????????????????????????????????????????????????????????????????????
+	'Bactrotheca'		                             1321100-0????????????????0--00---0??????????????????????????????10120011211-0-000?????????11(0,1)00--000100-110-0020------0???01-004?0?????????0?????????????????????????????????????????????????????????????????????????????????????
+	'Conotheca'		                               1321100-0????????????????0--00---0????????????????????????0?02?110120011211-0-0001????????11(0,1)00--000100-110-0020------00-001-004?0?????????0?????????????????????????????????????????????????????????????????????????????????????
+	'Haplophrentis carinatus'		                 1321100-00----0--00001?0?0--00---??????1?1?0??????12?10???0?02121011011111220-0001?0(1,2)?????11100--001101111121120------00-0022004?0?????????0???0?????????????????????????????????????????????????????????????????????????????????
+	'Maxilites'		                               ?????????????????????????0--00---0??????????????????????????????1011011111230-0001?02?????11100--001111111120120------00-001-104?0?111110000?????????????????????????????????????????????????????????????????????????????????????
+	'Paramicrocornus'		                         ?????????????????????????0--00---00-00-?????????????????????????10120011?1220-000?????????11000--001101111121120------00-001-004?0?22---1000?????????????????????????????????????????????????????????????????????????????????????
+	'Pauxillites'		                             1411(1,2)00-0?????????????????--00---0??????????????????????????????1011011111220-000?????????11?00--001111211121120------00-001-004?0?????????0?????????????????????????????????????????????????????????????????????????????????????
+	'Pedunculotheca diania'		                   11{1,2}1100-0????????????????11201222???????????????????????????02??10120011211-0-0001????????11{0,1}00--00110??11(1,0)21020------01?(1,0)022004?0?????????0?????????????????????????????????????????????????????????????????????????????????????
+	'Cotyledion tylodes'		                      ?????????0----0--000{0,1}??0?{1,0}--00---?0-00-1?1?0??????2?000???0?022-1?0100-0----0-0000-0--000--0000--000000---0-00-0------00-002100(3,4,2)?0{1,2}????????0?????????????????????????????????????????????????????????????????????????????????????
+	'Loxosomella'		                             0----00-00----0--000102020--00---00-00-121000?10012200000100032-000-00-0----0-0000-0--000--0000--000000---0-00-0------00-00--00--0------000000012210?114011?0021222112113021-11002101101100010101211220--000101110012(0,1)10101111221
+	'Flustra'		                                 0----00-00----0--000012010--00---00-00-1210001201?22000001000214000-00-0----0-0000-0--000--0000--000000---0-00-0------00-00--00--0------000000012220311400011020211011114022?00001000001100011100-1021121000000201002000100031110
+	'Amathia'		                                 0----00-011121042000012010--00---00-00-1?10001201?22000001000214000-00-0----0-0000-0--000--0000--000000---0-00-0------00-00--00--0------000000012220311400011?20?1???1?14022?00001?00001100011100-1021121??????201002???100031210
+	'Novocrania'		                              0----11310----0--000012010--00---0111{0,1}11210112???2211101010001-310120021?11-0-00011031011211000--010000-130-0010------00-002100320?21111010010001120201211000010312011202012100002000010010010?011102212100?0102??003000010020-10
+	'Pelagodiscus atlanticus'		                 1121211311122112110001?01111001211121121?11112???211100?0100022310120011111-0-0001-031100-10000--000000-130-001131----00-011-0021012111110001???1?1?1?111000?0???12011???01??0000?????????00??????????12?0??010(1,2)01?03000110020-10
+	'Lingula'		                                 1111210-11122112101001201111102211121021?111122102210101010002121012001111230-00011021100-31010--010000-32120010------00-001-00210?2111(2,1)0100100011101011110000?0312011204012100002000010010010?011102212100?010(1,2)01003000010020-10
+	'Terebratulina'		                           0----11211122112110001?01111111110111111220102210221010?010012-4101200111(2,1)121201112132001121100--000100-221210112-212-00-001-00320?22---01001???1?2?2?030011?0???120112?301??00002100????10010?0?1102111?00?010(1,2)00?03000110020-10
+	'Phoronis'		                                0----00-00----0--000012010--00---00-00-1320001210222000101000213000-00-0----0-0000-0--000--0000--000000---0-00-0------00-00--00-11------00000001221010020100002?212012204012?00002101010110011100-1021111101110210011000010021210
+	'Sipunculus'		                              0----00-012--2?-2001011010--00---00-00-11100011002220100010002-?000-00-0----0-0000-0--000--0000--000000---0-00-0------00-00--00--0------000011101121?013110?101112212211312221?10110000110112021122111121101011210102100110121211
+	'Serpula'		                                 0----00-111211131001012030--00---00-00-112000?1002220000010001--000-00-0----0-0000-0--000--0000--000000---0-00-0------00-00--00--0------000011101111?0030101?01012212211?12121?10111010111012110121021111101111210112100110121211
+	'Tonicella'		                               0----00-011111011001111120--00---00-00-0--000--00---0011101103--101200102121110000-0--000-3110121000000-1(1,2)1200112-223-00-001-004?0?43---000010001121?104100?113012201211312111111100010110112021121111112111001101101011111111221
+	'Dentalium'		                               0----00-00----0--000111120--00---00-00-121000?10031-0011101103--100200-0--210-0000-0--000--0000--000000---0-00-0------00-001-00--0------000010001120?10401001110121022102121?1111101010110112121122111111111001101001011011121121
+	'Wiwaxia corrugata'		                       ?????00-?1111??3100111?1?0--00---00-00-0--000--00---001???{0,1}101--000-00-0----0-0000-0--000--0000--000000---0-00-0------00-00--00-?0------0000???0?????????????????????????????????????????????????????????????????????????????????
+	'Halkieria evangelista'		                   ??????????????????00?????0--00---00-00-?????????????????????????1111111021220-0000-0??00??20000--000000-22121010------00-0021004?0{1,2}12---0000?????????????????????????????????????????????????????????????????????????????????????
+	'Dailyatia'		                               0----00-?????????????????????????00-00-?????????????????????????1?0111-0----0-0000-0--000--0000--000000---0-00-0------00-0021002?0?112110001?????????????????????????????????????????????????????????????????????????????????????
+	'Acanthotretella spinosa'		                 1????????1?????1?????????11110122?1311?1??????????21??0?????021?10120011111-0-0001{1,2}???1???21010--0?0000-211210213-----00-0?1-01{1,2,3,4}?0?-----?100?????????????????????????????????????????????????????????????????????????????????????
+	'Alisina'		                                 0----????1?????2?????????12(2,1)0?2120131111??????????21????????????1?12002111221201112?3200112110111100000-221210112-22{1,2}10110021003?0??????0000?????????????????????????????????????????????????????????????????????????????????????
+	'Askepasma toddense'		                      1123?112?1???????????????1???????011111?????????????????????????101200211{2,1}210-00012?21?0{0,1}?21100--100000-211210112-1---00-0022002?01312120000?????????????????????????????????????????????????????????????????????????????????????
+	'Micromitra'		                              1124?112?1?????2?????????1?10????014111?????????????????????????1?12002111210-000110??0?{1,0}?21100--{0,1}00000-211210112-221200-0121102?01311?10000?????????????????????????????????????????????????????????????????????????????????????
+	'Antigonambonites planus'		                 11212112?1???????????????11200222???????????????????????????????1?1200211121111111{1,2}02?0???2110122110100-221210{2,1}12-22121121121103?0{2,1}411110010?????????????????????????????????????????????????????????????????????????????????????
+	'Botsfordia'		                              1122?111?????????????????????????113112?????????????????????????1?12001111220-00011021?00-21010--010000-211100112-1---00-011-002?01211110000?????????????????????????????????????????????????????????????????????????????????????
+	'Clupeafumosus socialis'		                  11222112?1???????????????????????01111??????????????????????????1?120011111-0-00011021100-(3,1)1110--010000-{1,2}112102132----00{2,1}011-002?0?211221000?????????????????????????????????????????????????????????????????????????????????????
+	'Coolinia pecten'		                         11212112?1???????????????1???0??????????????????????????????????1?1200211121111111{2,1}02?00123110122100100-221210112-2212111101-103?0?211110010?????????????????????????????????????????????????????????????????????????????????????
+	'Craniops'		                                11211????????????????????0--00---0??????????????????????????????1?120011111-0-00011031?1??10000--000000-120-0010------00-1021003?0?211110000?????????????????????????????????????????????????????????????????????????????????????
+	'Eccentrotheca'		                           ?????00-?????????????????????????00-00-?????????????????????????1?0100-0----0-0000-0--000--0000--000000---0-00-0------00-0021002?0?112120000?????????????????????????????????????????????????????????????????????????????????????
+	'Eoobolus'		                                11222112?????????????????1???????113112??????????????1??????????1?12001111220-00011021?00-21110--010000-2{3,2}1100112-211100-011-00(2,3)?01211110000?????????????????????????????????????????????????????????????????????????????????????
+	'Gasconsia'		                               ?????????????????????????0--00---0??????????????????????????????1?120021111-0-(0,1)101{1,2}011001220000--000000-2(1,2)1210112-221100-0121104?0?211110000?????????????????????????????????????????????????????????????????????????????????????
+	'Glyptoria'		                               0----????????????????????11??????011111?????????????????????????1?1200211221110001112100132110121100000-221210112-1---00-001-103?0222---0000?????????????????????????????????????????????????????????????????????????????????????
+	'Heliomedusa orienta'		                     1????????1?????1?????????0--00---?111111?1?1??????12?10?????????1?120011111-0-0001{2,1}?1?????10000--010000-21120010------00-(1,0)02200{2,1}?0???????100?????????????????????????????????????????????????????????????????????????????????????
+	'Kutorgina chengjiangensis'		               0----????1?????2?????????12(2,1)001220????????????????21??0?????01-31?1200{1,2}11121130001102100122110122000000-211210{2,1}1??221?11?001-103?0222---0000???0?????????????????????????????????????????????????????????????????????????????????
+	'Lingulosacculus'		                         1??????????????????????0?1????????131121??????????21?10?????02121?120011111-0-0001{2,1}???1?0-2???0--0?0000-211??02132----0??0?1-00{1,4}?0?-----?000?????????????????????????????????????????????????????????????????????????????????????
+	'Lingulellotreta malongensis'		             11112{0,1}{0,1}??1?????2???????0?1111012211311?1?1?0??????21?10?????02121?12001111220-00011???100-21010--010000-2111002131----00-011-002?0???????000?????????????????????????????????????????????????????????????????????????????????????
+	'Longtancunella chengjiangensis'		          ?????????1?????2???????0?12100212?11?1?1??????????11??0?????02121?1200211122???001{2,1}???????2????--?00000-2{2,1}12101????????11101-00??0???????000?????????????????????????????????????????????????????????????????????????????????????
+	'Micrina'		                                 11212111?1?????1?????????1?1????????????????????????????????????1?1200101-1-110001{2,1}???????21000--000000-211200212-211200-002(2,1)002?0?212221100?????????????????????????????????????????????????????????????????????????????????????
+	'Mickwitzia muralensis'		                   122?2112?1?????1?????????1??????????????????????????????????????1?120011111-0-0000-0--?00-10000--000000-111200(1,2)1(2,3)3221200-0022102?0?211111100?????????????????????????????????????????????????????????????????????????????????????
+	'Mummpikia nuda'		                          ?????????????????????????1???0?2?1??????????????????????????????1?12001111220-0001????????2??????000000-221110111-1---00-011-003?0?1111(1,2)1000?????????????????????????????????????????????????????????????????????????????????????
+	'Nisusia sulcata'		                         0----????????????????????1110022(2,3)011????????????????????????0???1?1200211121130001102100122110121000000-211210(2,1)12-2112111001-113?0?22---0000?????????????????????????????????????????????????????????????????????????????????????
+	'Orthis'		                                  0----????????????????????11??????014111?????????????????????????1?120021111-111111-13?00112100121110100-221210112-1---00-001-103?0?22---0000???0?????????????????????????????????????????????????????????????????????????????????
+	'Paterimitra'		                             1223100-???????-?????????1?1??????0-00-?????????????????????????1?1101102-??0-000?????????11100--000000-211200212-211200-0021002?0?212220000?????????????????????????????????????????????????????????????????????????????????????
+	'Salanygolina'		                            12212112?1???????????????1???????0??????????????????????????????1?12002111210-0001{2,1}?2100??2110122(1,0)00000-211200{2,1}11-2112111102200{2,3}?0{2,1}212220000?????????????????????????????????????????????????????????????????????????????????????
+	'Siphonobolus priscus'		                    11211112?1?????1?????????1???????01311??????????????????????????1?120011111-0-00011???????21{0,1}(0,1)0--010000-(1,2)112{1,0}01132----00-11(2,1)-11210{2,1}211110100??????1??????????????????????????????????????????????????????????????????????????????
+	'Tomteluva perturbata'		                    0----????????????????????1??????????????????????????????????????1?120011121-0-0001{2,1}???????2100122000100-111200111-2222111{0,1}01-103?0??????0000?????????????????????????????????????????????????????????????????????????????????????
+	'Ussunia'		                                 ?????????????????????????0--00---0??????????????????????????????10120011111-0-0001{1,2}?1??11?20000--000000-220-0010------00-001-004?0{2,1}????????0?????????????????????????????????????????????????????????????????????????????????????
+	'Yuganotheca elegans'		                     ?????????1?????2???????0?11210222?111011?1?0??????11?10?????021?1?1200?11122???????????????????--0?0000-1{1,2}?2001????????1?101-001?1?----????0?????????????????????????????????????????????????????????????????????????????????????
+	;
+ENDBLOCK;
+
+BEGIN NOTES;
+	[Taxon comments]
+	TEXT TAXON=5 TEXT='Skeletal microstructure is not known from Haplophrentis. ^nHere we assume that the microstructure is equivalent to that described by Kouchinsky (2000).';
+	TEXT TAXON=13 TEXT='Senior synonym of Bowerbankia';
+	TEXT TAXON=21 TEXT='Selected as sperm morphology well documented by Buckland-Nicks et al. 1988';
+	TEXT TAXON=30 TEXT='Strophomenata -> Billingsellida -> Polytoechiidae';
+	TEXT TAXON=31 TEXT='General references: *Skovsted & Holmer (2005); Popov (1992); Williams et al (2000); Ushatinskaya & Koronikov 2016R; Popov et al. 2015';
+	TEXT TAXON=32 TEXT='Phylum: Brachiopoda, Class: Lingulata, Order: Acrotretida, Family: Acrotretidae';
+	TEXT TAXON=33 TEXT='Strophomenata -> Orthotetida -> Chilidiopsidae';
+	TEXT TAXON=37 TEXT='Phylum: Brachiopoda, Class: Craniata, Order: Trimerellida, Family: Trimerellidae, Genus: Gasconsia';
+	TEXT TAXON=38 TEXT='Rhynchonellata - Protorthida - Protorthidae';
+	TEXT TAXON=39 TEXT='Chen et al. (2007) interpret the weakly subconical valve with interarea as dorsal, but subsequent authors (Williams et al. 2007, Zhang et al. 2009) prefer the original interpretation that sees this valve as ventral; we follow this latter reconstruction.';
+	TEXT TAXON=46 TEXT='A phosphatic obolellid.^n^nIf another is desired, try Alisina (known from Chengjiang).';
+	TEXT TAXON=49 TEXT='The S1 sclerite is taken to be homologous with the ventral valve of brachiopods; the S2 sclerite presumably corresponds to the dorsal valve.';
+	TEXT TAXON=53 TEXT='Included because Gorjansky & Popov (1986) consider it intermediate between Trimerallids and Craniidae';
+
+	[Character comments]
+	TEXT CHARACTER=1 TEXT='The embryonic shell or protegulum is secreted by the embryo immediately before hatching.';
+	TEXT CHARACTER=2 TEXT='The brephic shell is the shell possessed by the young organism (see Ushatinskaya & Korovnikov 2016R and references therein for discussion of terminology).^n^nMicrina resembles linguliforms (Holmer et al. 2011): in both, the brephic mitral shell has one pair of setal sacs enclosed by lateral lobes, whereas the brephic ventral shell has two lateral setal tubes.^n^nPaterimitra and Salanygolina have "identical" ventral brephic shells (Holmer et al 2011), resembling the shape of a ship''s propeller.^n^nHaplophrentis is coded following typical hyoliths, which have a spherical brephic shell; Pedunculotheca''s, in contrast, is seemingly cap-shaped.';
+	TEXT CHARACTER=3 TEXT='Many taxa add to their embryonic shell (the protegulum possessed by the embryo upon hatching) during the larval phase of their life cycle.  The shell that exists at metamorphosis, marked by a halo or nick point, is variously termed the "first formed shell", "metamorphic shell" or "larval shell" (Bassett & Popov 2017).^n';
+	TEXT CHARACTER=4 TEXT='Pitting of the larval shell characterises acrotretids and their relatives.  Pustules occur on Paterinidae.  See Character 3 in Williams et al. (2000) tables 5-6.';
+	TEXT CHARACTER=5 TEXT='Embryonic shells of Micrina and certain linguliforms exhibit a transversely folded posterior extension that speaks of the original presence of a pedicle in the embryo.^n^nThis is independent of the presence of an adult pedicle, which may arise after metamorphosis.';
+	TEXT CHARACTER=6 TEXT='The protegulum of Micrina is penetrated with canals that were originally associated with setae, a character that it has in common with linguliforms (Holmer et al. 2011).';
+	TEXT CHARACTER=7 TEXT='Setal sacs are recognizable as raised lumps on the juvenile shell (see Bassett and Popov 2017).^n^nMicrina and linguliforms have setal sacs on their mitral/dorsal embryonic shell, whereas these are absent in Paterimitra (Holmer et al 2011).';
+	TEXT CHARACTER=8 TEXT='Two pairs on e.g. Coolina; one on e.g. Micrina';
+	TEXT CHARACTER=9 TEXT='Annelid chaetae are equivalent to the bundled setae expressed in certain brachiopod larvae.  See character 12 in @Vinther2008.';
+	TEXT CHARACTER=10 TEXT='@Luter2000 demonstrates that the setae of larval and adult brachiopods exhibit fundamental structural differences and are conceivably not homologous structures.  Larval setae are thus described separately.^n^nAlthough preservation of setae in fossil brachiopods is exceptional, their presence can be inferred from shelly material (see Holmer & Caron 2006).';
+	TEXT CHARACTER=11 TEXT='The majority of lophotrochozoan sclerites bear a characteristic striated texture that denotes their secretion by basal microvilli [@Butterfield1990].  The seta-like hooks of sipunculans lack this texture, suggesting that they may not be homologous with other setae.';
+	TEXT CHARACTER=12 TEXT='The diameter of secretory microvilli may vary across the diameter of a seta [@Smith2014]';
+	TEXT CHARACTER=13 TEXT='@Luter2000 distinguishes between the polygonal outline of microvillar canals in adult brachiopod setae and the oval outline of larval setae.';
+	TEXT CHARACTER=14 TEXT='The majority of lophotrochozoan sclerites are chitinous, occasionally hosting secondary biominerals.';
+	TEXT CHARACTER=15 TEXT='Certain setae are encapsulated in a 20 nm wide electron dense layer, termed "enamel" by @Gustus1973.  Enamel may be absent in larval setae [@Luter2003]; this character refers to the condition in adult setae.';
+	TEXT CHARACTER=16 TEXT='Setae penetrate the valves of many brachiopods.  In certain taxa, they are apparent only at the margins of the valves, in association with the commissure, being reduced or lost over the surface of the shell. ';
+	TEXT CHARACTER=17 TEXT='Sipunculan "setae" are basally invaginated, suggesting that they may not be homologous with annelid chaetae.';
+	TEXT CHARACTER=18 TEXT='Terebratulids and discinids instead exhibit knob-like individual spines These are distinct from the rings of spines that fringe lingulid setae.';
+	TEXT CHARACTER=19 TEXT='Lingulid setae bear crown-like rings of fine spines delimiting vertical sections, recalling the nodes of Equisetum stems. These arise by the addition of an additional circlet of microvilli [see @Luter2000, fig. 1e].  ';
+	TEXT CHARACTER=20 TEXT='Serial repetition in adult, whether expressed in valves, soft tissues or exoskeletal elements.  See character 13 in @Rouse1999; 19 in @Vinther2008; 38 in @Haszprunar1996; 40--41 in @Sutton2012; @Wanninger2009^n';
+	TEXT CHARACTER=21 TEXT='See characters 8 in @Haszprunar1996; 4 in @Vinther2008; 137 in @Rouse1999; 21 in @BucklandNicks2008; 37 in @Sutton2012; 1, 3 and 4 in @Haszprunar2008.^nIt is assumed that the adult foot is homologous with (and thus contingent on) the larval foot.^n';
+	TEXT CHARACTER=23 TEXT='Character 27 in @Haszprunar2000. Coelomoducts are excretory organs derived from the coelom, also in some cases serving as genital ducts (gonoducts); they replace (and may resemble) nephridia [@Goodrich1945].';
+	TEXT CHARACTER=24 TEXT='Gills (or ctenidia) surround the molluscan foot.^nCharacter 1.59-60, 2.09, 4.49 in @SPS1996; 10--11 in @Haszprunar2000; 45 in @Sutton2012';
+	TEXT CHARACTER=25 TEXT='After character 23 in @Haszprunar1996; 24 in @Haszprunar2000; 41 in @Rouse1999; 16 in @Scheltema1993; 16 in @Vinther2008; 5 in @Haszprunar2008';
+	TEXT CHARACTER=26 TEXT='The brachiopod pedicle is a fleshy protuberance that emerges from the posterior part of the body wall -- as denoted in fossil taxa by its occurrence between the dorsal and ventral valves.  ^n^nIt is important to distinguish the pedicle from the "pedicle sheath", a tubular extension of the umbo that grows by accretion from an isolated portion of the ventral mantle.  For discussion see Holmer et al. 2018T and Bassett and Popov 2017.';
+	TEXT CHARACTER=27 TEXT='The pedicle of certain chengjiang rhynchonelliforms comprises "densely stacked, three dimensionally preserved, tabular discs" (Holmer et al. 2018E).^nThis contrasts with the uniform (''massive'') pedicles of living taxa.';
+	TEXT CHARACTER=29 TEXT='A bulb is an expanded region of the distal pedicle, often embedded into the sediment to improve anchorage.';
+	TEXT CHARACTER=30 TEXT='Observed in Pedunculotheca and Bethia (Sutton et al 2005).';
+	TEXT CHARACTER=31 TEXT='Holmer et al. (2018T) remark that the tapering aspect of the Nisusia pedicle recalls that of certain Chengjiang taxa (Alisina, Longtancunella) whilst distinguishing it from many other taxa (Eichwaldia, Bethia) in which the pedicle is a constant thickness.';
+	TEXT CHARACTER=32 TEXT='Certain brachiopods, such as Acanthotretella, exhibit a coelomic cavity within the pedicle or pedicle sheath.^n^nTreated as transformational as it is not clear that either state is necessarily ancestral.';
+	TEXT CHARACTER=33 TEXT='Annulations are regular rings that surround the pedicle, and are distinguished from wrinkles, which are irregular in magnitude and spacing, and may branch or fail to entirely encircle the pedicle.';
+	TEXT CHARACTER=34 TEXT='In certain taxa the impression of the pedicle nerve is evident in the shell.  See character 28 in Williams et al. (1998T) appendix 1.  Care must be taken not to code an impression as absent when the preservational quality is insufficient to safely infer a genuine absence.  Treated as neomorphic as the presence of an innervation is considered a derived state.';
+	TEXT CHARACTER=35 TEXT='Whether impressed on a shell or expressed solely in soft tissue.';
+	TEXT CHARACTER=36 TEXT='The morphology of dorsal and ventral canals is identical in all included taxa, so is assumed not to be independent - hence the use of a single character (contra Williams et al. 2000).^n^nFor a description of terms see Williams et al. (1997, 2000).^n^nPinnate = "rapidly branch into a number of subequal, radially disposed canals"^nBifurcate = "vascula lateralia in both valves divide immediately after leaving the body cavity"^nBaculate =  "extend forward without any major dichotomy or bifurcation" (Williams et al. 1997 p. 418)^nSaccate = "pouchlike sinuses lying wholly posterior to the arcuate vascula media" (ibid., p412)';
+	TEXT CHARACTER=37 TEXT='We treat the vascula lateralia as equivalent to the vascula genitalia of articulated brachiopods, allowing phylogenetic analysis to test their proposed homology.^n^nWilliams et al (1997) write: "The mantle canal system of most of the organophosphate-shelled species consists of a single pair of main trunks in the ventral mantle (vascula lateralia) and two pairs in the dorsal mantle, one pair (vascula lateralia) occupying a similar position to the single pair in the ventral mantle and a second pair projecting from the body cavity near the midline of the valve. This latter pair may be termed the vascula media, but whether they are strictly homologous with the vascula media of articulated brachiopods is a matter of opinion. It is also impossible to assert that the vascula lateralia are the homologues of the vascula myaria or genitalia of articulated species, although they are likely to be so as they arise in a comparable position." ^n^n"In inarticulated brachiopods, two main mantle canals (vascula lateralia) emerge from the main body cavity through muscular valves and bifurcate distally to produce an increasingly dense array of blindly ending branches near the periphery of the mantle (fig. 71.1-71.2)."';
+	TEXT CHARACTER=38 TEXT='Williams et al. (1997) note that in addition to the vascula lateralia, "Discinisca has two additional mantle canals emanating from the body cavity into the dorsal mantle (vascula media)."^n^nThese structures are only evident in the dorsal valve for the included taxa, so only a single character is necessary.';
+	TEXT CHARACTER=39 TEXT='Presumed to be connected with setal follicles in life (Williams et al. 1998T).  See Williams et al. (2000) for discussion.';
+	TEXT CHARACTER=40 TEXT='The lophophore is a ring of tentacles that surrounds the mouth.  @Temereva2017Innervationof suggests that true lophophores must also encompass the anus, which excludes the tentacular apparatus of entoprocts from the definition; as homology between the tentacular apparatuses of entoprocts and other lophophorates has often been assumed, we prefer to take a more inclusive stance and code the structures as potentially homologous.^n^nIt is unlikely that the tentacles of annelids and sipunculans correspond to the lophophore, yet homology is not inconceivable.  In order that the tentacular apparatus of Haplophrentis can be compared with both organs without prejudice, we capture the presence of a tentacular apparatus in this very broad character, with arguments against homology reflected in separate transformation series.';
+	TEXT CHARACTER=41 TEXT='The tentacles of annelids and sipunculans originate from a dorsal pair of buds on the prostomium [@Adrianov2006], whereas the brachiopod lophophore arises from the second pair of coelomic sacs [@Nielsen1991].';
+	TEXT CHARACTER=42 TEXT='Tentacles may occur along one or both sides of the axis of the lophophore arm (Carlson 1995).';
+	TEXT CHARACTER=43 TEXT='After Carlson (1995), character 37.  Lophophore tentacles are commonly arranged into an ablabial and adlabial row, with ablabial tentacles sometimes added later in development.';
+	TEXT CHARACTER=44 TEXT='After Carlson (1995), character 37.  Lophophore tentacles are commonly arranged into an ablabial and adlabial row, with ablabial tentacles sometimes added later in development (and thus interpreted as a neomorphic addition).';
+	TEXT CHARACTER=45 TEXT='Following character 28 in Carlson 1995. Certain taxa exhibit a median tentacle early in development that is lost during ontogeny. ';
+	TEXT CHARACTER=46 TEXT='Following @Temereva2017Innervationof';
+	TEXT CHARACTER=47 TEXT='Annelid tentacles are innervated by palp nerves [@Orrhage2005]; lophophores ancestrally contained a pair of nerve rings [@Temereva2017Innervationof]';
+	TEXT CHARACTER=48 TEXT='Juvenile lophophorates exhibit two nerve rings in the tentacles; one of these rings is often reduced or lost at adulthood [@Temereva2017Innervationof]';
+	TEXT CHARACTER=49 TEXT='Juvenile lophophorates exhibit two nerve rings in the tentacles; one of these rings is often reduced or lost at adulthood [@Temereva2017Innervationof]';
+	TEXT CHARACTER=51 TEXT='Whereas the lophophore of crown-group brachiopods typically forms a closed loop, those of Haplophrentis and Heliomedusa diverge laterally (Moysiuk et al 2017).';
+	TEXT CHARACTER=52 TEXT='The lophophore arms of Heliomedusa and Haplophrentis arch posteriad, rather than anteriad as in lingulids.  See Zhang et al. 2009; Moysiuk et al. 2017.';
+	TEXT CHARACTER=53 TEXT='Following character 55 in Carlson (1995).  Not possible to code in most fossil taxa.';
+	TEXT CHARACTER=54 TEXT='Hyoliths exhibit a prominent protrusible muscular pharynx at the base of the lophophore (Moysiuk et al. 2017).  This is considered as potentially equivalent to the anterior projection of the visceral cavity in Heliomedusa, and, by extension, in Lingulosacculus and Lingulotreta.';
+	TEXT CHARACTER=55 TEXT='Any apparatus comprising multiple denticulate rows arranged serially in the sagittal plane is treated as potentially homologous with the molluscan radula.';
+	TEXT CHARACTER=56 TEXT='Following character 86 in @Giribet2002.';
+	TEXT CHARACTER=57 TEXT='Character 133 in @Grobe2007';
+	TEXT CHARACTER=58 TEXT='Character 66 in @Haszprunar2000';
+	TEXT CHARACTER=59 TEXT='The molluscan midgut is functionally subdivided into a sorting area (stomach), digestion area (midgut sac or gland), and transport tube (intestine).  Characters 42 in @Haszprunar2000, 1.38 in @SPS1996.^n';
+	TEXT CHARACTER=60 TEXT='Characters 1.40, 2.30 and 4.59 in @SPS1996; 42 in @Haszprunar2000.';
+	TEXT CHARACTER=61 TEXT='The digestive tract may either constitute a blind sac, or a through gut with anus.  The loss of an anus is known to be derived within spiralia, so this character is treated as neomorphic.';
+	TEXT CHARACTER=62 TEXT='"The relative position of the mouth and anus in the larvae of brachiopods and phoronids is similar: posterior anus and anterior mouth" -- Williams et al. 2007, p. 2884^nSee also character 6 in @Haszprunar2008';
+	TEXT CHARACTER=63 TEXT='A migrated anus may be located laterally or within the lophophore ring (as in entoprocts).';
+	TEXT CHARACTER=64 TEXT='If the anus is not within the ring of tentacles, in which direction is it oriented?';
+	TEXT CHARACTER=65 TEXT='Plate-like (wider than tall) skeletal elements, whether mineralized or non-mineralized.^nThe definition deliberately excludes setae (which are taller than wide).^n';
+	TEXT CHARACTER=66 TEXT='Certain taxa periodically slough and replace some of their individual sclerites during growth';
+	TEXT CHARACTER=67 TEXT='Scleritome dominated by prominent differentiated dorsal and ventral valves';
+	TEXT CHARACTER=68 TEXT='Taxa in the bivalved condition may retain sclerites as small additional elements, such as the L-elements of Paterimitra (Skovsted et al. 2015).  Hyolithid helens are coded as potentially homologous to these elements [following @Moysiuk2017Hyolithsare].^n^nThis character is treated as neomorphic, with accessory sclerites ancestrally present, recognizing the likely origin of brachiozoans (and Lophotrochozoans more generally) from a scleritomous organism.';
+	TEXT CHARACTER=69 TEXT='Following @Zhao2017';
+	TEXT CHARACTER=70 TEXT='Following @Zhao2017';
+	TEXT CHARACTER=72 TEXT='In crown-group brachiopods, the two primary shells close to form an enclosed filtration chamber.  Further down the stem, taxa such as Micrina do not.';
+	TEXT CHARACTER=73 TEXT='Orthothecid hyoliths can retract their operculum into their conical shell, in contrast to most other taxa, where the valves align exactly when they are closed, save perhaps for a pedicle notch or, in the case of hyolithids, depressions that allow the helens to protrude.  Refers only to two prominent valves, not to additional sclerites of e.g. Eccentrothca.';
+	TEXT CHARACTER=74 TEXT='The anterior commissure can be rectimarginate (i.e. straight), uniplicate (i.e. median sulcus in ventral valve), or sulcate (with median sulcus in dorsal valve).';
+	TEXT CHARACTER=75 TEXT='Shape of the commissure in plan view, ignoring any deflection arising due to articulation at the hinge (e.g. delthyrium/notothyrium).  This character seeks to discriminate the essentially conical ''conchs'' of orthothecid hyoliths from the polygonal ''conchs'' of hyolithids.  Triangular and oblong outlines are not distinguished, as this is not entirely independent of the strophic/astrophic nature of the hinge.';
+	TEXT CHARACTER=76 TEXT='If lateral margins are linear, are the subparallel (i.e. commissure profile oblong, with long hinge) or diverging (i.e. commissure profile triangular, with short hinge)?';
+	TEXT CHARACTER=77 TEXT='Micrina, like many brachiopods, bears tooth-like structures or processes that articulate the two primary valves. Caution must be applied before taxa are coded as "absent", as teeth can be subtle and may be overlooked.^n';
+	TEXT CHARACTER=78 TEXT='Deltidiodont teeth are simple hinge teeth developed by the distal accretion of secondary shell; Cyrtomatodont teeth are knoblike or hook-shaped hinge teeth developed by differential secretion and resorption of the secondary shell (fig. 322 in Williams et al 1997).^n^nKutorginata (here represented by Kutorgina and Nisusia) don''t have teeth (apophyses) or dental sockets, but their shells are articulated by "two triangular plates formed by dorsal interarea, bearing oblique ridges on the inner sides" (Williams et al 2000, p. 211); this simple hinge mechanism is different from other rhynchonelliforms (Williams et al. 2000, p.208; table 13 character 30), and is described as a "pseudodont articulation" (Holmer et al. 2018E).^n';
+	TEXT CHARACTER=79 TEXT='Williams et al. 1997 (p362) write: "Teeth [...] are commonly supported by a pair of variably disposed plates also built up exclusively of secondary shell and known as dental plates (Fig. 323.1, 323.3)."^n^nDewing (2001) elaborates: "Dental plates are near-vertical, narrow sheets of shell tissue between the anteromedian edge of the teeth and floor of the ventral valve. They are a composite structure, resulting from the growth of teeth over the ridge that bounds the ventral-valve muscle field."^n^nWilliams et al. 2000 (p.201) write: "The denticles lack supporting structures in all Obolellida, but in Naukatida they are supported by an arcuate plate below the^ninterarea, the anterise (Fig. 119.3a)".^n^nThe anterise is conceivably homologous with the dental plates, thus the presence of either is coded "present" for this character.';
+	TEXT CHARACTER=80 TEXT='Simplified from Bassett et al. (2001) character 16.^nThis character is independent of apophyses, as several taxa bear sockets without corresponding teeth; the function of these sockets is unknown.^nSee figs 323ff in Williams et al. (1997).';
+	TEXT CHARACTER=81 TEXT='After Bassett et al. (2001) character 17.  May be difficult to distinguish from a brachiophore (see Fig 323 in Williams et al 1997), so the two structures are not distinguished here.';
+	TEXT CHARACTER=82 TEXT='After Bassett et al. (2001) character 6';
+	TEXT CHARACTER=83 TEXT='Muscles can attach to the ventral valve posterolaterally to, as well as between, the vascula lateralia (Popov 1992)';
+	TEXT CHARACTER=84 TEXT='After Bassett et al. (2001) character 7.^nThis character is contingent on the presence of a pedicle.  Extreme caution must be used in inferring an absent state, as adjustor scars can be extremely difficult to distinguish from the adductor scars.';
+	TEXT CHARACTER=85 TEXT='After Bassett et al. (2001) character 8, and Williams et al. (1996, character 35; 2000, p. 160, character 54)^n^nIn the dorsal valve, the anterior and posterior adductor scars of articulated brachiopods form a single (quadripartite) muscle field (Williams et al. 2000, p. 201)^n^nIn contrast, the anterior and posterior scars of e.g. trimerellids have prominently separate attachment points, with anterior and posterior muscle fields clearly distinct, and coded as "dispersed".^n^nIn e.g. kutorginates, adductor muscles are separated into left and right fields; the same is the case in lingulids, where there are more separate muscle groups and the left and right fields conspire to produce a radial arrangement; both of these configurations are scored as "radially arranged".';
+	TEXT CHARACTER=86 TEXT='Position of adductor muscles relative to commissural plane.^nAfter Bassett et al. (2001) character 11.^n^n';
+	TEXT CHARACTER=87 TEXT='Based on character 11 in Zhang et al. (2014).^nWell developed dermal muscles present in the body wall of recent lingulates, which are absent in all calcareous-shelled brachiopods. These muscles are responsible for the hydraulic shell-opening mechanism, and possibly present in all organophosphatic-shelled brachiopods, with the possible exception of the paterinates (Williams et al., 2000, p. 32) ^n';
+	TEXT CHARACTER=88 TEXT='The levator ani is a diminutive unpaired medial muscle found in certain calcitic brachiopods (Williams et al. 2000; see fig. 89, character 34 in table 13)';
+	TEXT CHARACTER=89 TEXT='After Bassett et al. (2001) character 9';
+	TEXT CHARACTER=90 TEXT='After Bassett et al. (2001) character 10.';
+	TEXT CHARACTER=91 TEXT='See Fig. 284 in Williams et al (1997).^nThe growth direction dictates the attitude of the cardinal area relative to the hinge, which does not therefore represent an independent character.^nCrudely put, if, viewed from a dorsal position, the umbo falls within the outer margin of the shell, growth is holoperipheral; if it falls outside the margin, it is mixoperipheral; if it falls exactly on the margin, it is hemiperipheral.';
+	TEXT CHARACTER=92 TEXT='In shells that grow by mixoperipheral growth, the triangular area subtended between each apex and the posterior ends of the lateral margins is termed the cardinal area.  In shells with holoperipheral growth, a flattened surface on the posterior margin of the valve is termed a pseudointerarea (paraphrasing Williams et al. 1997).^n^nIn order for this character to be independent of a shell''s growth direction, we do not distinguish between a "cardinal area", "interarea" or "pseudointerarea".^n';
+	TEXT CHARACTER=93 TEXT='It is possible for a cardinal area or pseudointerarea to be distinct from the anterior part of the shell, yet to remain curved in lateral profile.^n^nTaking an undifferentiated posterior margin as primitive, the primitive condition is curved -- flattening of the posterior margin represents an additional modification that can only occur once the posterior margin is differentiated.';
+	TEXT CHARACTER=94 TEXT='Following character 29 in Williams et al. (2000), table 9 (which relates to pseudointerarea)';
+	TEXT CHARACTER=95 TEXT='A notothyrium is an opening in an interarea that accommodates the pedicle, and may be filled with plates.^n';
+	TEXT CHARACTER=96 TEXT='A notothyrium is an opening in an interarea that accommodates the pedicle, and may be filled with plates.^n^nA simplification of character 5 in Bassett et al. 2001.';
+	TEXT CHARACTER=97 TEXT='A notothyrium may be open or covered by a chilidium or two chilidial plates.^nNo included taxa exhibit more than one chilidial plate.^nTransformational as it is not self-evident whether the ancestral taxon had an open or closed notothyrium.';
+	TEXT CHARACTER=98 TEXT='After Bassett et al. (2001) character 12.^nThe presence or absence of a notothyrial platform, which often serves as an attachment point for the diductors in a similar fashion to the cardinal processes, is independent of the presence of a notothyrium.';
+	TEXT CHARACTER=99 TEXT='The dorsal valve of many taxa is exhibits a septum or process (or myophragm) along the medial line.  See character 25 in Benedetto (2009).';
+	TEXT CHARACTER=100 TEXT='The hyolithid operculum is divided into a cardinal and conical shield [@Zhang2018Ahyolithid], separated by furrows corresponding to the position of the helens. See @Marek1976 (fig. 2) or @MartiMus2005 (fig. 1) for schematic.^n^nWith no obvious sites for muscle attachment, the shields are unlikely to be homologous to the notothyrial platform.  ';
+	TEXT CHARACTER=101 TEXT='After Bassett et al. (2001) character 13.  See @MartiMus2005 for an illustration.^nCardinal processes are unlikely to be homologous with the notothyrial platform, even if their function is similar.';
+	TEXT CHARACTER=102 TEXT='Radially arranged teeth, separated by furrows, adorn the cardinal margin of the operculum of certain hyolithids [@Marek1963].  The absence of corresponding tooth sockets indicates that they do not serve to articulate the valves; @Marek1967 does not consider the teeth to be homologous with brachiopod cardinal teeth.';
+	TEXT CHARACTER=103 TEXT='Prominent symmetrical ridges on the inner surface of the hyolith operculum';
+	TEXT CHARACTER=104 TEXT='Usually the operculum of hyoliths has one pair of clavicles, but in some taxa of hyolithida there are more than one pair of clavicles, which can be divided into six types [@Marek1967].  The included taxa either exhibit a single pair of monoclavicles, or three pairs of clavicles.';
+	TEXT CHARACTER=105 TEXT='See Fig. 284 in Williams et al. (1997) for depiction of terms.^n^nThe growth direction dictates the attitude of the cardinal area relative to the hinge, which does not therefore represent an independent character.^nCrudely put, if, viewed from a dorsal position, the umbo falls within the outer margin of the shell, growth is holoperipheral; if it falls outside the margin, it is mixoperipheral; if it falls exactly on the margin, it is hemiperipheral.';
+	TEXT CHARACTER=106 TEXT='In many brachiopods, the valves are closely similar in size; in others, the ventral valve is markedly larger than the dorsal, on account of being more convex.  Marginal cases are treated as ambiguous for the relevant states.';
+	TEXT CHARACTER=107 TEXT='In shells that grow by mixoperipheral growth, the triangular area subtended between each apex and the posterior ends of the lateral margins is termed the cardinal area.  In shells with holoperipheral growth, a flattened surface on the posterior margin of the valve is termed a pseudointerarea (paraphrasing Williams et al. 1997).^n^nIn order for this character to be independent of a shell''s growth direction, we do not distinguish between a "cardinal area", "interarea" or "pseudointerarea".^n';
+	TEXT CHARACTER=108 TEXT='Balthasar (2008) notes an inward-growing posterior margin of the pseudointerarea as potentially linking Mummpikia with the linguliform brachiopods.^n^nCoded as inapplicable in taxa without a differentiated posterior margin: the posterior margin can only grow inwards if it is differentiated from the anterior margin; else the entire shell would grow in on itself.';
+	TEXT CHARACTER=109 TEXT='It is possible for a cardinal area or pseudointerarea to be distinct from the anterior part of the shell, yet to remain curved in lateral profile.^n^nTaking an undifferentiated posterior margin as primitive, the primitive condition is curved -- flattening of the posterior margin represents an additional modification that can only occur once the posterior margin is differentiated.^n^nA flat and triangular interarea links Mummpikia with the Obolellidae (Balthasar 2008) -- but all included taxa have triangular interareas, so this is not listed as a separate character.^n';
+	TEXT CHARACTER=110 TEXT='The aperture of many hyolithid hyoliths is characterised by a ligula, a tongue-like protruding shelf on the functionally ventral surface of conical shell [@MartiMus2005].  This can be recognized by an acute angle in the lateral profile of the commissure [see second figure on p. 91 of @Marek1966].  No brachiopods display an equivalent feature.';
+	TEXT CHARACTER=111 TEXT='Distinguishes taxa whose ventral valve is essentially flat from those that are essentially conical';
+	TEXT CHARACTER=112 TEXT='A delthyrium is an opening in an interarea or pseudointerarea that accommodates the pedicle, and may be filled with plates.^n^nThe homology of the pedicle in the pseudointerarea of obolellids and botsfordiids with the umbonal pedicle foramen of acrotretids was proposed by Popov (1992), and seemingly corroborated by observations of Ushatinskaya & Korovnikov (2016R), who note that the propareas of the Botsfordia ventral valve sometimes merge to form an elongate teardrop-shaped pedicle foramen.^n';
+	TEXT CHARACTER=113 TEXT='A parallel-sided delthyrium links Mummpikia with the Obolellidae (Balthasar 2008).^n^nFollowing Popov (1992), the larval delthyrium of acrotretids and allied taxa is understood to be sealed in adults by outgrowths of the posterolateral margins of the shell. The resultant round or teardrop-shaped foramen corresponds the delthyrium.^n';
+	TEXT CHARACTER=114 TEXT='Chen et al. (2007) propose that an oval to rhombic foramen characterises the discinids (and Heliomedusa, though the foramen in this taxon has since been reinterpreted by Zhang et al. (2009) as an impression of internal tissue).^n';
+	TEXT CHARACTER=115 TEXT='An open delthyrium links Mummpikia with the Obolellidae (Balthasar 2008).^n^nThe delthyrial opening can be covered by one or more deltidial plates, or a pseudodeltitium.^n^nInapplicable in taxa with a round delthiruym (generated by overgrowth of the delthyrial opening by posterolateral parts of the shell, per Popov 1992).^n';
+	TEXT CHARACTER=117 TEXT='This character has the capacity for further resolution (one or more deltidial plates), but this is unlikely to affect the results of the present study.^n^nThe pseudodelthyrium is also referred to as a homeodeltidium.^n^nThe antemucronal area of Polyplacophora is treated as equivalent to the brachiopod delthyrium, but is not depositionally distinct to the rest of the shell, so is coded with a distinct character state.';
+	TEXT CHARACTER=118 TEXT='A ridge-like (i.e. convex) pseudodeltitium unites Salanygolina with Coolinia and other Chileata (Holmer et al. 2009, p. 6).';
+	TEXT CHARACTER=119 TEXT='After Bassett et al. (2001) character 18, "Hinge furrows on lateral sides of pseudodeltidium".';
+	TEXT CHARACTER=120 TEXT='Certain taxa, particularly those with a colleplax, exhibit a perforation at the umbo of the ventral valve.  This opening is sometimes associated with a pedicle sheath, which emerges from the umbo of the ventral valve without any indication of a relationship with the hinge.^n^nIn contrast, the pedicle of acrotretids and similar brachiopods is situated on the larval hinge line, but is later surrounded by the posterolateral regions of the growing shell to become separated from the hinge line, and encapsulated in a position close to (or with resorption of the brephic shell, at) the umbo (see Popov 1992, pp. 407-411 and fig. 3 for discussion).  In some cases, an internal pedicle tube attests to this origin -- potentially corresponding to the pedicle groove of lingulids.  As such, the pedicle foramen of acrotretids and allies is not originally situated at the umbo; it is instead understood to represent a basally sealed delthyrium.';
+	TEXT CHARACTER=121 TEXT='The perforation in Cupitheca seems to have a distinct origin, arising through decollation; as such, the shape simply reflects the outline of the shell.  This reflects a distinct origin of the perforation and is therefore provided as a separate state.';
+	TEXT CHARACTER=122 TEXT='In certain taxa, the umbo of the ventral valve bears a colleplax, cicatrix or pedicle sheath; Bassett et al. (2008) consider these structures as homologous.';
+	TEXT CHARACTER=123 TEXT='Chen et al. (2007) observe a median septum in what they interpret as the ventral valve of Heliomedusa, and the ventral valve of Discinisca, which they propose points to a close relationship.';
+	TEXT CHARACTER=124 TEXT='After character 11 in Williams et al. (1998T).  Coded as transformational as it is possible that maintaining a smooth shell without occasional prominent ridges requires greater secretory control.';
+	TEXT CHARACTER=125 TEXT='After character 11 in Williams et al. (1998T).';
+	TEXT CHARACTER=126 TEXT='Ridges radiating from umbo, i.e. ribs';
+	TEXT CHARACTER=127 TEXT='Mineralized or partly mineralized spines are observed in Heliomedusa and Acanthotretella';
+	TEXT CHARACTER=129 TEXT='Williams et al. (1996) identify glycoprotein-based organic scaffolds as distinct from those comprising glycosaminoglycans (GAGs), chitin and collagen.  This character can only be scored for extant taxa.';
+	TEXT CHARACTER=130 TEXT='Phoronids and Yuganotheca aggulutinate particles into their sclerites.';
+	TEXT CHARACTER=131 TEXT='Following character 9 in Williams et al. (1998T); see their p228-230 for a discussion of how this might be inferred from fossil material.';
+	TEXT CHARACTER=132 TEXT='Hyolith conchs comprise two mineralized layers of fibrous bundles.  Bundles are measure 5-15 um across; their constituent fibres are each 0.1-1.0 um wide.  In the inner layer, the fibres are transverse; in the outer layer, the bundles are inclined towards the umbo, becoming longitudinal on the outermost margin.^n^nCoded as non-additive as there is no clear necessity to add layers sequentially: for example, three layers could arise by the addition of a void within a single pre-existing layer.^n^nStratiform laminae, shell-penetrating canals and other features above the scale of crystal organization are not considered as contributing to the mineralogical microstructure and are coded separately.^n^nInapplicable in taxa with a non-mineralized shell.';
+	TEXT CHARACTER=133 TEXT='Hyolith conchs comprise two mineralized layers of fibrous bundles.  Bundles measure 5--15 &mu;m across; their constituent fibres are each 0.1-1.0 um wide.  In the inner layer, the fibres are transverse; in the outer layer, the bundles are inclined towards the umbo, becoming longitudinal on the outermost margin.^n^nStratiform laminae, shell-penetrating canals and other features above the scale of crystal organization are not considered as contributing to the mineralogical microstructure and are coded separately.^n^nThe pervasive (not just superficial) polygonal structures in Paterimitra are distinct, and characterize Askepasma, Salanygolina, Eccentrotheca and Paterimitra (Larsson et al. 2014)^n^nWilliams et al. (2000) identify cross-bladed laminae as diagnostic of Strophomenata, with the exception of some older groups that contain fibres or laminar laths.';
+	TEXT CHARACTER=134 TEXT='In tommotiids, the shell simply comprises a stack of stratiform lamellae, each corresponding to a circumferential rib at the shell surface.  This is particularly apparent in Dailyatia [@Skovsted2015Theearly] and Paterimitra [@Larsson2014iPaterimitra].';
+	TEXT CHARACTER=135 TEXT='Laminae within, for example, Salanygolina are separated by voids that may originally have contained organic material [e.g. @Holmer2009Theenigmatic]. In contrast, tommotiids and paterinids exhibit stratification without voids, perhaps representing periodic fluctuations in phosphate availability [@Balthasar2009Homologousskeletal].';
+	TEXT CHARACTER=136 TEXT='See character 37 in @Williams1998Thediversity.  ^n"A distinct primary layer [...] is characterized by a polygonal ornament that is mineralized from the polygon walls inward, while the rest of the shell and/or sclerite is secreted by basal accretion" -- @Balthasar2009Homologousskeletal.  Distinguished from epithelial cell moulds in lingulids, which do not form an integral part of the shell structure [@Balthasar2009Homologousskeletal].^nTreated as transformational as ancestral condition is ambiguous.';
+	TEXT CHARACTER=137 TEXT='A caniculate microstructure occurs in lingulids; canals are narrower (&lt; 1 um) than punctae, may branch, and do not fully penetrate the shell, terminating just within the boundaries of a microstructural layer. See Williams 1997, p303ff, and Balthasar 2008, p273, for discussion.^n^nTubules described in hyoliths by Kouchinsky (2000) measure around 10 um in diameter, making them an order of magnitude wider than lingulid canals.  ^n^nThis said, Balthasar (2008) considers the rod-like tubules within the columnar shell microstructure of Mickwitzia cf. occidens (1-3 um wide, Skovsted & Holmer 2003), acrotretides (1 um wide, see Holmer 1989, Zhang et al. 2016) and lingulellotretids (100 nm wide, Cusack et al 1999) as equivalent to lingulid canals.^n^nMicrina exhibits both punctae and canals (Harper et al. 2017), challenging Carlson''s contention (in Williams et al. 2007) that the structures are potentially homologous as shell perforations.';
+	TEXT CHARACTER=138 TEXT='Punctae are 10-20 um wide canals created by multicellular extensions of the outer epithelium.  They penetrate the full depth of the shell.^n^nBalthasar (2008) writes:^n^n"Vertical shell penetrating structures, such as punctae, pseudopunctae, extropunctae and canals, are common in many groups of brachiopods and are distinguished based on their geometry and size (Williams 1997). Punctae are 10-20 um wide and represent multicellular extensions of the outer epithelium (Owen and Williams 1969). Pseudopunctae and extropunctae are similar in diameter but, instead of canals, are vertical stacks of conical deflections of individual shell layers (Williams and Brunton 1993). None of these three types of vertical shell structure, all of which are confined to calcitic-shelled brachiopods, compares with the much smaller canals (&lt; 1 um in diameter) of M. nuda. The only type of vertical structure that fits the size and nature of the canals of the Mural obolellids are the canals of linguliform brachiopods, which range in width from 180 to 740 nm and are occupied by proteinaceous strands in extant taxa (Williams et al. 1992; Williams et al. 1994; Williams et al. 1997). In contrast to obolellid canals, however, linguliform canals are not known to penetrate the entire shell but terminate in organic-rich layers (Williams 1997). Based on these considerations it would, therefore, be misleading to call obolellid shells punctate (they are as much "punctate" as acrotretids or other linguliforms); rather their shell structure should be called canaliculate (Williams 1997)."';
+	TEXT CHARACTER=139 TEXT='Pseudopunctae are not punctae, but deflections of shell laminae.  They characterise Strophomenata in particular.';
+	TEXT CHARACTER=140 TEXT='Regular polygonal compartments, around 10 um in diameter, characterise Paterimitra.  Walls between compartments have the cross-section of an anvil. An external polygonal structure (possible imprints of epithelial tissue) occurs in Dailyatia, but it is a surface pattern, which is different from the polygonal prisms in the body wall of other paterinid-like groups.';
+	TEXT CHARACTER=141 TEXT='Character 27 in @Haszprunar1996';
+	TEXT CHARACTER=142 TEXT='After character 31 in @Haszprunar1996.';
+	TEXT CHARACTER=143 TEXT='After character 31 in @Haszprunar1996.';
+	TEXT CHARACTER=144 TEXT='After character 30 in @Haszprunar1996.';
+	TEXT CHARACTER=145 TEXT='After characters 1.61 and 2.54 in @SPS1996';
+	TEXT CHARACTER=146 TEXT='After character 62 in @Haszprunar2000.';
+	TEXT CHARACTER=147 TEXT='Following Carlson (1995), character 7.  This character is only possible to code in extant taxa.  It is not considered independent of Carlson''s character 11, number of gametes released per spawning, as it is possible to produce more small eggs than large eggs -- thus this latter character is not reproduced in the present study.  The same goes for Carlson''s character 12, gamete dispersal mode; brooders will tend to brood large eggs.';
+	TEXT CHARACTER=148 TEXT='After character 4.69 in @SPS1996';
+	TEXT CHARACTER=149 TEXT='After Carlson (1995), character 9. Only possible to code in extant taxa.';
+	TEXT CHARACTER=150 TEXT='After character 41 in @Ponder1997';
+	TEXT CHARACTER=151 TEXT='Following @Smith2012, after character 160 in @Giribet2002. A fossa (latin: ditch) is a dent or impression.';
+	TEXT CHARACTER=153 TEXT='Hodgson & Reunov 1994 describe the Discinisca acrosome as having "an electron-lucent centre and an electron-dense outer region", and state that this trait is characteristic of inarticulate brachiopods.';
+	TEXT CHARACTER=155 TEXT='Following Hodgson & Reunov (1994)';
+	TEXT CHARACTER=156 TEXT='Following Hodgson & Reunov 1994.';
+	TEXT CHARACTER=157 TEXT='Following @Smith2012; see @BucklandNicks2008';
+	TEXT CHARACTER=158 TEXT='Following @Smith2012, after character 48 in @Ponder1997.';
+	TEXT CHARACTER=159 TEXT='After character 5 in @BucklandNicks2008; see also character 43 in @Ponder1997.';
+	TEXT CHARACTER=160 TEXT='After character 44 in @Ponder1997.  Cristae are internal compartments formed by inner mitochondrial membranes.';
+	TEXT CHARACTER=161 TEXT='After @Smith2012; see also character 43 in @Ponder1997; character 164 in @Giribet2002';
+	TEXT CHARACTER=162 TEXT='Following @Hejnol2010.  Blastomeres may undergo significant size differentiation, generating macromeres and micromeres of prominently different sizes.';
+	TEXT CHARACTER=163 TEXT='Following character 170 in @Giribet2002';
+	TEXT CHARACTER=164 TEXT='The "molluscan cross" and "annelid cross" cannot be systematically discriminated from one another, so are treated as a single state.  ^nSee characters 127 & 128 in @Rouse1999; 1.49 in @SPS1996;^ncharacter 34 in @Haszprunar1996; 35 in @Haszprunar2000; 172 in @Giribet2002.';
+	TEXT CHARACTER=165 TEXT='Following character 171 in @Giribet2002';
+	TEXT CHARACTER=166 TEXT='See characters 32-33 in @Haszprunar1996; character 1.48 in @SPS1996; character 29 in @Glenner2004.';
+	TEXT CHARACTER=167 TEXT='After characters 32 in @Grobe2007 and 36-37 in @Glenner2004';
+	TEXT CHARACTER=168 TEXT='Character 8 in @Vinther2008';
+	TEXT CHARACTER=169 TEXT='Character 8 in @Haszprunar2008.';
+	TEXT CHARACTER=170 TEXT='Character 79 in @Glenner2004';
+	TEXT CHARACTER=171 TEXT='After character 3 in @Richter2010';
+	TEXT CHARACTER=172 TEXT='Character 1.43 in@SPS1996';
+	TEXT CHARACTER=173 TEXT='Character 26 in @Haszprunar2000';
+	TEXT CHARACTER=174 TEXT='Foot or neurotroch present in larval stage, whether or not it is also present in mature individuals. Following @Wingstrand1985.';
+	TEXT CHARACTER=175 TEXT='A pedal gland is considered evidence for homology between the molluscan and entoproct foot [@Haszprunar2008].';
+	TEXT CHARACTER=176 TEXT='Character 2.02 in @Scheltema1993';
+	TEXT CHARACTER=177 TEXT='Character 1.03 in @Scheltema1993';
+	TEXT CHARACTER=178 TEXT='Character 140 in @Rouse1999. See also character 2.66 in @SPS1996; 153 in @Giribet2002.';
+	TEXT CHARACTER=179 TEXT='See characters 129 and 131 in @Rouse1999; 40 in @Haszprunar1996.^nA prototroch is the defining character of a trochophore larva; a metatroch is a secondary ciliary ring [@Rouse1999].^n';
+	TEXT CHARACTER=180 TEXT='A posterior ciliary band. Character 136 in @Rouse1999.';
+	TEXT CHARACTER=181 TEXT='Character 132 in @Rouse1999';
+	TEXT CHARACTER=182 TEXT='Downstream-collecting ciliary bands of compound cilia on multiciliated cells. See character 32 in @Glenner2004.';
+	TEXT CHARACTER=183 TEXT='Upstream-collecting ciliary bands with single cilia on monociliated cells. See character 32 in @Glenner2004.';
+	TEXT CHARACTER=184 TEXT='Characters 1.50, 2.66 and 4.68 in @SPS1996; 2 in @Vinther2008.  See also characters 39 in @Haszprunar1996 and 153 in @Giribet2002.';
+	TEXT CHARACTER=185 TEXT='Following @Wanninger2009';
+	TEXT CHARACTER=186 TEXT='After @Lundin2009';
+	TEXT CHARACTER=187 TEXT='After @Lundin2009^n';
+	TEXT CHARACTER=188 TEXT='After @Lundin2009. Fibres radiate from the distal end of the basal foot of the cilia in certain taxa.^n';
+	TEXT CHARACTER=189 TEXT='After @Lundin2009.  Also termed "dense plate".^n';
+	TEXT CHARACTER=190 TEXT='After @Lundin2009; coded following @Smith2012';
+	TEXT CHARACTER=191 TEXT='After @Lundin2009^n';
+	TEXT CHARACTER=192 TEXT='After @Lundin2009.^nThe ciliary necklace is defined by @Gilula1972 as "Well-defined rows or strands of membrane particles that encircle the ciliary shaft".  It occurs immediately below the basal plate, and comprises three beaded circles of on the circumference of the cilia membrane.';
+	TEXT CHARACTER=193 TEXT='After @Lundin2009. Compound cilia are motile structures composed of 10--100 regular cilia used in locomotion or feeding^n';
+	TEXT CHARACTER=194 TEXT='Character 14 in @Glenner2004.  Compound cilia can be produced by the aggregation of cilia from multiple monociliate cells, or from a single cell bearing multiple cilia [@Nielsen1987].';
+	TEXT CHARACTER=195 TEXT='After @Lundin2009^n';
+	TEXT CHARACTER=196 TEXT='After @Lundin2009^n';
+	TEXT CHARACTER=197 TEXT='After @Lundin2009.  The vertical ciliary rootlet is also termed the posterior rootlet.';
+	TEXT CHARACTER=198 TEXT='After @Lundin2009.  The vertical ciliary rootlet is also termed the posterior rootlet.^n';
+	TEXT CHARACTER=199 TEXT='After @Lundin2009.  The secondary ciliary rootlet is also termed the anterior ciliary rootlet.^n';
+	TEXT CHARACTER=200 TEXT='After @Lundin2009.  The secondary ciliary rootlet is also termed the anterior ciliary rootlet.^n^n';
+	TEXT CHARACTER=201 TEXT='After @Lundin2009.  The secondary ciliary rootlet is also termed the anterior ciliary rootlet.';
+	TEXT CHARACTER=202 TEXT='See characters 21 and 28 in @Haszprunar2000; 1.12 in @Scheltema1993';
+	TEXT CHARACTER=203 TEXT='Pore cells.  Character 20 in @Haszprunar2000.';
+	TEXT CHARACTER=204 TEXT='See character 4.46 in @SPS1996.';
+	TEXT CHARACTER=205 TEXT='Also termed cyrtocytes.  Character 21 in @Grobe2007; 1.47 in @SPS1996; 138 in @Rouse1999; 20 in @Haszprunar1996; 90 in @Glenner2004';
+	TEXT CHARACTER=206 TEXT='See characters 35 in @Rouse1999; 28 in @Haszprunar2000; 93 in @Glenner2004; 1.47 in @SPS1996; 21 in @Grobe2007; 138 in @Rouse1999; 20 in @Haszprunar1996.';
+	TEXT CHARACTER=207 TEXT='Character 1 in @Haszprunar1996';
+	TEXT CHARACTER=208 TEXT='Character 2 in @Haszprunar2008';
+	TEXT CHARACTER=209 TEXT='After @Borisanova2015';
+	TEXT CHARACTER=210 TEXT='After @Borisanova2015';
+	TEXT CHARACTER=211 TEXT='Character 1 in @Haszprunar2000.';
+	TEXT CHARACTER=212 TEXT='After @Borisanova2015';
+	TEXT CHARACTER=213 TEXT='Character 19 in @Haszprunar1996; see also character 13 in @Haszprunar2000';
+	TEXT CHARACTER=214 TEXT='See character 18 in @Haszprunar1996';
+	TEXT CHARACTER=215 TEXT='Characters 1.13, 1.40 & 2.08 in @Scheltema1993; 114 in @Giribet2002; 1.53 in @SPS1996; 9 in @Haszprunar1996';
+	TEXT CHARACTER=217 TEXT='Character 14 in @Haszprunar1996. Paired longitudinal nerve cords regularly interconnected by transversal commissures to form a rectangular pattern.';
+	TEXT CHARACTER=218 TEXT='Character 16 in @Haszprunar1996.  The Gliointerstitial system interconnects the nervous and muscle systems.';
+	TEXT CHARACTER=219 TEXT='Character 7b in @Haszprunar2008';
+	TEXT CHARACTER=220 TEXT='Character 7c in @Haszprunar2008.  A pre-oral nerve loop is present in molluscs, Loxosomella and certain annelids [@Wanninger2007].';
+	TEXT CHARACTER=221 TEXT='Character 1.22 in @SPS1996';
+	TEXT CHARACTER=222 TEXT='After character 13 in @Haszprunar1996.';
+	TEXT CHARACTER=223 TEXT='After character 13 in @Haszprunar1996.';
+	TEXT CHARACTER=224 TEXT='  See character 7 in @Haszprunar2008.';
+	TEXT CHARACTER=225 TEXT='Character 80 in @Glenner2004; see also character 6 in @Vinther2008.';
+
+	[Attribute comments]
+	TEXT TAXON=1 CHARACTER=65 TEXT='The mineralized endoskeleton of Namacalathus is not interpreted as a sclerite.';
+	TEXT TAXON=19 CHARACTER=65 TEXT='Hooks are present, though the absence of chitin or microvillar impressions indicates that they are not homologous with those of other lophotrochozoans.^n';
+	TEXT TAXON=23 CHARACTER=65 TEXT='The scales of Wiwaxia are treated as homologous with the chaetae of annelids and brachiopods [@Butterfield1990;@Smith2014;@Zhang2015], rather than brachiopod shell.';
+	TEXT TAXON=24 CHARACTER=65 TEXT='Halkieriid sclerites are interpreted as potentially homologous with those of Dailyatia and hence the brachiopods [@Zhao2017].';
+	TEXT TAXON=21 CHARACTER=65 TEXT='Molluscan valves are treated as potential homologues of brachiopod valves.';
+	TEXT TAXON=22 CHARACTER=65 TEXT='Molluscan valves are treated as potential homologues of brachiopod valves.';
+	TEXT TAXON=20 CHARACTER=65 TEXT='Annelid setae are not considered to represent potential homologues with the brachiopod shell.';
+	TEXT TAXON=41 CHARACTER=128 TEXT='The absence of relief in Lingulosacculus rules out a phosphatic or calcitic composition, but co-occurring (and presumably aragonitic) hyolithids are preserved in the same fashion.  Its constitution was thus either organic or aragonitic (Balthasar & Butterfield 2009E).';
+	TEXT TAXON=46 CHARACTER=128 TEXT='Identified as calcareous by preservational criteria, and description "primary^ncalcitic shells of M. nuda" (Balthasar 2008).';
+	TEXT TAXON=50 CHARACTER=128 TEXT='Original mineralogy unknown, but known to be mineralised and anticipated to be phosphatic (Holmer et al. 2009)';
+	TEXT TAXON=26 CHARACTER=128 TEXT='Holmer & Caron (2006) note the absence of brittle breakage, interpreted as indicating the absence of a material mineralized component to the shells.  The preservation is strikingly different from that of other Burgess Shale brachiopods, ruling out a primarily calcitic or phosphatic composition.  The two-dimensional nature of the preservation also differs from that of co-occurring aragonitic taxa (hyoliths; Holmer & Caron 2006 p. 273), indicating that any mineralization was minor at best.^n^nHolmer & Caron (2006, p. 286) suggest that it is more likely that a (minor) mineral component was present than that it was not, though without providing an uncontestable rationale.  To be as conservative as possible, we therefore code this taxon as ambiguous.^n';
+	TEXT TAXON=39 CHARACTER=128 TEXT='"Shell originally organophosphatic, but may generally have been poorly mineralized" -- Williams et al. 2007 -- cf. ibid, p. 2889, "These strong similarities to discinoids in soft-part anatomy imply that the Heliomedusa shell was chitinous or chitinophosphatic, not calcareous."';
+	TEXT TAXON=43 CHARACTER=128 TEXT='"The original composition of the shell cannot be determined with certainty", though it was "most probably entirely soft and organic" -- Zhang et al. 2011T';
+	TEXT TAXON=42 CHARACTER=128 TEXT='Coded as phosphatic by Zhang et al. (2014), but with no explanation.^nCracks within shells of Chengjiang specimens (e.g. Zhang et al. 2007N, fig. 3) demonstrate that the shells were originally mineralized, but not the identity of the original biomineral. This said, phosphatized material from Kazakhstan (Holmer et al. 1997) is attributed to the same species; presuming this phosphate to be original and the material to be conspecific, L. malongensis is coded as having phosphatic shells.';
+	TEXT TAXON=14 CHARACTER=128 TEXT='Ventral valve uncalcified in extant forms or sometimes thin (Williams et al., 2000), but coded as calcitic as calcite-mineralizing pathways are present.';
+	TEXT TAXON=37 CHARACTER=128 TEXT='Confirmed in Trimerella by Balthasar et al. 2011';
+	TEXT TAXON=32 CHARACTER=128 TEXT='Phosphatic - hence the conventional placement within Linguliformea.';
+	TEXT TAXON=34 CHARACTER=128 TEXT='Shell calcitic';
+	TEXT TAXON=53 CHARACTER=128 TEXT='Trimerellids were probably aragonitic [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=45 CHARACTER=128 TEXT='Calcite and silica deemed diagenetic by Balthasar (2004).';
+	TEXT TAXON=36 CHARACTER=128 TEXT='"the original shell of Eoobolus contained small calcareous grains that were incorporated into organic-rich layers alongside apatite" (Balthasar 2007)';
+	TEXT TAXON=10 CHARACTER=128 TEXT='The extensive relief and association with pyrite framboids indicates original mineralization, but the identity of the biomineral remains uncertain [@Zhang2013].';
+	TEXT TAXON=2 CHARACTER=128 TEXT='Reconstructed as aragonitic from microstructural fabrics [@Vendrasco2017]';
+	TEXT TAXON=5 CHARACTER=10 TEXT='Not observed [@Moysiuk2017Hyolithsare], despite suitable preservation';
+	TEXT TAXON=26 CHARACTER=10 TEXT='Note that the setae do not obviously emerge from tubes, leading Holmer and Caron to question their homology with the setae of other taxa (Heliomedusa, Mickwitzia).^n^nBoth valves of Acanthotretella were covered by long spine-like and shell penetrating setae. The setae of A. decaius are usually preserved along anterior and anterolateral margins (Hu et al. 2010).';
+	TEXT TAXON=42 CHARACTER=10 TEXT='"Setae appear short, delicate, and are closely fringed with the entire^nmantle margin, hardly extending beyond the edge of shell" -- @Zhang2005';
+	TEXT TAXON=14 CHARACTER=10 TEXT='"Adult craniids are without setae (a feature shared with the thecideides, the^nshells of which are also cemented)." -- Williams et al. 2007';
+	TEXT TAXON=32 CHARACTER=10 TEXT='Setal bundles interpreted as present in acrotretids by Ushatinskaya (2016P).';
+	TEXT TAXON=51 CHARACTER=10 TEXT='Phosphatised setae emerge from hollow spines (Popov et al. 2009)';
+	TEXT TAXON=12 CHARACTER=10 TEXT='A gizzard is not present in all bryozoans, and has not been reported in Flustra.';
+	TEXT TAXON=19 CHARACTER=10 TEXT='The absence of chitin or microvillar lineations in sipunculan hooks argues against their interpretation as setae, but they are coded as conceivable homologues, with these characteristics treated separately.';
+	TEXT TAXON=23 CHARACTER=10 TEXT='Sclerites likely correspond with lophotrochozoan setae [@Butterfield1990;@Smith2014;@Zhang2015]';
+	TEXT TAXON=21 CHARACTER=10 TEXT='The girdle elements of certain polyplacophorans are chitinous and secreted by microvilli [@Fischer1980;@Leise1982;@Leise1988]; it is therefore likely that they are homologous with the setae of other lophotrochozoans.';
+	TEXT TAXON=13 CHARACTER=10 TEXT='The teeth of the Bryozoan gizzard have been homologized with annelid setae [@Gordon1975].';
+	TEXT TAXON=40 CHARACTER=61 TEXT='Although "the possibility of a blind ending may not be completely eliminated [...] the weight of evidence [...] leads us to reject the possibility of a blind-ending intestine" -- Zhang et al. 2007R, p. 1399';
+	TEXT TAXON=38 CHARACTER=61 TEXT='Scored according to familial level feature.';
+	TEXT TAXON=4 CHARACTER=61 TEXT='[@Devaere2014]';
+	TEXT TAXON=40 CHARACTER=62 TEXT='"Five specimens have an exceptionally preserved digestive tract, dorsally curved, with a putative dorso-terminal anus located near the proximal end of a pedicle" -- Zhang et al. 2007R';
+	TEXT TAXON=17 CHARACTER=62 TEXT='"In rhynchonelliforms, the gut curves somewhat into a C-shape and the (blind) anus becomes posteroventral in position." -- Williams et al. 2007, p. ^n2884';
+	TEXT TAXON=22 CHARACTER=62 TEXT='The U-shaped gut of scaphopods arises by exaggeration of the dorsal surface, rather than migration of the anus [@Steiner1992]';
+	TEXT TAXON=4 CHARACTER=62 TEXT='[@Devaere2014]';
+	TEXT TAXON=46 CHARACTER=106 TEXT='Aside from hinge, valves similar in convexity and size (Balthasar 2008)';
+	TEXT TAXON=40 CHARACTER=106 TEXT='Ventral valve larger (see Williams et al. 2000, fig. 125.)';
+	TEXT TAXON=39 CHARACTER=106 TEXT='Ventral valve larger than the dorsal valve (Zhang et al. 2009, p. 659)';
+	TEXT TAXON=43 CHARACTER=106 TEXT='The ventral valve is somewhat, but not markedly, larger than the dorsal; as such, this character is coded ambiguous for equivalve/ventral valve larger';
+	TEXT TAXON=47 CHARACTER=106 TEXT='Ventral valve larger (see Williams et al. 2000, fig. 126.)';
+	TEXT TAXON=30 CHARACTER=106 TEXT='Broadly equivalve - see Williams et al. (2000) fig. 508.2c ';
+	TEXT TAXON=37 CHARACTER=106 TEXT='Equivalve as juveniles, becoming "convexiplane" (Williams et al. 2000, p. 187) as adults [@Hanken1985Thetaxonomy]';
+	TEXT TAXON=54 CHARACTER=106 TEXT='The ventral valve is somewhat, but not markedly, larger than the dorsal; as such, this character is coded ambiguous for equivalve/ventral valve larger';
+	TEXT TAXON=34 CHARACTER=106 TEXT='"Shell subequally biconvex" -- Williams et al. 2000';
+	TEXT TAXON=53 CHARACTER=106 TEXT='Subequally biconvex (Williams et al. 2000, p. 192)';
+	TEXT TAXON=36 CHARACTER=106 TEXT='"Eoobolus is biconvex", but in his amended diagnosis, Balthasar (2009T) described it as "shell inequivalved, dorsibiconvex".';
+	TEXT TAXON=51 CHARACTER=106 TEXT='Ventribiconvex (Popov et al. 2009)';
+	TEXT TAXON=31 CHARACTER=106 TEXT='After table 8 in Williams et al. (2000)';
+	TEXT TAXON=21 CHARACTER=106 TEXT='Coded as ambiguous for equivalve/ventral valve larger: the posterior embryonic shell field, treated herein as equivalent to the ventral valve, ';
+	TEXT TAXON=35 CHARACTER=16 TEXT='Skovsted et al (2011) assumed the setae may have been  present along the margin of the adapical opening, but there is no fossil evidence.';
+	TEXT TAXON=39 CHARACTER=16 TEXT='Throughout the shell -- see Williams et al. 2007 -- causing the pustulose appearance remarked upon by Chen et al. 2007';
+	TEXT TAXON=42 CHARACTER=16 TEXT='At margin of shell [@Zhang2005]';
+	TEXT TAXON=21 CHARACTER=16 TEXT='Uniformly distributed around girdle (though not within shell) with no serial repetition [@Vinther2005;@Leise1988].';
+	TEXT TAXON=44 CHARACTER=26 TEXT='The prominent foramen between artificially articulated valves is taken to imply the presence of a pedicle [@Holmer2008TheEarly]';
+	TEXT TAXON=49 CHARACTER=26 TEXT='"Paterimitra is interpreted to have attached to hard substrates via a pedicle that emerged through the small posterior opening" -- Skovsted et al. 2009';
+	TEXT TAXON=1 CHARACTER=26 TEXT='There is no obvious way to homologise the attachment structure with the ventral pedicle of brachiopods.';
+	TEXT TAXON=41 CHARACTER=26 TEXT='The absence of a pedicle is inferred from the absence of an internal pedicle tube, and the absence of a pedicle at the hinge.';
+	TEXT TAXON=18 CHARACTER=26 TEXT='The tube-bearing stalk of phoronids arises as an eversion of the metastomal sac, a markedly different origin from the brachiopod pedicle, which arises from a terminal attachment disc [@Young2002]; the structures are of dubious homology.';
+	TEXT TAXON=26 CHARACTER=26 TEXT='The attachment structure of Acanthotretella originates at the margin of the dorsal and ventral valves; although it emerges from the umbo of the ventral valve, the presence of an internal pedicle tube betrays its identity as a pedicle, rather than a pedicle sheath.^n^nThe pedicle of Acanthotretella emerges from a short extension of the umbo of the ventral valve.  This extension is contiguous with the valve and presumably grew by accretion; its position and continuity with the valve suggest its interpretation as a pedicle sheath that is superseded as an attachment structure.  On the other hand, its continuity with the internal pedicle tube suggests that is may represent an independent organ.';
+	TEXT TAXON=39 CHARACTER=26 TEXT='"It seems unlikely that H. orienta possessed a pedicle that attached it to^nthe soft seafloor, like most other Chengjiang brachiopods." ...^n"The putative pedicle illustrated by Chen et al. (2007: Figs 4, 6, 7) in fact is the mold of a three-dimensionally preserved visceral cavity" -- Zhang et al. 2009';
+	TEXT TAXON=29 CHARACTER=26 TEXT='The presence of a pedicle is indicated by the propensity of Micromitra to attach to hard substrates, such as sponge spicules [@Holmer2006Aspinose].';
+	TEXT TAXON=47 CHARACTER=26 TEXT='Has a pedicle, rather than a pedicle sheath as in Kutorgina (Holmer et al. 2018E; Holmer et al. 2018T)';
+	TEXT TAXON=32 CHARACTER=26 TEXT='A pedicle was presumably present, but only the foramen is preserved.';
+	TEXT TAXON=34 CHARACTER=26 TEXT='Attached apically by cementation';
+	TEXT TAXON=45 CHARACTER=26 TEXT='An attachment structure is inferred based on the presence of an opening (Balthasar 2004); this is assumed to have been homologous with the brachiopod pedicle.';
+	TEXT TAXON=51 CHARACTER=26 TEXT='Presumed present, based on ventral foramen with colleplax.';
+	TEXT TAXON=31 CHARACTER=26 TEXT='Pedicle foramen was not necessarily occupied by a pedicle (though it presumably was).';
+	TEXT TAXON=10 CHARACTER=26 TEXT='The stalk is conceivably homologous with the brachiopod pedicle, but this possibility is impossible to test.';
+	TEXT TAXON=11 CHARACTER=26 TEXT='The stalk corresponds to the molluscan foot, rather than a pedicle.';
+	TEXT TAXON=12 CHARACTER=26 TEXT='Grows directly onto the substrate.';
+	TEXT TAXON=19 CHARACTER=26 TEXT='Absent; there is no clear basis to homologise the larval attachment structure of certain sipunculans with a pedicle';
+	TEXT TAXON=8 CHARACTER=26 TEXT='Uncertain: specimens in @Valent2015 do not unambiguously show apical termination';
+	TEXT TAXON=3 CHARACTER=26 TEXT='The apex of Bactrotheca deleta is pointed (Novak, 1891).';
+	TEXT TAXON=2 CHARACTER=26 TEXT='Not possible to reconcile with decollation.';
+	TEXT TAXON=47 CHARACTER=32 TEXT='A coleomic canal is inferred based on the ease with which the pedicle is deformed (Holmer et al. 2018E), but its presence is not known for certain so is coded ambiguous.';
+	TEXT TAXON=40 CHARACTER=33 TEXT='"Pronounced concentric annular discs disposed at intervals of 0.6--1.0 mm" -- @Zhang2007Rhynchonelliformeanbrachiopods';
+	TEXT TAXON=26 CHARACTER=33 TEXT='"The pedicle surface is ornamented with pronounced annulated rings, disposed at intervals of about 0.2 mm"';
+	TEXT TAXON=43 CHARACTER=33 TEXT='"The preserved pedicle has condensed annulations" -- Zhang et al. 2011T';
+	TEXT TAXON=42 CHARACTER=33 TEXT='Regularly annotated (see fig. 14.9 in Hou et al. 2017)';
+	TEXT TAXON=47 CHARACTER=33 TEXT='The "strong annulations" vary significantly in transverse thickness (Holmer et al. 2018E), so it is not clear whether these represent true annulations or wrinkles.';
+	TEXT TAXON=30 CHARACTER=33 TEXT='"The emerging pedicle has a consistent shape in all the available specimens and is strongly annulated and distally tapering" -- Holmer et al. 2018E';
+	TEXT TAXON=27 CHARACTER=33 TEXT='"It appears that the pedicle lacks a coelomic space and is distinctly annulated, with densely stacked tabular bodies" -- Zhang et al. 2011A';
+	TEXT TAXON=54 CHARACTER=33 TEXT='Annulations present in median collar';
+	TEXT TAXON=26 CHARACTER=29 TEXT='Holmer and Caron (2006) interpret the presence of a bulb as tentative; we score it as ambiguous.';
+	TEXT TAXON=40 CHARACTER=63 TEXT='"Presumed to terminate in a functional anus located near the proximal end of the pedicle." -- Zhang et al. 2007R';
+	TEXT TAXON=41 CHARACTER=54 TEXT='The prominent anterior extension of the visceral area noted by Balthasar & Butterfield (2009E) is considered as potentially homologous with that of Heliomedusa (Zhang et al. 2009) and, by extension, Haplophrentis (Moysiuk et al. 2017)';
+	TEXT TAXON=39 CHARACTER=54 TEXT='Corresponding to the "neck" of the vase-shaped visceral cavity reported by Zhang et al. 2009';
+	TEXT TAXON=42 CHARACTER=54 TEXT='An anterior projection of the visceral area is noted by Williams et al. (2000) and considered equivalent to that observed in Lingulosacculus (Balthasar & Butterfield 2009E).';
+	TEXT TAXON=54 CHARACTER=54 TEXT='Possibly present, following interpretation of mouth (see fig. 2c, d in Zhang et al. 2014)';
+	TEXT TAXON=36 CHARACTER=54 TEXT='Prominent extension of dorsal visceral platform (Balthasar 2009T)';
+	TEXT TAXON=19 CHARACTER=54 TEXT='Eversible pharynx (introvert)';
+	TEXT TAXON=5 CHARACTER=64 TEXT='Opening to the right -- see figures 1, 3, and extended data 5 in Moysiuk et al. (2017).  The text states in error that the anus is to the left of the midline.';
+	TEXT TAXON=41 CHARACTER=64 TEXT='"This same arrangement occurs in L. nuda, with the looped dark line tracking the same course as the exceptionally preserved guts of Chengjiang lingulellotretids, including the median position of its posterior loop and the sharp right turn as it exits the posterior extension of the ventral valve" (Balthasar & Butterfield 2009E, p.310).';
+	TEXT TAXON=40 CHARACTER=64 TEXT='"Five specimens have an exceptionally preserved digestive tract, dorsally curved, with a putative dorso-terminal anus located near the proximal end of a pedicle" -- Zhang et al. 2007R';
+	TEXT TAXON=16 CHARACTER=64 TEXT='"In the lingulids, the [intestine] follows an oblique course anteriorly to open at the anus on the right body wall." -- Williams et al. 1997, p. 89';
+	TEXT TAXON=43 CHARACTER=64 TEXT='"The intestine extends posteriorly, and then turns right to continue as a tortuous strand, finally terminating at the latero-median position of the anterior body wall" -- Zhang et al. 2007A^n';
+	TEXT TAXON=42 CHARACTER=64 TEXT='"finally terminating in an anal opening on the right anterior body wall" (Zhang et al. 2007N, p.66).';
+	TEXT TAXON=17 CHARACTER=64 TEXT='"In rhynchonelliforms, the gut curves somewhat into a C-shape and the (blind) anus becomes posteroventral in position." -- Williams et al. 2007, p. ^n2884';
+	TEXT TAXON=54 CHARACTER=64 TEXT='The identification of the "very poorly impressed possible anus at the lateral side of the anterior body wall" is not yet confident, so this character is coded as not presently available.';
+	TEXT TAXON=12 CHARACTER=64 TEXT='Anus remains on ventral surface.  Arguably, rather than the anus migrating, the dorsal surface of the animal has become extended.';
+	TEXT TAXON=22 CHARACTER=64 TEXT='An alternative interpretation would be that the posterior of the scaphopod has been extended to generate the relatively anterior position of the originally ventral anus.';
+	TEXT TAXON=4 CHARACTER=64 TEXT='Opening to left in @Devaere2014, fig. 5A.';
+	TEXT TAXON=13 CHARACTER=64 TEXT='Anus remains on ventral surface.  Arguably, rather than the anus migrating, the dorsal surface of the animal has become extended.';
+	TEXT TAXON=1 CHARACTER=51 TEXT='The existence of a lophophore is speculative.';
+	TEXT TAXON=41 CHARACTER=51 TEXT='Two diverging arms of the lophophore are preserved (Balthasar & Butterfield 2009E)';
+	TEXT TAXON=18 CHARACTER=51 TEXT='Two lophophore arms rather than a single continuous loop, but with tips close together to form functional loop [@Torrey1901]';
+	TEXT TAXON=43 CHARACTER=51 TEXT='Two distinct, diverging arms reconstructed by Zhang et al. 2007A';
+	TEXT TAXON=47 CHARACTER=51 TEXT='No specimens of Nisusia preserve the lophophore.';
+	TEXT TAXON=10 CHARACTER=51 TEXT='Tentacles form almost complete circular crown';
+	TEXT TAXON=11 CHARACTER=51 TEXT='@Nielsen1966';
+	TEXT TAXON=19 CHARACTER=51 TEXT='Growing to encircle mouth in adults';
+	TEXT TAXON=20 CHARACTER=51 TEXT='Growing to encircle mouth in adults';
+	TEXT TAXON=13 CHARACTER=51 TEXT='Ends of arms meet to form closed loop [@Temereva2016Thenervous]';
+	TEXT TAXON=44 CHARACTER=132 TEXT='Identical to Mickwitzia and more derived linguliforms (Holmer et al 2011)';
+	TEXT TAXON=1 CHARACTER=132 TEXT='Namacalathus exhibits three layers, none of which have any obvious correspondence with those of brachiopods.';
+	TEXT TAXON=46 CHARACTER=132 TEXT='Balthasar (2008) considers the single mineralogical layer, which comprises phosphatic rods and laminae, to characterize Obolellata.';
+	TEXT TAXON=32 CHARACTER=132 TEXT='General acrotretid structure taken from Zhang et al. (2016)';
+	TEXT TAXON=45 CHARACTER=132 TEXT='"the shell structure of Mickwitzia [...] is closely similar to the columnar shell of linguliform acrotretoid brachiopods as well as to the linguloid Lingulellotreta, in that it has slender columns in the laminar succession" -- Williams et al. 2007';
+	TEXT TAXON=36 CHARACTER=132 TEXT='"Eoobolus shells exhibit the general characteristics of modern linguliform shells, i.e. they were composed of alternating sets of organic and apatite-rich layers that were separated by thin sheets of recalcitrant organic layers." -- Balthasar 2007';
+	TEXT TAXON=51 CHARACTER=132 TEXT='"Orthodoxly secreted primary and secondary layers" -- Williams et al. 2004';
+	TEXT TAXON=31 CHARACTER=132 TEXT='"Composed of a thin primary layer and a laminate secondary shell exhibiting  baculate shell structure" -- Skovsted & Holmer (2005), with reference to Skovsted & Holmer 2003.';
+	TEXT TAXON=24 CHARACTER=132 TEXT='Single layer of fibrous aragonite [@Porter2008]';
+	TEXT TAXON=21 CHARACTER=132 TEXT='From periostracum inwards, Chiton bears three microstructural layers: fine-grained, nacreous, and regular crossed lamellar.';
+	TEXT TAXON=6 CHARACTER=132 TEXT='Coded following helen microstructure described in the similar material of ''Hyolithes'' [@MartiMus2007]';
+	TEXT TAXON=3 CHARACTER=132 TEXT='Taxon known only from moulds [@Valent2012]';
+	TEXT TAXON=7 CHARACTER=132 TEXT='"The shells of both skeletal components show very similar structures and are composed of two layers" -- @Zhang2018Ahyolithid';
+	TEXT TAXON=2 CHARACTER=132 TEXT='Inner and outer layers [@Vendrasco2017]';
+	TEXT TAXON=9 CHARACTER=107 TEXT='Lateral lines suggest differentiation of posterior surface, but difficult to discern a change in morphology of this region. Coded ambiguous.';
+	TEXT TAXON=49 CHARACTER=107 TEXT='Triangular notch and subapical flange';
+	TEXT TAXON=41 CHARACTER=107 TEXT='The conical valve is interpreted as the ventral valve with an extended pseudointerarea.';
+	TEXT TAXON=52 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=46 CHARACTER=107 TEXT='Balthasar (2008) interprets a pseudointerarea as being present - e.g. p273, "Of particular interest is the vault that bridges the most anterior portion of the ventral pseudointerarea and raises it above the visceral platform.";  "This pattern is reversed in the ventral valves of M. nuda, where the anterior projection of the pedicle groove is raised above the valve floor whereas the lateral parts of pseudointerarea are not".  ';
+	TEXT TAXON=33 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=40 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=50 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=39 CHARACTER=107 TEXT='Zhang et al. (2009) report a moderate to somewhat developed ventral pseudointerarea, confirmed by Williams et al (2007).';
+	TEXT TAXON=43 CHARACTER=107 TEXT='Though "all evidence of a pseudointerarea is lacking" -- Zhang et al. 2011T -- the region of the shell between the strophic hinge line and the colleplax (fig. 2 in Zhang et al. 2011T) is distinct from the rest of the shell; the ends of the strophic hinge line are marked by prominent nicks in the shell margin.  Longtancunella is therefore coded as having a differentiated posterior surface.';
+	TEXT TAXON=47 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=17 CHARACTER=107 TEXT='Interarea.';
+	TEXT TAXON=30 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=27 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=48 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=37 CHARACTER=107 TEXT='The region corresponding to the ventral (pseudo)interarea is described as a "trimerellid ventral cardinal area" by Williams et al. (2000, p.162), who code both an interarea and a pseudointerarea as absent in trimerellids.';
+	TEXT TAXON=38 CHARACTER=107 TEXT='Interarea present.';
+	TEXT TAXON=32 CHARACTER=107 TEXT='Described by Topper et al. (2013R).';
+	TEXT TAXON=53 CHARACTER=107 TEXT='Following char 17 in table 15 of Williams et al. 2000';
+	TEXT TAXON=45 CHARACTER=107 TEXT='Termed an interarea by Balthasar (2004)';
+	TEXT TAXON=51 CHARACTER=107 TEXT='"Ventral pseudointerarea, low, undivided, poorly defined" -- Williams et al. 2000';
+	TEXT TAXON=21 CHARACTER=107 TEXT='Following the proposed homology model between the posterior valve of polyplacophorans and the ventral valve of brachiopods, the "posterior" surface of the polyplacophoran valve is taken to be the surface that would articulate with the anterior valve, which is anatomically anterior on the living organism.';
+	TEXT TAXON=4 CHARACTER=107 TEXT='Round in cross-section, with no clear delineation of posterior (functionally dorsal) surface [@Devaere2014]';
+	TEXT TAXON=3 CHARACTER=107 TEXT='No clear delineation of posterior (functionally dorsal) surface';
+	TEXT TAXON=2 CHARACTER=107 TEXT='No evidence of differentiation; circular cross-section [@Vendrasco2017]';
+	TEXT TAXON=44 CHARACTER=112 TEXT='Opening inferred by Holmer et al. (2008)';
+	TEXT TAXON=26 CHARACTER=112 TEXT='Origin modelled on Siphonobolus.';
+	TEXT TAXON=43 CHARACTER=112 TEXT='Unclear: a narrow ridge that may correspond to a pseudodeltidium evident in fig 2a and sketched in fig. 2c is not discussed in the text of Zhang et al. 2011T, so the delthyrial region is coded as ambiguous.';
+	TEXT TAXON=28 CHARACTER=112 TEXT='Homeodeltidium absent (Williams et al. 2000, p. 153); deltidium is open (see Topper et al. 2013T, fig. 4)';
+	TEXT TAXON=15 CHARACTER=112 TEXT='The listrum (pedicle opening) is interpreted as originating via a similar mechanism to that of acrotretids (Popov 1992), and hence corresponding to a basally sealed delthyrium.';
+	TEXT TAXON=38 CHARACTER=112 TEXT='"Delthyrium and notothyrium open, wide" -- Cooper 1976';
+	TEXT TAXON=32 CHARACTER=112 TEXT='Following Popov (1992), the larval delthyrium is sealed in adults by outgrowths of the posterolateral margins of the shell.';
+	TEXT TAXON=54 CHARACTER=112 TEXT='Details of the hinge region are unclear due to the flattened and overprinted nature of fossil preservation.';
+	TEXT TAXON=45 CHARACTER=112 TEXT='A delthyrium is present in young individuals (Balthasar 2004).';
+	TEXT TAXON=36 CHARACTER=112 TEXT='See for example fig. 5 in Balthasar 2009T.';
+	TEXT TAXON=51 CHARACTER=112 TEXT='Ontogeny presumed to resemble that of acrotretids.';
+	TEXT TAXON=31 CHARACTER=112 TEXT='The homology of the triangular notch or groove in the pseudointerarea with the umbonal pedicle foramen of acrotretids was proposed by Popov (1992), and seemingly corroborated by observations of Ushatinskaya & Korovnikov (2016R), who note that the propareas of the Botsfordia ventral valve sometimes merge to form an elongate teardrop-shaped pedicle foramen.';
+	TEXT TAXON=21 CHARACTER=112 TEXT='The antemucronal area [@Schwabe2010] is treated as equivalent to the brachiopod delthyrium';
+	TEXT TAXON=5 CHARACTER=138 TEXT='The tubules within the centre of the bundles of hyolith shells (Kouchinsky 2000) are c. 10 um wide, making them an order of magnitude larger than the canals that characterize lingulid valves, and a similar scale to punctae.  This said, they have only been reported in a putative allathecid, so the presence of equivalent structures in hyolithids has never been demonstrated.';
+	TEXT TAXON=46 CHARACTER=138 TEXT='"Vertical shell penetrating structures, such as punctae, pseudopunctae, extropunctae and canals, are common in many groups of brachiopods and are distinguished based on their geometry and size (Williams 1997). Punctae are 10-20 um wide and represent multicellular extensions of the outer epithelium (Owen and Williams 1969). [...] None of these three types of vertical shell structure, all of which are confined to calcitic-shelled brachiopods, compares with the much smaller canals (< 1 um in diameter) of M. nuda. The only type of vertical structure that fits the size and nature of the canals of the Mural obolellids are the canals of linguliform brachiopods, which range in width from 180 to 740 nm and are occupied by proteinaceous strands in extant taxa (Williams et al. 1992, 1994; Williams 1997)." -- Balthasar 2008';
+	TEXT TAXON=39 CHARACTER=138 TEXT='''Identical'' to those in Mickwitzia -- see Williams et al. 2007';
+	TEXT TAXON=17 CHARACTER=138 TEXT='Endopunctae are relatively large canals, diameter vary greatly from 5-20 um.';
+	TEXT TAXON=34 CHARACTER=138 TEXT='"impunctate"';
+	TEXT TAXON=45 CHARACTER=138 TEXT='Coded as present to reflect that the chambers contained setae; following Carlson in Williams et al. 2007, the punctae may or may not be homologous as punctae, but are likely homologous as shell perforations; both these perforations and those of Micrina were associated with setae, even if their equivalence bay be with juvenile vs adult setal structures in modern brachiopods (Balthasar 2004, p. 397).';
+	TEXT TAXON=51 CHARACTER=138 TEXT='The ''canals'' through the shell have a diameter of c. 20 um (Williams et al. 2004, text-fig. 2a), falling within the definition of punctae used herein.';
+	TEXT TAXON=6 CHARACTER=138 TEXT='Coded following helen microstructure described in the similar material of ''Hyolithes'' [@MartiMus2007]';
+	TEXT TAXON=3 CHARACTER=138 TEXT='Taxon known only from moulds [@Valent2012]';
+	TEXT TAXON=7 CHARACTER=138 TEXT='Not evident despite excellent preservation; interpreted as absent [@Zhang2018Ahyolithid]';
+	TEXT TAXON=44 CHARACTER=137 TEXT='Acrotretid laminae bear characteristic columns (e.g. Zhang et al. 2016); a similar fabric has been reported, and assumed homologous, in Micrina (Butler et al. 2012).^n^nA similar columnar shell microstructure also occurs in the closely related Mickwitzia (Balthasar 2008).';
+	TEXT TAXON=1 CHARACTER=137 TEXT='Canal-like structures have been reported in Namacalathus (Zhuravlev et al. 2015), and interpreted as evidence for a Lophophorate affinity.  Though the structures are not necessarily directly equivalent, the hypothesis of homology is followed here.';
+	TEXT TAXON=43 CHARACTER=137 TEXT='Preservational resolution not sufficient to evaluate';
+	TEXT TAXON=32 CHARACTER=137 TEXT='Acrotretid laminae bear characteristic columns (e.g. Zhang et al. 2016).^n^nBalthasar (2008) considers these columns as homologous with tubules within the columnar shell microstructure Mummpikia, Mickwitzia and lingulellotretids';
+	TEXT TAXON=45 CHARACTER=137 TEXT='Coded as present to reflect similarity of columnar microstructure remarked on by, among others, Balthasar (2008); Williams et al. (2007); Skovsted & Holmer (2003)';
+	TEXT TAXON=51 CHARACTER=137 TEXT='The ''canals'' through the shell have a diameter of c. 20 um (Williams et al. 2004, text-fig. 2a), falling within the definition of punctae (rather than canals) used herein.';
+	TEXT TAXON=31 CHARACTER=137 TEXT='Not evident in section presented by Skovsted & Holmer (2003).';
+	TEXT TAXON=24 CHARACTER=137 TEXT='The chambers in halkieriid sclerites do not correspond in morphology or dimension to the brachiopod-like canals documented by this character.';
+	TEXT TAXON=21 CHARACTER=137 TEXT='Aesthete canals do not fall within the definition of this character.';
+	TEXT TAXON=6 CHARACTER=137 TEXT='Coded following helen microstructure described in the similar material of ''Hyolithes'' [@MartiMus2007]';
+	TEXT TAXON=3 CHARACTER=137 TEXT='Taxon known only from moulds [@Valent2012]';
+	TEXT TAXON=7 CHARACTER=137 TEXT='Columns, replicated in phosphate and present in both layers of the shell, have been interpreted as potential homologues to acrotretid columns [@Zhang2018Ahyolithid]';
+	TEXT TAXON=2 CHARACTER=137 TEXT='Orthogonal tubules [@Vendrasco2017]';
+	TEXT TAXON=49 CHARACTER=115 TEXT='Covered by subaical flange, in part.  ';
+	TEXT TAXON=33 CHARACTER=115 TEXT='A convex pseudodeltidium completely covers the delthyrium in Coolinia.^n';
+	TEXT TAXON=28 CHARACTER=115 TEXT='Open (Topper et al. 2013T)';
+	TEXT TAXON=29 CHARACTER=115 TEXT='Williams et al. 2000, fig. 83.3';
+	TEXT TAXON=47 CHARACTER=115 TEXT='"Covered only apically by a small convex pseudodeltitium" - Holmer et al. 2018E';
+	TEXT TAXON=38 CHARACTER=115 TEXT='Coded as open by Williams et al. (1998T)';
+	TEXT TAXON=31 CHARACTER=115 TEXT='See pl. 3 fig. 15 in Skovsted & Holmer (2005)';
+	TEXT TAXON=46 CHARACTER=108 TEXT='Balthasar (2008) interprets an inward-growing posterior margin of the pseudointerarea - e.g. p273, "Of particular interest is the vault that bridges the most anterior portion of the ventral pseudointerarea and raises it above the visceral platform [...] An inward-growing posterior margin is otherwise known only from the pseudointerareas of linguliform brachiopods".';
+	TEXT TAXON=42 CHARACTER=108 TEXT='Transverse cross section of ventral pseudointerarea concave.';
+	TEXT TAXON=32 CHARACTER=108 TEXT='See Topper et al. (2013R)';
+	TEXT TAXON=36 CHARACTER=108 TEXT='See for example Skovsted & Holmer (2005), pl. 3.';
+	TEXT TAXON=31 CHARACTER=108 TEXT='Inward-growing; see Skovsted & Holmer (2005), pl. 4';
+	TEXT TAXON=1 CHARACTER=1 TEXT='Inapplicable insofar as reproduction occurs by budding; there is no evidence for a free-living larval stage.  Nevertheless, the presence of a sexual reproductive phase in addition to asexual reproduction cannot be discounted.';
+	TEXT TAXON=14 CHARACTER=1 TEXT='Shell not secreted until after metamorphosis (Popov et al. 2010).   Freeman & Lundelius (1999) report a Craniops-like larval shell in fossil "Crania", but observe that Quaternary [Novo]crania no longer exhibit a larval shell.';
+	TEXT TAXON=37 CHARACTER=1 TEXT='The earliest shell is not described by @Hanken1985Thetaxonomy or @Watkins2002Newrecord.';
+	TEXT TAXON=32 CHARACTER=1 TEXT='Described by Topper et al. (2013R).';
+	TEXT TAXON=11 CHARACTER=1 TEXT='Absent, with no possible equivalent [@Nielsen1966]';
+	TEXT TAXON=21 CHARACTER=1 TEXT='On hatching, the polyplacophoran larva lacks a shell field.  ^n^nShell fields develop during the trochophore larva stage. The larva of the chiton Mopalia has two distinct shell fields: that anterior to the prototroch will develop into the first shell plate; the one posterior to the prototroch becomes the subsequent plates [@Wanninger2002C].^n^nThis disc-shaped posterior plate, whose position corresponds to the conchiferan shell field, bears a polygonal ornament and is subdivided by a series of grooves that prefigure the adult shell plates [@Wanninger2002C].';
+	TEXT TAXON=22 CHARACTER=1 TEXT='The shell does not form until the trochophore larval stage, which has been exquisitely described in Antalis [@Wanninger2001].^nThis shell field is initially disc-like, subsequently expanding to fuse ventrally and produce the cylindrical protoconch. The prototroch is clearly delineated fro the telotroch in post-metamorphic juveniles [@Wanninger2001].';
+	TEXT TAXON=4 CHARACTER=1 TEXT='[@Wrona2003]';
+	TEXT TAXON=8 CHARACTER=1 TEXT='Coded following Recilites [@Dzik1978], a fellow member of Pauxillitidae [@Marek1967]';
+	TEXT TAXON=13 CHARACTER=1 TEXT='@Reed1982';
+	TEXT TAXON=7 CHARACTER=1 TEXT='"The initial part of the conch appears to be a simple apex without clearly delineated protoconch" [@Zhang2018Ahyolithid], though it is not clear from illustrated figures whether an embryonic shell contiguous with the adult shell was present.';
+	TEXT TAXON=9 CHARACTER=3 TEXT='The flattened region at the umbo of the ventral valve in smaller specimens conceivably represents an embryonic shell, though it may alternatively represent a cicatrix or colleplax-like structure.';
+	TEXT TAXON=42 CHARACTER=3 TEXT='No prominent nick point [@Holmer1997EarlyCambrian;@Li2004]';
+	TEXT TAXON=32 CHARACTER=3 TEXT='Described by Topper et al. (2013R).';
+	TEXT TAXON=34 CHARACTER=3 TEXT='Prominent nick; see Freeman & Lundelius 1999, fig. 6A';
+	TEXT TAXON=36 CHARACTER=3 TEXT='Nick point indicated by arrows in fig. 1 of Balthasar (2009T).';
+	TEXT TAXON=21 CHARACTER=3 TEXT='@Wanninger2002C';
+	TEXT TAXON=4 CHARACTER=3 TEXT='Prominent nick [@Wrona2003, figs 5G-H, 6a1]';
+	TEXT TAXON=8 CHARACTER=3 TEXT='No prominent nick in Recilites (Pauxillitidae) [@Dzik1978]';
+	TEXT TAXON=3 CHARACTER=3 TEXT='There is a small ridge and a change in surface ornament at the end of the larval shell [@Dzik1980Ontogenyof]';
+	TEXT TAXON=7 CHARACTER=3 TEXT='Not clearly delineated [@Zhang2018Ahyolithid], so either inapplicable or undifferentiated';
+	TEXT TAXON=2 CHARACTER=3 TEXT='Prominent nick [@Skovsted2016]';
+	TEXT TAXON=33 CHARACTER=2 TEXT='See fig. 3 in Bassett et al. 2017';
+	TEXT TAXON=16 CHARACTER=2 TEXT='See fig. 159 in Williams et al. 1997';
+	TEXT TAXON=42 CHARACTER=2 TEXT='Disc-like [@Li2004]';
+	TEXT TAXON=28 CHARACTER=2 TEXT='Renoid -- see fig. 4B3 in Topper et al. 2013T';
+	TEXT TAXON=29 CHARACTER=2 TEXT='Subtriangular -- essentially round';
+	TEXT TAXON=15 CHARACTER=2 TEXT='See e.g. fig 169 in Williams et al. (1997)';
+	TEXT TAXON=32 CHARACTER=2 TEXT='The flat larval shell of Clupeafumosus resembles that of Micrina in outline (Topper et al. 2013R; cf. Holmer et al. 2011).';
+	TEXT TAXON=34 CHARACTER=2 TEXT='The embryonic shell is more or less circular in outline -- see Freeman & Lundelius, 1999, fig. 6A';
+	TEXT TAXON=45 CHARACTER=2 TEXT='Trifoliate appearance results from prominent attachment rudiment and bunching of setal sacs (Balthasar 2009T).';
+	TEXT TAXON=21 CHARACTER=2 TEXT='Disc-like, subdivided by transverse grooves [@Wanninger2002C]';
+	TEXT TAXON=4 CHARACTER=2 TEXT='[@Wrona2003]';
+	TEXT TAXON=8 CHARACTER=2 TEXT='Fusiform, following Recilites (Pauxillitidae) [@Dzik1978]';
+	TEXT TAXON=2 CHARACTER=2 TEXT='The impression of the larval shell on the operculum is flat and disc-like [@Skovsted2016]. The fusiform ''protoconch'' [@Sun2018] likely represents a larval (rather than brephic) shell.';
+	TEXT TAXON=42 CHARACTER=6 TEXT='Possible suggestion of setal sacs present on brephic shell [@Holmer1997EarlyCambrian;@Li2004], but outline inadequately preserved to code with confidence; treated as ambiguous.';
+	TEXT TAXON=32 CHARACTER=6 TEXT='Setal bundles interpreted as present in acrotretids by Ushatinskaya (2016P).';
+	TEXT TAXON=45 CHARACTER=6 TEXT='Four setal sacs';
+	TEXT TAXON=31 CHARACTER=6 TEXT='"One specimen shows fine capillae running laterally from the posterior tubercles on the dorsal valve (Pl. 3, fig. 5b). This is possibly the imprints of setae." -- Ushatinskaya & Korovnikov 2016R';
+	TEXT TAXON=4 CHARACTER=6 TEXT='[@Wrona2003]';
+	TEXT TAXON=8 CHARACTER=6 TEXT='Following Recilites (Pauxillitidae) [@Dzik1978]';
+	TEXT TAXON=2 CHARACTER=6 TEXT='Absent [@Skovsted2016]';
+	TEXT TAXON=42 CHARACTER=5 TEXT='The pedicle foramen intersects the brephic shell [@Holmer1997EarlyCambrian;@Li2004], suggesting larval attachment.';
+	TEXT TAXON=32 CHARACTER=5 TEXT='The larval shell embraces the pedicle foramen, suggesting a larval attachment. See fig. 4 of Topper et al. (2013R).';
+	TEXT TAXON=45 CHARACTER=5 TEXT='Note the posterior lobe related to the attachment rudiment in fig. 2 of Balthasar 2009T';
+	TEXT TAXON=36 CHARACTER=5 TEXT='Lobe related to the attachment rudiment (Balthasar 2009T, fig. 2)';
+	TEXT TAXON=51 CHARACTER=5 TEXT='Interpreted as having planktotrophic (and thus non-attached) larvae (Popov et al. 2009)';
+	TEXT TAXON=4 CHARACTER=5 TEXT='[@Wrona2003]';
+	TEXT TAXON=8 CHARACTER=5 TEXT='Distal extension of Recilites (Pauxillitidae) has plausible similarity to pedicle [@Dzik1978], but deemed unlikely.  Coded as ambiguous.';
+	TEXT TAXON=2 CHARACTER=5 TEXT='A pedicle is not inferred by @Skovsted2016, and is difficult to reconcile with the apical morphology documented by @Sun2018.';
+	TEXT TAXON=9 CHARACTER=122 TEXT='The flat apical termination of juvenile individuals possibly functioned as colleplax for attachment, but may simply represent the brephic shell; we treat it as ambiguous to reflect this potential homology.';
+	TEXT TAXON=44 CHARACTER=122 TEXT='Absent in Micrina (Holmer et al. 2011)';
+	TEXT TAXON=52 CHARACTER=122 TEXT='The internal canal associated with the pedicle is unique to the tomteluvids, and has an uncertain identity (Streng et al. 2016).  It could conceivably correspond to an internalized pedicle sheath or an equivalent structure, so this feature is coded as ambiguous here.';
+	TEXT TAXON=40 CHARACTER=122 TEXT='The umbonal region of kutorginides "clearly lacks a pedicle sheath" (Holmer et al. 2018T)';
+	TEXT TAXON=39 CHARACTER=122 TEXT='A cicatrix was reconstructed by Jin & Wang 1992 (figs 6b, 7), but has not been reported by later authors; possibly, as with the ''pedicle foramen'' of Chen et al. (2007), this structure represents internal organs rather than a cicatrix proper (Zhang et al. 2009); as such it has been recorded as ambiguous.';
+	TEXT TAXON=43 CHARACTER=122 TEXT='A ring-like structure surrounding the pedicle is interpreted as a colleplax (Zhang et al. 2011T), though the authors make no comparison with the pedicle capsule exhibited by extant terebratulids (see Holmer et al. 2018E).';
+	TEXT TAXON=42 CHARACTER=122 TEXT='The pedicle is identified as such (rather than a pedicle sheath) by the internal pedicle tube.';
+	TEXT TAXON=32 CHARACTER=122 TEXT='Not reported by Topper et al. (2013R).';
+	TEXT TAXON=54 CHARACTER=122 TEXT='The median collar or conical tube is conceivably homologous with the pedicle sheath.';
+	TEXT TAXON=34 CHARACTER=122 TEXT='Paracraniops is "externally similar to Craniops, but lacking cicatrix" -- indicating that Craniops bears a cicatrix (Williams et al. 2000).  Also coded as present in their table 15.';
+	TEXT TAXON=53 CHARACTER=122 TEXT='Following table 15 in Williams et al. 2000';
+	TEXT TAXON=51 CHARACTER=122 TEXT='Coded as present in view of the attachment scar, which has been considered homologous with the "adult colleplax and foramen with attachment pad" in Salanygolina (Popov et al. 2009)';
+	TEXT TAXON=31 CHARACTER=122 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=3 CHARACTER=122 TEXT='The apical termination of the conical valve is not preserved [@Valent2012]';
+	TEXT TAXON=16 CHARACTER=7 TEXT='Lingulids'' larval setae are not arranged in bundles (Carlson 1995)';
+	TEXT TAXON=42 CHARACTER=7 TEXT='Possible suggestion of setal sacs present on brephic shell [@Holmer1997EarlyCambrian;@Li2004], but outline inadequately preserved to code with confidence; treated as ambiguous.';
+	TEXT TAXON=15 CHARACTER=7 TEXT='Three pairs (Carlson 1995)';
+	TEXT TAXON=14 CHARACTER=7 TEXT='Three pairs (Carlson 1995)';
+	TEXT TAXON=32 CHARACTER=7 TEXT='Setal bundles interpreted as present in acrotretids by Ushatinskaya (2016P).';
+	TEXT TAXON=31 CHARACTER=7 TEXT='A single pair of low tubercles are (Ushatinskaya & Korovnikov 2016R state "may be") located in the middle region of the dorsal and the ventral brephic valve; these are interpreted as a single pair of setal sacs, with the identity of the (dorsally unpaired) tubercles uncertain.^n';
+	TEXT TAXON=4 CHARACTER=7 TEXT='[@Wrona2003]';
+	TEXT TAXON=8 CHARACTER=7 TEXT='Following Recilites (Pauxillitidae) [@Dzik1978]';
+	TEXT TAXON=3 CHARACTER=7 TEXT='Following Bactrotheca [@Dzik1980Ontogenyof]';
+	TEXT TAXON=52 CHARACTER=77 TEXT='Tomteluvids [...] lack articulation structures such as teeth and sockets (Streng et al. 2016)';
+	TEXT TAXON=46 CHARACTER=77 TEXT='No articulation structures are evident; instead, the propareas are rotated inwards (Balthasar 2008).  The definition of Family Obolellidae in Williams et al. (2000) notes that articulation may be lacking or vestigial in the group.';
+	TEXT TAXON=40 CHARACTER=77 TEXT='Kutorginata don''t have teeth or dental sockets, but their shells are articulated by "two triangular plates formed by dorsal interarea, bearing oblique ridges on the inner sides" (Williams et al 2000, p. 211); this simple hinge mechanism is different from other rhynchonelliforms (Williams et al. 2000, p.208), but serves an equivalent purpose and is thus potentially homologous.  We thus code kutorginids as present, using a subsequent character to capture difference in tooth morphology.';
+	TEXT TAXON=47 CHARACTER=77 TEXT='Kutorginata don''t have teeth or dental sockets, but their shells are articulated by "two triangular plates formed by dorsal interarea, bearing oblique ridges on the inner sides" (Williams et al 2000, p. 211); this simple hinge mechanism is different from other rhynchonelliforms (Williams et al. 2000, p.208), but serves an equivalent purpose and is thus potentially homologous.  We thus code kutorginids as present, using a subsequent character to capture difference in tooth morphology.';
+	TEXT TAXON=27 CHARACTER=77 TEXT='"Strophic articulation with paired, ventral denticles, composed of secondary shell" -- definition of family Trematobolidae in Williams et al. 2000^n';
+	TEXT TAXON=37 CHARACTER=77 TEXT='"Articulatory structure comprising ventral cardinal socket and dorsal hinge plate [...] The shape of the shell probably correlates strongly with the unique type of articulation, which consists of a dorsal hinge plate that fits tightly into a cardinal socket in the ventral valve, with a concave homeodeltidium in the center of the ventral interarea" -- Williams et al. 2000, p.184, concerning order Trimerellida^n';
+	TEXT TAXON=32 CHARACTER=77 TEXT='No articulating processes evident or reported by Topper et al. (2013R).';
+	TEXT TAXON=53 CHARACTER=77 TEXT='"articulatory structures poorly developed" -- Williams et al. 2000, p. 192';
+	TEXT TAXON=45 CHARACTER=77 TEXT='Not reported by or evident in Balthasar (2004)';
+	TEXT TAXON=21 CHARACTER=77 TEXT='The sutural laminae correspond in function and position to brachiopod apophyses [@Connors2012], and so are coded as potentially homologous.';
+	TEXT TAXON=32 CHARACTER=140 TEXT='The polygonal ornament reported in acrotretids by Zhang et al. (2016) is on the internal surface of the shell.';
+	TEXT TAXON=44 CHARACTER=133 TEXT='Micrina exhibits polygonal imprints on the internal surfaces of successive second-order laminae, suggesting the existence of a polygonal organization of these layers [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=49 CHARACTER=133 TEXT='Laminated [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=1 CHARACTER=133 TEXT='The inner and outer layer are foliated.  The columnar inflections lack canals, and as such we do not consider them to bear any obvious homology with the hollow pillars of tommotiids and certain brachiopods, their superficial similarity to strophomenid pseudopunctae notwithstanding.';
+	TEXT TAXON=35 CHARACTER=133 TEXT='Laminated [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=52 CHARACTER=133 TEXT='No original structural details evident [@Streng2016Anew]';
+	TEXT TAXON=46 CHARACTER=133 TEXT='Balthasar (2008) considers the single mineralogical layer, which comprises phosphatic rods and laminae, to characterize Obolellata.';
+	TEXT TAXON=33 CHARACTER=133 TEXT='@Dewing2004';
+	TEXT TAXON=40 CHARACTER=133 TEXT='Lamination absent [following @Williams1998Thediversity, appendix 2]';
+	TEXT TAXON=50 CHARACTER=133 TEXT='"Apatitic crystals of varying shapes and dimensions" -- @Holmer2009Theenigmatic';
+	TEXT TAXON=16 CHARACTER=133 TEXT='Lingulid laminae are thicker than those of tommotiids or paterinids, but construed as homologous [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=28 CHARACTER=133 TEXT='Lamination present [@Balthasar2009Homologousskeletal], with imprints of presumed mantle cells [following @Williams1998Thediversity, appendix 2]';
+	TEXT TAXON=29 CHARACTER=133 TEXT='Lamination present, with no imprints of presumed mantle cells [following @Williams1998Thediversity, appendix 2]';
+	TEXT TAXON=14 CHARACTER=133 TEXT='Laminar secondary layer [@Parkinson2005]';
+	TEXT TAXON=17 CHARACTER=133 TEXT='@Parkinson2005';
+	TEXT TAXON=30 CHARACTER=133 TEXT='Tabular laminae, not fibrous as previously thought [@Madison2017Laminarshell].';
+	TEXT TAXON=48 CHARACTER=133 TEXT='Orithidina have impunctate shells with a fibrous secondary layer (Williams et al. 2000, p. 724)';
+	TEXT TAXON=37 CHARACTER=133 TEXT='Laminated relict shell structure visible, indicating original constitution from "sheet-like laminae" [@Hanken1985Thetaxonomy]';
+	TEXT TAXON=38 CHARACTER=133 TEXT='Lamination absent [following @Williams1998Thediversity, appendix 2]';
+	TEXT TAXON=34 CHARACTER=133 TEXT='[@Williams1997Introduction, fig. 249.1]';
+	TEXT TAXON=45 CHARACTER=133 TEXT='Alternation of layers [@Balthasar2004Shellstructure]';
+	TEXT TAXON=36 CHARACTER=133 TEXT='Lamination present, with no imprints of presumed mantle cells [following @Williams1998Thediversity, appendix 2]';
+	TEXT TAXON=51 CHARACTER=133 TEXT='Cleaved stratified platy laminae, best preserved in canal walls (Williams et al. 2004)';
+	TEXT TAXON=31 CHARACTER=133 TEXT='"Composed of a thin primary layer and a laminate secondary shell exhibiting  baculate shell structure" -- Skovsted & Holmer (2005), with reference to Skovsted & Holmer 2003.^n^n@Williams1998Thediversity [appendix 2] code lamination as present, with no imprints of presumed mantle cells.';
+	TEXT TAXON=6 CHARACTER=133 TEXT='Coded following helen microstructure described in the similar material of ''Hyolithes'' [@MartiMus2007]';
+	TEXT TAXON=7 CHARACTER=133 TEXT='Fibrous [@Zhang2018Ahyolithid]';
+	TEXT TAXON=2 CHARACTER=133 TEXT='Fibrous bundles [@Vendrasco2017]';
+	TEXT TAXON=15 CHARACTER=8 TEXT='Three pairs (Carlson 1995)';
+	TEXT TAXON=14 CHARACTER=8 TEXT='Three pairs (Carlson 1995)';
+	TEXT TAXON=32 CHARACTER=8 TEXT='Two pairs identified in acrotretids by Ushatinskaya (2016P).';
+	TEXT TAXON=45 CHARACTER=8 TEXT='See fig. 2 in Balthasar 2009T';
+	TEXT TAXON=51 CHARACTER=8 TEXT='Two pairs of setal sacs (Popov et al. 2009)';
+	TEXT TAXON=31 CHARACTER=8 TEXT='"larval shell with one to three apical tubercles in ventral valve and two in dorsal valve" (Williams et al. 2000) -- if these correspond to setal sacs, then we interpret this as equivalent to one pair.^n^nIn B. minuta, the ventral valve bears a single medial tubercle (which in figured material seems to have two bilaterally symmetrical fields), whereas the dorsal valve bears two apical tubercles [@Li2004] -- supporting the interpretation of a single pair of setal sacs.';
+	TEXT TAXON=44 CHARACTER=118 TEXT='Convex deltoid (Holmer et al. 2008T)';
+	TEXT TAXON=49 CHARACTER=118 TEXT='Gently convex (see Williams et al. 2000, fig. 83.1)';
+	TEXT TAXON=52 CHARACTER=118 TEXT='Convex (Streng et al. 2016)';
+	TEXT TAXON=40 CHARACTER=118 TEXT='Difficult to determine based on material presented in Zhang et al (2007R), or indeed for other species in the genus (e.g. Williams et al. 2000; Skovsted & Holmer 2005; Holmer et al. 2018T)';
+	TEXT TAXON=50 CHARACTER=118 TEXT='"The presence of [...] a narrow delthyrium covered by a convex pseudodeltidium, places Salanygolinidae outside the Class Paterinata and strongly suggests affinity to the Cambrian Chileida" -- Holmer et al. 2009, p. 9';
+	TEXT TAXON=29 CHARACTER=118 TEXT='Gently convex (see Williams et al. 2000, fig. 83.3)';
+	TEXT TAXON=47 CHARACTER=118 TEXT='Convex in Nisusia (see Rowell and Caruso, 1985, fig. 8.4)';
+	TEXT TAXON=30 CHARACTER=118 TEXT='Convex (Williams et al. 2000, fig. 508)';
+	TEXT TAXON=27 CHARACTER=118 TEXT='"concave pseudodeltidium with median plication" -- Williams et al. 2000^nCoded as "Pseudodeltidium: Covered by concave plate" by Bassett et al. (2001)';
+	TEXT TAXON=37 CHARACTER=118 TEXT='"Narrow depressed homeodeltidium" -- @Hanken1985Thetaxonomy';
+	TEXT TAXON=45 CHARACTER=118 TEXT='Convex (see Balthasar 2004, fig. 4B)';
+	TEXT TAXON=44 CHARACTER=71 TEXT='Non-strophic: see Holmer et al 2008.';
+	TEXT TAXON=52 CHARACTER=71 TEXT='"Tomteluvid taxa all have a strongly ventribiconvex, astrophic shell with a unisulcate commissure" -- Streng et al. 2016, p5';
+	TEXT TAXON=40 CHARACTER=71 TEXT='@Williams1998Thediversity (appendix 2) and @Williams2000LinguliformeaCraniiformea (p. 208) consider the hinge of Kutorgina to be stropic, whereas Bassett et al (2001) argue for an astropic interpretation -- whilst noting that the arrangement is prominently different from other astrophic taxa.  We therefore code this taxon as ambiguous.';
+	TEXT TAXON=50 CHARACTER=71 TEXT='Coded as strophic in Williams et al (1998T); see @Holmer2009Theenigmatic';
+	TEXT TAXON=43 CHARACTER=71 TEXT='"Longtancunella has an oval to subcircular shell with a very short strophic hinge line" -- Zhang et al. 2011T';
+	TEXT TAXON=28 CHARACTER=71 TEXT='Coded as strophic in Williams et al (1998T)';
+	TEXT TAXON=29 CHARACTER=71 TEXT='Coded as strophic in Williams et al (1998T)';
+	TEXT TAXON=47 CHARACTER=71 TEXT='"The strophic, articulated shells of the Kutorginata rotated on simple hinge mechanisms that are different from those of other rhynchonelliforms" (Williams et al. 2000, p. 208)';
+	TEXT TAXON=14 CHARACTER=71 TEXT='Craniides have a strophic posterior valve edge (Williams et al. 2007, table 39 on p. 2853): Novocrania''s "dorsal posterior margin" is "straight" (Williams et al. 2000, p. 171).';
+	TEXT TAXON=37 CHARACTER=71 TEXT='The straight posterior margin of Gasconsia contributes to an overall resemblance with the Chileids [@Holmer2014OrdovicianSilurian]';
+	TEXT TAXON=38 CHARACTER=71 TEXT='Coded as strophic in Williams et al (1998T)';
+	TEXT TAXON=54 CHARACTER=71 TEXT='Not evident from fossil material; the possibility of a short strophic hinge line (as in Longtancunella) is difficult to discount.';
+	TEXT TAXON=34 CHARACTER=71 TEXT='Astrophic: rounded posterior margin (see fig. 91 in Williams et al. 2000) ';
+	TEXT TAXON=45 CHARACTER=71 TEXT='Non-strophic';
+	TEXT TAXON=36 CHARACTER=71 TEXT='Coded as astrophic in Williams et al (1998T); see also @Balthasar2009Thebrachiopod';
+	TEXT TAXON=31 CHARACTER=71 TEXT='Coded as dissociated in Williams et al. (1998T), appendix 2';
+	TEXT TAXON=24 CHARACTER=71 TEXT='Non-strophic';
+	TEXT TAXON=21 CHARACTER=71 TEXT='A linear hinge articulation does not exist between valves 1 and 2; nor would it exist between valves 1 and 8 were these adjacent [@Connors2012]. ';
+	TEXT TAXON=2 CHARACTER=71 TEXT='[@Skovsted2016]';
+	TEXT TAXON=49 CHARACTER=105 TEXT='The apical flange notwithstanding, the umbo of the S1 sclerite is posterior of the hinge line and the posterior edge of the lateral plate -- see Larsson et al. 2014, fig. 2a, c.';
+	TEXT TAXON=39 CHARACTER=105 TEXT='Williams et al. (2000, 2007) reconstruct mixoperipheral growth in the ventral valve (though Chen et al. (2007) reconstruct the valves the other way round, i.e. it is the ventral valve that grows holoperipherally, and the dorsal mixoperipherally). ';
+	TEXT TAXON=32 CHARACTER=105 TEXT='Inferred from Topper et al. (2013R).';
+	TEXT TAXON=34 CHARACTER=105 TEXT='"Both valves with growth holoperipheral" -- Williams et al. 2000, p. 164';
+	TEXT TAXON=53 CHARACTER=105 TEXT='Growth "mixoperipheral in both valves" in trimerellids [@Williams2000LinguliformeaCraniiformea;@Popov1997]';
+	TEXT TAXON=51 CHARACTER=105 TEXT='Initially holoperipheral (Popov et al. 2009, p. 159), then on the brink of being mixoperipheral in adulthood, so coded as polymorphic.';
+	TEXT TAXON=21 CHARACTER=105 TEXT='Growth is hemiperipheral in the anterior valve of polyplacophorans and holoperipheral in the posterior valves [@Schwabe2010;@Connors2012]';
+	TEXT TAXON=44 CHARACTER=91 TEXT='See Holmer et al. (2008)';
+	TEXT TAXON=49 CHARACTER=91 TEXT='S2 and L sclerites are clearly holoperipheral. See Larsson et al. 2014, fig. 2.^n';
+	TEXT TAXON=39 CHARACTER=91 TEXT='"holoperipheral growth in dorsal valve" -- Williams et al. 2007.^n^nZhang et al. (2009) conclude that Chen et al. (2007) misidentify the dorsal valve as the ventral valve.';
+	TEXT TAXON=32 CHARACTER=91 TEXT='Appears hemiperipheral in fig. 3 in Topper et al (2013R), though bordering on holoperipheral, so scored as ambiguous.';
+	TEXT TAXON=34 CHARACTER=91 TEXT='"Both valves with growth holoperipheral" -- Williams et al. 2000, p. 164';
+	TEXT TAXON=53 CHARACTER=91 TEXT='Growth "mixoperipheral in both valves" in trimerellids [@Williams2000LinguliformeaCraniiformea;@Popov1997]';
+	TEXT TAXON=21 CHARACTER=91 TEXT='For the purposes of this analysis, we must treat polyplacophoran and brachiopod valves as potentially homologous.  ^n^nIn brachiopods, the dorsal valve bears the lophophore, which arises from the anterior lobe of the larva [@Altenburger2013] -- indicating that the dorsal shell field is associated with the anterior lobe.^n^nIn polyplacophorans, the head valve arises from a shell field on the anterior (pre-prototroch) lobe of the larva [@Wanninger2002C], which we therefore treat as homologous with the brachiopod dorsal valve.^n^nIn support of this hypothesis, we note that the posterior (but not anterior) valves of chitons bear apophyses [@Schwabe2010;@Connors2012], which are most prominent in the ventral (but not dorsal) valves of brachiopods (Williams et al 1997, fig. 322), and which occur in the morph A shell of Oikozetetes, which is interpreted as the posterior valve of a halkieriid [@Paterson2009].^n^nAs the single posterior shell field of polyplacophorans subdivides to give rise to the six intermediate valves plus the tail valve [@Wanninger2002C], we prefer to consider the intermediate valves as representing "subdivisions" of a single valve rather than additional valves added to the body plan.^n^nGrowth is hemiperipheral in the anterior valve of polyplacophorans and holoperipheral in the posterior valves [@Schwabe2010;@Connors2012]';
+	TEXT TAXON=49 CHARACTER=120 TEXT='The presumed pedicle foramen is an opening between the S1 and S2 sclerites, neither of which are perforated (Skovsted et al. 2009).';
+	TEXT TAXON=35 CHARACTER=120 TEXT='The sclerites of Eccentrotheca form a ring that surrounds the inferred attachment structure; the attachment structure does not emerge from an aperture within an individual sclerite.  Thus no feature in Eccentrotheca is judged to be potentially homologous with the apical perforation in bivalved brachiopods.';
+	TEXT TAXON=41 CHARACTER=120 TEXT='The apical termination of the fossil is unknown.';
+	TEXT TAXON=52 CHARACTER=120 TEXT='Streng et al (2016) observe "an internal tubular structure probably representing the ventral end of the canal within the posterior wall of the pedicle tube", but do not consider this tomteluvid dube to be homologous with the pedicle tube of acrotretids and their ilk, stating (p. 274) that it appears to be unique within Brachiopoda.';
+	TEXT TAXON=25 CHARACTER=120 TEXT='The B and C sclerites of Dailyatia bear small umbonal perforations (Skovsted et al 2015), but these are not considered to be homologous with the ventral valve, so this character is coded as inapplicable - though the possibility that the perforations are equivalent is intriguing.^n^nA1 sclerites typically have a pair of perforations, which are conceivably equivalent to the setal tubes of Micrina (Holmer et al. 2011). The A1 sclerite of D. bacata has a structure that is arguably similar to the ''colleplax'' of Paterimitra.  But the homology of any of these structures to the umbonal aperture of brachiopods is difficult to establish.';
+	TEXT TAXON=39 CHARACTER=120 TEXT='There is "compelling evidence to demonstrate that the putative pedicle^nillustrated by Chen et al. (2007: Figs. 4, 6, 7) in fact is the mold of a three-dimensionally preserved visceral cavity." -- Zhang et al. 2009';
+	TEXT TAXON=32 CHARACTER=120 TEXT='The presumed pedicle foramen reported by Topper et al. (2013R) is at the ventral valve umbo.  No evidence of an internal pedicle tube is present, but we follow Popov (1992) in inferring the encapsulation of the pedicle foramen.';
+	TEXT TAXON=45 CHARACTER=120 TEXT='The umbo itself is imperforate (Balthasar 2004)';
+	TEXT TAXON=51 CHARACTER=120 TEXT='Prominent subcircular perforation at umbo associated with an internal pedicle tube (Popov et al. 2009), thus presumed to share an origin with the acrotretid pedicle foramen.';
+	TEXT TAXON=3 CHARACTER=120 TEXT='The apical termination of the conical valve is not preserved [@Valent2012]';
+	TEXT TAXON=7 CHARACTER=120 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=2 CHARACTER=120 TEXT='Decollation generates open umbo, sealed secondarily with septum';
+	TEXT TAXON=28 CHARACTER=113 TEXT='Prominently triangular (see Topper et al. 2013T, fig. 2)';
+	TEXT TAXON=32 CHARACTER=113 TEXT='Following the model of Popov (1992)';
+	TEXT TAXON=45 CHARACTER=113 TEXT='An opening is incorporated at the base of the homeodeltidium when the organism switches from early to late maturity (fig. 10 in Balthasar 2004).  This opening is conceivably homologous with the pedicle foramen of acrotretid brachiopods and their ilk.  To reflect this possible homology, Mickwitzia is coded as polymorphic (triangular/round).';
+	TEXT TAXON=44 CHARACTER=117 TEXT='"Ventral valve convex with apsacline interarea bearing delthyrium, covered by a convex pseudodeltidium" -- Holmer et al. 2008';
+	TEXT TAXON=42 CHARACTER=117 TEXT='The subapical flange of the Paterimitra S1 sclerite has been homologised with the ventral homeodeltidium of Micromitra (Larsson et al 2014).';
+	TEXT TAXON=28 CHARACTER=117 TEXT='No pseudodeltidium (Williams et al. 2000, p. 153)';
+	TEXT TAXON=27 CHARACTER=117 TEXT='Stated as "concave pseudodeltidium with median plication" -- Williams et al. 2000^nCoded as "Pseudodeltidium: Covered by concave plate" by Bassett et al. (2001)';
+	TEXT TAXON=37 CHARACTER=117 TEXT='A homeodeltidium is illustrated by @Hanken1985Thetaxonomy.';
+	TEXT TAXON=45 CHARACTER=117 TEXT='Termed a homoedeltidium by Balthasar (2004)';
+	TEXT TAXON=44 CHARACTER=116 TEXT='Remains somewhat open';
+	TEXT TAXON=29 CHARACTER=116 TEXT='Completely covered (Williams et al. 2000, fig. 83.3)';
+	TEXT TAXON=47 CHARACTER=116 TEXT='A well-defined pseudo-deltidium [...] closes only the apical part of^n the delthyrium (Rowell & Caruso 1985)';
+	TEXT TAXON=17 CHARACTER=27 TEXT='Extant rhynconellid pedicles are massive, consisting of a thick outer chitinous cuticle, a pedicle epithelium, and a core composed of collagen fibres and cartilage-like connective tissue (Holmer et al. 2018E).';
+	TEXT TAXON=30 CHARACTER=27 TEXT='Biomineralized (Holmer et al. 2018E)';
+	TEXT TAXON=40 CHARACTER=28 TEXT='The tabular discs that make up the pedicle "clearly have a pronounced three-dimensional preservation and may have been partly mineralized." --@Holmer2018Theattachment';
+	TEXT TAXON=29 CHARACTER=28 TEXT='A pedicle has not been observed in biomineralized material [@Williams1998Thediversity], indicating an originally non-mineralized constitution.';
+	TEXT TAXON=9 CHARACTER=31 TEXT='The pedicle thickness gradually typering from the apex of the shell to the holdfast.';
+	TEXT TAXON=30 CHARACTER=31 TEXT='Tapered pedicle sheath with holdfast.';
+	TEXT TAXON=44 CHARACTER=82 TEXT='Prominent ventral muscle scars - see e.g. Holmer et al 2008, fig. 1f';
+	TEXT TAXON=27 CHARACTER=82 TEXT='Muscle scars scored based on Alisina comleyensis (Bassett et al. 2001)';
+	TEXT TAXON=53 CHARACTER=82 TEXT='Scars preserved on ventral valve [@Nikitin1984]';
+	TEXT TAXON=45 CHARACTER=82 TEXT='Scars absent; instead, cones ornament shell''s internal surface.';
+	TEXT TAXON=24 CHARACTER=82 TEXT='Muscle scars are known from the Type A, but not Type B, morphs of the halkieriid Oikozetetes [@Paterson2009;@Jacquet2014].';
+	TEXT TAXON=21 CHARACTER=82 TEXT='Absent [@Schwabe2010]';
+	TEXT TAXON=4 CHARACTER=82 TEXT='[Reference needed]';
+	TEXT TAXON=3 CHARACTER=82 TEXT='"Muscle scars were not found" -- @Valent2012';
+	TEXT TAXON=7 CHARACTER=82 TEXT='Not preserved in conchs, though likely present (by analogy with Maxilites) [@Zhang2018Ahyolithid].';
+	TEXT TAXON=28 CHARACTER=84 TEXT='Following the interpretation of the musculature presented by Williams et al. (2000), fig. 81.';
+	TEXT TAXON=27 CHARACTER=84 TEXT='Muscle scars scored based on Alisina comleyensis (Bassett et al. 2001). The presence of an adjustor is marked as not presently available, as it is not clear that a scar, if present, could be distinguished from the diminutive muscle scars present.';
+	TEXT TAXON=37 CHARACTER=84 TEXT='No mention of an adjustor muscle in Gasconsia or Trimerellida more generally on pp. 184-185 of Williams et al. 2000, nor in discussion in Williams et al. 2007 (p. 2850).  Coded as absent.';
+	TEXT TAXON=32 CHARACTER=84 TEXT='Not known in any acrotretid (Williams et al. 2000); not evident in Clupeafumosus (Topper et al. 2013R).';
+	TEXT TAXON=45 CHARACTER=84 TEXT='Scars absent; instead, cones ornament shell''s internal surface.';
+	TEXT TAXON=51 CHARACTER=84 TEXT='Ventral musculature poorly constrained (Williams et al. 2000; Popov et al. 2009)';
+	TEXT TAXON=31 CHARACTER=84 TEXT='Not described in Popov (1992)';
+	TEXT TAXON=5 CHARACTER=85 TEXT='Moysiuk et al. (2017) reconstruct distinct left and right attachment scars, consistent with general situation in hyoliths (see Dzik 1980); it is unclear whether additional smaller scars were present in a radial arrangement [as in e.g. Gompholites, @Marek1967] or whether unseen scars were dispersed, hence the partially ambiguous coding.';
+	TEXT TAXON=33 CHARACTER=85 TEXT='"radially arranged adductor scars" -- Bassett & Popov 2017, p1';
+	TEXT TAXON=50 CHARACTER=85 TEXT='"The dorsal valve of Salanygolina has a radial arrangement of adductor muscle scars and the scars of posteromedially placed internal oblique muscles, which are also characteristic of paterinates and chileates" -- Holmer et al. (2009)';
+	TEXT TAXON=39 CHARACTER=85 TEXT='Distinct anterior and posterior fields (Chen et al. 2007); coded as "dispersed" by Williams et al. (2000) in table 15.';
+	TEXT TAXON=28 CHARACTER=85 TEXT='Separate left and right fields, so radially arranged -- following the interpretation of the musculature presented by Williams et al. (2000), fig. 81.';
+	TEXT TAXON=29 CHARACTER=85 TEXT='Williams et al. (1998T) code as "dispersed", but have a less divided scheme of character states and disagree with other sources in some codings (e.g. Bassett et al. 2001, in Kutorginates).  Williams et al. (2000) do not describe Micromitra musculature and we were unable to find any reliable description of the scars, so we code as "not presently available".';
+	TEXT TAXON=15 CHARACTER=85 TEXT='Discinids scored as "open, quadripartite" by Williams et al. (1996)';
+	TEXT TAXON=14 CHARACTER=85 TEXT='Craniids scored as "open, quadripartite" by Williams et al. (1996)';
+	TEXT TAXON=17 CHARACTER=85 TEXT='Coded as "grouped, quadripartite" by Williams et al. (1996)';
+	TEXT TAXON=30 CHARACTER=85 TEXT='Treatise';
+	TEXT TAXON=27 CHARACTER=85 TEXT='Following Williams et al. (2000) table 15 (their character 54)';
+	TEXT TAXON=37 CHARACTER=85 TEXT='Following the coding of Williams et al. (2000), table 15.';
+	TEXT TAXON=38 CHARACTER=85 TEXT='Scored as "dispersed" by Williams et al. (1998T) ... but then so is Kutorgina, which Bassett et al (2001) score as radial.^n^nWilliams et al. (2000) state, for superfamily Protorthida, "dorsal adductor scars probably linear", which fits in the category of "radial" employed herein -- so that''s what we follow.';
+	TEXT TAXON=32 CHARACTER=85 TEXT='Following reconstruction of Hadrotreta by Williams (2000), fig. 51, which exhibits distinct left and right fields.';
+	TEXT TAXON=53 CHARACTER=85 TEXT='Following coding with state 0 (dispersed) in table 15 in Williams et al. 2000';
+	TEXT TAXON=45 CHARACTER=85 TEXT='Scars absent; instead, cones ornament shell''s internal surface.';
+	TEXT TAXON=51 CHARACTER=85 TEXT='Ventral musculature poorly constrained (Williams et al. 2000; Popov et al. 2009)';
+	TEXT TAXON=31 CHARACTER=85 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=24 CHARACTER=85 TEXT='It is unclear whether the paired muscle scars of Oikozetetes may be homologous to brachiopod adductors.';
+	TEXT TAXON=6 CHARACTER=85 TEXT='A pair of large oval muscle scars on the conical shield is complemented with smaller scars elsewhere on the operculum [@Marek1972;@MartiMus2005]';
+	TEXT TAXON=26 CHARACTER=89 TEXT='Not observable in Acanthotretella itself, so coded as ambiguous -- though it is likely based on the anticipated phylogenetic affinities of Acanthotretella that the muscles are absent.';
+	TEXT TAXON=28 CHARACTER=89 TEXT='Possible diductor scar could instead correspond to discinoid posterior adductors [@Williams1998Thediversity]; coded as uncertain. Not reconstructed in the the interpretation of the musculature presented by Williams et al. (2000), fig. 81.';
+	TEXT TAXON=29 CHARACTER=89 TEXT='Possible diductor scar could instead correspond to discinoid posterior adductors [@Williams1998Thediversity]; coded as uncertain.';
+	TEXT TAXON=37 CHARACTER=89 TEXT='Internal oblique muscles serve as diductors.';
+	TEXT TAXON=32 CHARACTER=89 TEXT='Not reported by Topper et al. (2013R), nor reconstructed in generic acrotretid by Williams et al. (2000)';
+	TEXT TAXON=53 CHARACTER=89 TEXT='Internal oblique muscles present [@Nikitin1984] and taken to serve as diductors by analogy with Gasconsia.';
+	TEXT TAXON=51 CHARACTER=89 TEXT='Ventral musculature poorly constrained (Williams et al. 2000; Popov et al. 2009)';
+	TEXT TAXON=24 CHARACTER=89 TEXT='It is unclear whether the paired muscle scars of Oikozetetes are homologous to brachiopod diductors.';
+	TEXT TAXON=51 CHARACTER=90 TEXT='Ventral musculature poorly constrained (Williams et al. 2000; Popov et al. 2009)';
+	TEXT TAXON=33 CHARACTER=86 TEXT='Not reported by Williams et al. (2000), nor Bassett & Popov (2017), nor explicitly by Dewing (2001).';
+	TEXT TAXON=28 CHARACTER=86 TEXT='Following the interpretation of the musculature presented by Williams et al. (2000), fig. 81.';
+	TEXT TAXON=15 CHARACTER=86 TEXT='Musculature considered essentially equivalent to Lingula by Williams et al 2000, so Lingula coding followed here.';
+	TEXT TAXON=37 CHARACTER=86 TEXT='See discussion under Trimerellida in Williams et al. (2000).';
+	TEXT TAXON=45 CHARACTER=86 TEXT='Scars absent; instead, cones ornament shell''s internal surface.';
+	TEXT TAXON=36 CHARACTER=86 TEXT='"Eoobolus should have anterior and posterior adductors and a variety of oblique muscles which were probably arranged in criss-crossing pairs" -- Balthasar 2009T';
+	TEXT TAXON=51 CHARACTER=86 TEXT='Ventral musculature poorly constrained (Williams et al. 2000; Popov et al. 2009)';
+	TEXT TAXON=31 CHARACTER=86 TEXT='Following description of Popov (1992)';
+	TEXT TAXON=33 CHARACTER=98 TEXT='Referred to as the "posterior platform" in Dewing (2001)';
+	TEXT TAXON=40 CHARACTER=98 TEXT='"Dorsal diductor scars impressed on floor of notothyrial cavity": Williams et al. 2000, regarding Kutorginata.^nBassett et al. (2001) score as absent in Table 18.1.';
+	TEXT TAXON=28 CHARACTER=98 TEXT='Raised notothyrial platform [@Williams1998Thediversity]';
+	TEXT TAXON=29 CHARACTER=98 TEXT='A low notothyrial plate [@Williams1998Thediversity] conceivably correspond to the raised notothyrial platform of Askepasma; coded ambiguous accordingly.';
+	TEXT TAXON=47 CHARACTER=98 TEXT='Bassett et al. (2001) score as absent in Table 18.1.^n"Dorsal diductor scars impressed on floor of notothyrial cavity": Williams et al. 2000, regarding Kutorginata.';
+	TEXT TAXON=27 CHARACTER=98 TEXT='Bassett et al. (2001) score as present in Table 18.1.';
+	TEXT TAXON=38 CHARACTER=98 TEXT='Bassett et al. (2001) score as present in Table 18.1.';
+	TEXT TAXON=53 CHARACTER=98 TEXT='"Visceral platforms absent in both valves" -- Williams et al. 2000, p. 192';
+	TEXT TAXON=43 CHARACTER=101 TEXT='Not evident, and ought arguably to be discernable if present given the quality of preservation';
+	TEXT TAXON=32 CHARACTER=101 TEXT='Not reported by Topper et al. (2013R).';
+	TEXT TAXON=4 CHARACTER=101 TEXT='Present [@Wrona2003]';
+	TEXT TAXON=6 CHARACTER=101 TEXT='Narrow cardinal processes [@Marek1972]';
+	TEXT TAXON=8 CHARACTER=101 TEXT='@Marek1966';
+	TEXT TAXON=3 CHARACTER=101 TEXT='"Narrow broadly diverging cardinal processes with subparallel edges" -- @Valent2012';
+	TEXT TAXON=7 CHARACTER=101 TEXT='Present [@Zhang2018Ahyolithid]';
+	TEXT TAXON=2 CHARACTER=101 TEXT='Well-defined [@Skovsted2016]';
+	TEXT TAXON=52 CHARACTER=80 TEXT='Tomteluvids [...] lack articulation structures such as teeth and sockets (Streng et al. 2016)';
+	TEXT TAXON=47 CHARACTER=80 TEXT='Coded as absent in Benedetto (2009).';
+	TEXT TAXON=30 CHARACTER=80 TEXT='Coded as present in Benedetto (2009)';
+	TEXT TAXON=27 CHARACTER=80 TEXT='"bearing sockets, bounded by low ridges" -- Williams et al. 2000';
+	TEXT TAXON=37 CHARACTER=80 TEXT='"Articulatory structure comprising ventral cardinal socket and dorsal hinge plate" -- Williams et al. 2000, p. 184';
+	TEXT TAXON=38 CHARACTER=80 TEXT='Coded as absent in Benedetto (2009)';
+	TEXT TAXON=53 CHARACTER=80 TEXT='Following table 15 in Williams et al. 2000';
+	TEXT TAXON=45 CHARACTER=80 TEXT='Not reported by or evident in Balthasar (2004)';
+	TEXT TAXON=52 CHARACTER=81 TEXT='Tomteluvids [...] lack articulation structures such as teeth and sockets (Streng et al. 2016)';
+	TEXT TAXON=47 CHARACTER=81 TEXT='Coded as absent in Benedetto (2009)';
+	TEXT TAXON=30 CHARACTER=81 TEXT='Coded as present in Benedetto (2009)';
+	TEXT TAXON=27 CHARACTER=81 TEXT='"bearing sockets, bounded by low ridges" -- Williams et al. 2000';
+	TEXT TAXON=38 CHARACTER=81 TEXT='Coded as absent in Benedetto (2009)';
+	TEXT TAXON=9 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=44 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=49 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=35 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=5 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=41 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=18 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=46 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=40 CHARACTER=119 TEXT='Coded as present in Bassett et al. 2001 (table 18.1).';
+	TEXT TAXON=50 CHARACTER=119 TEXT='The presence of this feature is impossible to determine based on the available material.';
+	TEXT TAXON=25 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=16 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=26 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=39 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=42 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=28 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=29 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=47 CHARACTER=119 TEXT='Coded as present in Bassett et al. 2001 (table 18.1).';
+	TEXT TAXON=15 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=14 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=17 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=48 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=37 CHARACTER=119 TEXT='Not evident or illustrated [@Hanken1985Thetaxonomy]';
+	TEXT TAXON=38 CHARACTER=119 TEXT='Coded as absent in Bassett et al. 2001 (table 18.1).';
+	TEXT TAXON=32 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=4 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=6 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=8 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=3 CHARACTER=119 TEXT='Absent due to inapplicability of neomorphic character.';
+	TEXT TAXON=9 CHARACTER=93 TEXT='Difficult to evaluate based on present material, given low nature of valve and compressed preservation';
+	TEXT TAXON=39 CHARACTER=93 TEXT='Posterior surface cannot be flat if it is not differentiated.';
+	TEXT TAXON=29 CHARACTER=93 TEXT='Essentially straight; see fig. 3.7 in Ushatinskaya 2016P';
+	TEXT TAXON=15 CHARACTER=93 TEXT='Posterior surface cannot be flat if it is not differentiated.';
+	TEXT TAXON=37 CHARACTER=93 TEXT='Posterior surface cannot be flat if it is not differentiated.';
+	TEXT TAXON=32 CHARACTER=93 TEXT='Truncated but essentially planar surface; see e.g. p196 of Topper et al. 2013R^n';
+	TEXT TAXON=53 CHARACTER=93 TEXT='Posterior surface cannot be flat if it is not differentiated.';
+	TEXT TAXON=45 CHARACTER=93 TEXT='Posterior surface cannot be flat if it is not differentiated.';
+	TEXT TAXON=36 CHARACTER=93 TEXT='Essentially planar; see Balthasar (2009T), fig. 4a';
+	TEXT TAXON=51 CHARACTER=93 TEXT='The short interarea appears planar (see for example Popov et a. 2009 fig. 6A), but its short length makes it difficult to establish whether slight curvature is present.';
+	TEXT TAXON=31 CHARACTER=93 TEXT='"Curved pseudointerarea" -- Skovsted et al. 2017';
+	TEXT TAXON=21 CHARACTER=93 TEXT='Essentially planar, though open in aspect [following Chiton in @Schwabe2010]';
+	TEXT TAXON=4 CHARACTER=93 TEXT='Difficult to establish from material figured in @Devaere2014 due to low elevation of operculum.';
+	TEXT TAXON=6 CHARACTER=93 TEXT='Approximately planar [@Marek1972]';
+	TEXT TAXON=8 CHARACTER=93 TEXT='Not clear from published material';
+	TEXT TAXON=3 CHARACTER=93 TEXT='The short aspect of the cardinal interarea [@Valent2012] makes it difficult to evaluate whether it is planar or curved.';
+	TEXT TAXON=7 CHARACTER=93 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=2 CHARACTER=93 TEXT='Curved [@Sun2018]';
+	TEXT TAXON=47 CHARACTER=139 TEXT='Scored absent in data matrix of Benedetto (2009).';
+	TEXT TAXON=30 CHARACTER=139 TEXT='Scored absent in data matrix of Benedetto (2009).';
+	TEXT TAXON=48 CHARACTER=139 TEXT='Scored absent (in Eoorthis) in data matrix of Benedetto (2009).';
+	TEXT TAXON=38 CHARACTER=139 TEXT='Scored absent in data matrix of Benedetto (2009).';
+	TEXT TAXON=6 CHARACTER=139 TEXT='Coded following helen microstructure described in the similar material of ''Hyolithes'' [@MartiMus2007]';
+	TEXT TAXON=3 CHARACTER=139 TEXT='Taxon known only from moulds [@Valent2012]';
+	TEXT TAXON=7 CHARACTER=139 TEXT='Absent [@Zhang2018Ahyolithid]';
+	TEXT TAXON=33 CHARACTER=111 TEXT='See fig. 485 in Williams et al. 2000';
+	TEXT TAXON=40 CHARACTER=111 TEXT='This taxon (see Williams et al. 2000, fig. 129; Popov 1992, fig. 1) comes close to expressing the deeply conical ventral valve that this character is intended to reflect, though this is not always so pronounced (e.g. Williams et al. 2000, fig. 125).  It is therefore coded as ambiguous.';
+	TEXT TAXON=50 CHARACTER=111 TEXT='Whereas Williams et al. (2000, p. 156) describe the ventral pseudointerarea as high, the shell lacks the deeply conical aspect that this character is intended to capture; we thus code the taxon as ambiguous.';
+	TEXT TAXON=47 CHARACTER=111 TEXT='Scored as high in data matrix of Benedetto (2009), and depicted as such in Williams et al. (2000, fig. 125) and Popov (1992, fig. 1); but not high in all specimens (e.g. Williams et al. 2000, fig. 126).  It is therefore coded as polymorphic.';
+	TEXT TAXON=14 CHARACTER=111 TEXT='Low cone';
+	TEXT TAXON=30 CHARACTER=111 TEXT='Though scored High in data matrix of Benedetto (2009), this taxon (see Williams et al. 2000, fig. 508) does not express the deeply conical ventral valve that this character is intended to reflect.  It is charitably coded as ambiguous.';
+	TEXT TAXON=48 CHARACTER=111 TEXT='Scored ''Low'' for Eoorthis by Benedetto (2009); assumed same in Orthis.';
+	TEXT TAXON=37 CHARACTER=111 TEXT='"ventral cardinal interarea low, apsacline, with narrow, poorly defined homeodeltidium" - Williams et al. 2000, p. 186';
+	TEXT TAXON=32 CHARACTER=111 TEXT='Entire valve length -- see schematic in Williams et al. (1997), fig. 286';
+	TEXT TAXON=45 CHARACTER=111 TEXT='Often not prominently high (Skovsted & Holmer, 2003; Balthasar, 2004), though in some cases (e.g. Butler et al. 2015) the ventral valve approaches the conical shape that this character is intended to capture.  Coded as polymorphic.';
+	TEXT TAXON=9 CHARACTER=109 TEXT='Essentially linear.';
+	TEXT TAXON=5 CHARACTER=109 TEXT='Dorsal surface essentially linear [@Moysiuk2017Hyolithsare, fig ed6a, ed7a]';
+	TEXT TAXON=26 CHARACTER=109 TEXT='ventral pseudointerareas are most similar to those found within the Order Siphonotretida';
+	TEXT TAXON=43 CHARACTER=109 TEXT='Flattened, reflecting the strophic hinge line';
+	TEXT TAXON=42 CHARACTER=109 TEXT='Transverse cross section of ventral pseudointerarea concave.';
+	TEXT TAXON=29 CHARACTER=109 TEXT='Essentially planar; see fig. 6 in Ushatinskaya 2016P';
+	TEXT TAXON=32 CHARACTER=109 TEXT='"Ventral pseudointerarea is gently procline and is flat in lateral profile". ---^n (Topper et al. 2013R)';
+	TEXT TAXON=36 CHARACTER=109 TEXT='Some curvature retained';
+	TEXT TAXON=51 CHARACTER=109 TEXT='''Almost'' planar -- see Popov et al. (2009, fig. 4).  Coded as ambiguous.';
+	TEXT TAXON=31 CHARACTER=109 TEXT='See Skovsted & Holmer (2005), pl. 3, fig. 14.';
+	TEXT TAXON=21 CHARACTER=109 TEXT='[@Schwabe2010]';
+	TEXT TAXON=4 CHARACTER=109 TEXT='Strongly curved in some species [@Wrona2003]';
+	TEXT TAXON=6 CHARACTER=109 TEXT='Gently sinuous [@MartiMus2005]';
+	TEXT TAXON=8 CHARACTER=109 TEXT='Reconstructed as linear by @Marek1976.';
+	TEXT TAXON=7 CHARACTER=109 TEXT='Posterior (functionally dorsal) surface is linear in adults (though slightly curving in juveniles) [@Zhang2018Ahyolithid]';
+	TEXT TAXON=44 CHARACTER=78 TEXT='The simple knob-like teeth of Micrina show no evidence of resprobtion or the hook-like shape that characterises Cyrtomatodont teeth.';
+	TEXT TAXON=40 CHARACTER=78 TEXT='"Articulation characterized by two triangular plates formed by dorsal interarea, bearing oblique ridges on the inner sides" -- Williams et al 2000, p. 211';
+	TEXT TAXON=47 CHARACTER=78 TEXT='The ''teeth'' are formed by the distal lateral extensions from the ventral^npseudodeltidium fitting into the ''sockets'' on the inner side of the dorsal interarea (Holmer et al. 2018E).  (Coded as "deltidiodont teeth absent" in Benedetto (2009).)';
+	TEXT TAXON=17 CHARACTER=78 TEXT='Cyrtomatodont - see fig. 322 in Williams et al (2000)';
+	TEXT TAXON=30 CHARACTER=78 TEXT='Coded as deltidiodont in Benedetto (2009).';
+	TEXT TAXON=48 CHARACTER=78 TEXT='Coded as deltidiodont (in Eoorthis) in Benedetto (2009).';
+	TEXT TAXON=38 CHARACTER=78 TEXT='Coded as deltidiodont in Benedetto (2009).';
+	TEXT TAXON=21 CHARACTER=78 TEXT='Chiton apophyses (sutural laminae) are accretions deriving from the ventral shell layer of the intermediate and tail valves [@Schwabe2010], so correspond to the deltidiodont situation in brachiopods.';
+	TEXT TAXON=33 CHARACTER=79 TEXT='Coded as present following Dewing (2001), who seems to use the term Strophomenoids to encompass Coolinia, and attests to the presence of dental plates.';
+	TEXT TAXON=47 CHARACTER=79 TEXT='Coded as absent in Benedetto (2009)';
+	TEXT TAXON=30 CHARACTER=79 TEXT='Coded as present (well developed) in Benedetto (2009)';
+	TEXT TAXON=48 CHARACTER=79 TEXT='Coded as present (short and recessive, in Eoorthis) in Benedetto (2009)';
+	TEXT TAXON=37 CHARACTER=79 TEXT='Coded ambiguous to reflect the possibility that the hinge plate in trimerellids is homologous to the dental plates of other taxa, and has replaced the teeth themselves as the primary articulatory mechanism (see Williams et al. 2000, p. 184, for details of the articulation)';
+	TEXT TAXON=38 CHARACTER=79 TEXT='Coded as absent in Benedetto (2009)';
+	TEXT TAXON=18 CHARACTER=129 TEXT='"The presence of sulphated glycosaminoglycans (GAGs) in the chitinous cuticle of Phoronis (Herrmann, 1997, p. 215) would suggest a link with linguliforms, as GAGs are unknown in rhynchonelliform shells (Fig. 1891, 1896)" -- Williams et al. 2007, p. 2830';
+	TEXT TAXON=16 CHARACTER=129 TEXT='Coded as GAGs, chitin and collagen in lingulids by Williams et al (1996)';
+	TEXT TAXON=15 CHARACTER=129 TEXT='Coded as GAGs, chitin and collagen in discinids by Williams et al (1996)';
+	TEXT TAXON=14 CHARACTER=129 TEXT='Coded as glycoprotein for craniids by Williams et al (1996)';
+	TEXT TAXON=17 CHARACTER=129 TEXT='Coded as glycoprotein for terebratulids by Williams et al (1996)';
+	TEXT TAXON=51 CHARACTER=129 TEXT='Lenticular chambers in siphonotretid shells interpreted as degraded GAG residue (Williams et al. 2004)';
+	TEXT TAXON=33 CHARACTER=88 TEXT='Not reported in Dewing (2001)';
+	TEXT TAXON=40 CHARACTER=88 TEXT='Following table 13 in Williams et al. 2000';
+	TEXT TAXON=39 CHARACTER=88 TEXT='Poor preservation of minor muscle scars noted by Chen et al. (2007)';
+	TEXT TAXON=47 CHARACTER=88 TEXT='Following table 13 in Williams et al. 2000';
+	TEXT TAXON=15 CHARACTER=88 TEXT='Musculature considered essentially equivalent to Lingula by Williams et al 2000, so Lingula coding followed here.';
+	TEXT TAXON=14 CHARACTER=88 TEXT='Following table 13 in Williams et al. 2000 (for Novocrania)';
+	TEXT TAXON=27 CHARACTER=88 TEXT='Following table 13 in Williams et al. 2000';
+	TEXT TAXON=37 CHARACTER=88 TEXT='Williams et al. 2000 code an unpaired medial muscle scar as present in their table 13, but give no reference for this coding, which perhaps arises from their interpretation of the taxon as a trimerellid.  Hanken and Harper (1985, p. 249 and text-fig. 2) explicitly identify a pair of central muscles, so we code a levator ani as absent.';
+	TEXT TAXON=34 CHARACTER=88 TEXT='See fig. 90 in Williams et al. 2000';
+	TEXT TAXON=53 CHARACTER=88 TEXT='Following table 15 in Williams et al. 2000';
+	TEXT TAXON=45 CHARACTER=88 TEXT='Scars absent; instead, cones ornament shell''s internal surface.';
+	TEXT TAXON=51 CHARACTER=88 TEXT='Ventral musculature poorly constrained (Williams et al. 2000; Popov et al. 2009)';
+	TEXT TAXON=9 CHARACTER=92 TEXT='Pseudointerarea.';
+	TEXT TAXON=44 CHARACTER=92 TEXT='= Sellate sclerite duplicature (Holmer et al. 2008)';
+	TEXT TAXON=49 CHARACTER=92 TEXT='Pseudointerarea.';
+	TEXT TAXON=5 CHARACTER=92 TEXT='A very short pseudointerarea appears to be present (Moysiuk et al. 2017)';
+	TEXT TAXON=41 CHARACTER=92 TEXT='Unclear from fossil material.^n';
+	TEXT TAXON=52 CHARACTER=92 TEXT='Cardinal area (interarea) present.';
+	TEXT TAXON=46 CHARACTER=92 TEXT='"Information on the dorsal interarea is inconclusive [...] no obvious^ninterarea is recognisable; whether or not this is the primary state or a taphonomic artefact is difficult to assess" -- Balthasar 2008, p. 276';
+	TEXT TAXON=33 CHARACTER=92 TEXT='Cardinal area (interarea) present.';
+	TEXT TAXON=40 CHARACTER=92 TEXT='Cardinal area (interarea) present.';
+	TEXT TAXON=50 CHARACTER=92 TEXT='Cardinal area (interarea) present.';
+	TEXT TAXON=16 CHARACTER=92 TEXT='Pseudointerarea present, following Williams et al. (2000), table 6.';
+	TEXT TAXON=26 CHARACTER=92 TEXT='Pseudointerarea present, following Siphonotretidae coding in Williams et al. (2000), table 6.';
+	TEXT TAXON=39 CHARACTER=92 TEXT='Pseudointerea in ventral valve, but not dorsal valve (Williams et al. 2000, 2007)';
+	TEXT TAXON=43 CHARACTER=92 TEXT='Zhang et al. (2011T) note that "all evidence of a pseudointerarea is lacking", but the two-dimensional preservation style of Chengjiang material makes details of dorsal valve difficult to distinguish, and the possibility of a diminutive pseudointerarea cannot be excluded with total confidence.';
+	TEXT TAXON=42 CHARACTER=92 TEXT='Pseudointerarea present, following Williams et al. (2000), table 6.';
+	TEXT TAXON=28 CHARACTER=92 TEXT='Well-defined pseudointerarea (Williams et al. 2000, p153)';
+	TEXT TAXON=29 CHARACTER=92 TEXT='"Dorsal pseudointerarea usually well defined, low, anacline to catacline" - Williams et al. 2000';
+	TEXT TAXON=47 CHARACTER=92 TEXT='Cardinal area (interarea) present -- with reference to Holmer et al. (2018E).';
+	TEXT TAXON=15 CHARACTER=92 TEXT='Absent, following entry for Discinidae in Williams et al. (2000), table 6.';
+	TEXT TAXON=14 CHARACTER=92 TEXT='Pseudointerarea';
+	TEXT TAXON=17 CHARACTER=92 TEXT='Interarea present';
+	TEXT TAXON=30 CHARACTER=92 TEXT='Cardinal area (interarea) present.';
+	TEXT TAXON=27 CHARACTER=92 TEXT='Cardinal area (interarea) present.';
+	TEXT TAXON=48 CHARACTER=92 TEXT='Cardinal area (interarea) present.';
+	TEXT TAXON=37 CHARACTER=92 TEXT='Absent: the dorsal (branchial) pseudointerarea of G. schucherti is "reduced or obsolete"; that of G. worsleyi "short, virtually obsolete" (Hanken & Harper 1985).';
+	TEXT TAXON=38 CHARACTER=92 TEXT='Cardinal area (interarea) present.';
+	TEXT TAXON=32 CHARACTER=92 TEXT='Pseudointerarea present; figured by Topper et al. (2013R), fig. 3j.';
+	TEXT TAXON=54 CHARACTER=92 TEXT='A differentiated region is not obvious in fossil material or its reconstruction (Zhang et al. 2014), but the two-dimensional preservation style of Chengjiang material makes details of dorsal valve difficult to distinguish, and the possibility of a diminutive pseudointerarea cannot be excluded with confidence.';
+	TEXT TAXON=34 CHARACTER=92 TEXT='"Only some craniopsids (Lingulapholis, Pseudopholidops [not Craniops]) have well-developed pseudointerareas." -- Williams et al. 2000';
+	TEXT TAXON=53 CHARACTER=92 TEXT='Following table 15 in Williams et al. 2000';
+	TEXT TAXON=45 CHARACTER=92 TEXT='Shell flat.';
+	TEXT TAXON=51 CHARACTER=92 TEXT='"Dorsal pseudointerarea weakly anacline, undivided, elevated above the valve floor" -- Popov et al. 2009';
+	TEXT TAXON=31 CHARACTER=92 TEXT='"dorsal pseudointerarea vestigial, divided by median groove" - Williams et al. 2000';
+	TEXT TAXON=21 CHARACTER=92 TEXT='V-shaped notch in anterior valve [@Schwabe2010]';
+	TEXT TAXON=8 CHARACTER=92 TEXT='@Marek1966';
+	TEXT TAXON=26 CHARACTER=94 TEXT='The dorsal pseudointerarea is poorly preserved, but appears to have a median groove (Holmer & Caron, 2006)';
+	TEXT TAXON=39 CHARACTER=94 TEXT='"A posteriorly protruding dorsal pseudointerarea with no median groove and no flexure lines" - Chen et al. 2007';
+	TEXT TAXON=42 CHARACTER=94 TEXT='Dorsal pseudointerarea with wide, concave median groove and short propareas" - Williams et al 2000';
+	TEXT TAXON=32 CHARACTER=94 TEXT='Present; figured by Topper et al. (2013R), fig. 3j.';
+	TEXT TAXON=36 CHARACTER=94 TEXT='Prominent medial groove (Balthasar 2009T)';
+	TEXT TAXON=51 CHARACTER=94 TEXT='The dorsal pseudointerarea of S. priscus is undivided (Popov et al. 2009), but in other species it is divided by a "wide, poorly defined median groove" (Williams et al. 2000).  Coded, therefore, as polymorphic.^n';
+	TEXT TAXON=31 CHARACTER=94 TEXT='"dorsal pseudointerarea vestigial, divided by median groove" -- Williams et al. 2000';
+	TEXT TAXON=6 CHARACTER=94 TEXT='@Marek1972';
+	TEXT TAXON=7 CHARACTER=94 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=41 CHARACTER=36 TEXT='Baculate vascula media - Balthasar & Butterfield (2009E)';
+	TEXT TAXON=52 CHARACTER=36 TEXT='Preservation not adequate to evaluate (Streng 2016).';
+	TEXT TAXON=46 CHARACTER=36 TEXT='"Poorly resolved" -- Balthasar 2008';
+	TEXT TAXON=33 CHARACTER=36 TEXT='Not reported in Williams et al. 2000.';
+	TEXT TAXON=40 CHARACTER=36 TEXT='Following table 15 in Williams et al. (2000) (for Neocrania).';
+	TEXT TAXON=50 CHARACTER=36 TEXT='Coded uncertain in appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=16 CHARACTER=36 TEXT='Following table 6 in Williams et al. (2000).';
+	TEXT TAXON=26 CHARACTER=36 TEXT='Following Table 6, for Siphonotretidae, in Williams et al. (2000).';
+	TEXT TAXON=39 CHARACTER=36 TEXT='Described as pinnate by Jin & Wang (1992)';
+	TEXT TAXON=43 CHARACTER=36 TEXT='Reported by Zhang et al. (2007A, 2011T) though the interpretation is tentative.';
+	TEXT TAXON=42 CHARACTER=36 TEXT='Following table 6 in Williams et al. (2000).';
+	TEXT TAXON=28 CHARACTER=36 TEXT='Described as pinnate (at least in ventral valve) by Williams et al. (1998T, p. 250).';
+	TEXT TAXON=29 CHARACTER=36 TEXT='Described as saccate by Williams et al. (1998T).';
+	TEXT TAXON=47 CHARACTER=36 TEXT='Following table 15 in Williams et al. (2000).';
+	TEXT TAXON=15 CHARACTER=36 TEXT='Following table 6, for Discinidae, in Williams et al. (2000).';
+	TEXT TAXON=14 CHARACTER=36 TEXT='Following table 15 in Williams et al. (2000) (for Neocrania).';
+	TEXT TAXON=17 CHARACTER=36 TEXT='"In modern terebratulides, the vascula media are subordinate to the lemniscate or pinnate vascula genitalia" -- Williams et al. 1997';
+	TEXT TAXON=30 CHARACTER=36 TEXT='Not reported in Treatise (Williams et al. 2000).';
+	TEXT TAXON=27 CHARACTER=36 TEXT='Following Table 15 in Williams et al. (2000).';
+	TEXT TAXON=48 CHARACTER=36 TEXT='Sacculate (sometimes digitate in dorsal valve) (Williams et al. 2000, p716)';
+	TEXT TAXON=37 CHARACTER=36 TEXT='Williams et al. (2000, table 15) appear to use Palaeotrimerella (as drawn in Williams et al. 1997) as a model for Gasconsia, which pre-supposes a close relationship.  We are not aware of any report of mantle canals from Gasconsia itself.';
+	TEXT TAXON=38 CHARACTER=36 TEXT='Following appendix 2 (char. 21) in Williams et al. (1998T).';
+	TEXT TAXON=32 CHARACTER=36 TEXT='Following Table 8 (for Acrotreta) in Williams et al. (2000), and the general pinnate condition for acrotretoids stated in Williams et al. (1997), p. 420.';
+	TEXT TAXON=34 CHARACTER=36 TEXT='Not reported from fossil material';
+	TEXT TAXON=36 CHARACTER=36 TEXT='Following Williams et al. 1998T, appendix 2, and Williams et al (2000), table 8';
+	TEXT TAXON=51 CHARACTER=36 TEXT='Interpreted as baculate, following Havlicek 1982';
+	TEXT TAXON=31 CHARACTER=36 TEXT='Following Williams et al. 1998T, appendix 2, and Williams et al (2000), table 8';
+	TEXT TAXON=52 CHARACTER=37 TEXT='Preservation not adequate to evaluate (Streng 2016).';
+	TEXT TAXON=40 CHARACTER=37 TEXT='Following table 15 in Williams et al. (2000).';
+	TEXT TAXON=26 CHARACTER=37 TEXT='Following table 8 (which records presence in Siphonotreta) in Williams et al. (2000).';
+	TEXT TAXON=39 CHARACTER=37 TEXT='Present: Williams et al. (2000); Jin & Wang (1992).';
+	TEXT TAXON=43 CHARACTER=37 TEXT='Presence is possible but requires interpretation that is not unambiguous:^n^n"In the dorsal valve, there can be seen two baculate grooves that arise from the^nanterior body wall at an antero-lateral position. These two grooves (Figs 4H, 5D) could be taken to represent the vascula lateralia" -- Zhang et al 2007A';
+	TEXT TAXON=42 CHARACTER=37 TEXT='Present (Williams et al. 2000).';
+	TEXT TAXON=28 CHARACTER=37 TEXT='"Laurie (1987) has shown that arcuate vascula media were present in the mantles of both valves as were pouchlike vascula genitalia, especially in the ventral valve" -- Williams et al. 1997';
+	TEXT TAXON=29 CHARACTER=37 TEXT='"Laurie (1987) has shown that arcuate vascula media were present in the mantles of both valves as were pouchlike vascula genitalia, especially in the ventral valve" -- Williams et al. 1997';
+	TEXT TAXON=47 CHARACTER=37 TEXT='Following table 15 in Williams et al. (2000).';
+	TEXT TAXON=15 CHARACTER=37 TEXT='Following Lochkothele (Discinidae), Fig. 43.4a in Williams et al. (2000).';
+	TEXT TAXON=14 CHARACTER=37 TEXT='Following table 15 in Williams et al. (2000) (for Neocrania), who write that "Holocene craniides have only a single pair of main trunks in both valves, corresponding to the vascula lateralia".  Williams et al. (2007) reiterate this position (p. 2875), at least for the ventral valve.';
+	TEXT TAXON=17 CHARACTER=37 TEXT='= vascula genitalia';
+	TEXT TAXON=27 CHARACTER=37 TEXT='Following table 15 in Williams et al. (2000).';
+	TEXT TAXON=48 CHARACTER=37 TEXT='= vascula genitalia';
+	TEXT TAXON=37 CHARACTER=37 TEXT='Williams et al. (2000, table 15) appear to use Palaeotrimerella (as drawn in Williams et al. 1997) as a model for Gasconsia, which pre-supposes a close relationship.  We are not aware of any report of mantle canals from Gasconsia itself.';
+	TEXT TAXON=32 CHARACTER=37 TEXT='Presence indicated in Table 8 (for Acrotreta) in Williams et al. (2000).';
+	TEXT TAXON=54 CHARACTER=37 TEXT='Based on the figures and sketches in Zhang et al. 2014 (and supplementary material), the mantle canals are interpreted as lateral, with no clear vascula media present.';
+	TEXT TAXON=51 CHARACTER=37 TEXT='Noted in Siphonobolus by Williams et al. (2000), with reference to Havlicek (1982).';
+	TEXT TAXON=31 CHARACTER=37 TEXT='Following Popov (1992)';
+	TEXT TAXON=52 CHARACTER=38 TEXT='Preservation not adequate to evaluate (Streng 2016).';
+	TEXT TAXON=40 CHARACTER=38 TEXT='Following table 15 in Williams et al. (2000).';
+	TEXT TAXON=16 CHARACTER=38 TEXT='Following table 6 in Williams et al. (2000).';
+	TEXT TAXON=26 CHARACTER=38 TEXT='Following table 6 (for Siphonotretidae) in Williams et al. (2000).';
+	TEXT TAXON=39 CHARACTER=38 TEXT='Present: Williams et al. (2000) p162, Jin & Wang (1992).';
+	TEXT TAXON=43 CHARACTER=38 TEXT='Reported by Zhang et al. (2007A) though the interpretation is tentative.';
+	TEXT TAXON=42 CHARACTER=38 TEXT='Following table 6 in Williams et al. (2000).';
+	TEXT TAXON=28 CHARACTER=38 TEXT='Following table 6 (for Paterinidae) in Williams et al. (2000).';
+	TEXT TAXON=29 CHARACTER=38 TEXT='Reported by Williams et al. (1998T).';
+	TEXT TAXON=47 CHARACTER=38 TEXT='Following table 15 in Williams et al. (2000).';
+	TEXT TAXON=15 CHARACTER=38 TEXT='Following table 6 (for Discinidae) in Williams et al. (2000).';
+	TEXT TAXON=14 CHARACTER=38 TEXT='Williams et al. (2000) write "Holocene craniides have only a single pair of main trunks in both valves, corresponding to the vascula lateralia" -- an observation reflected in their table 15 (for Neocrania).  ^nBut in contrast, Williams et al. 2007, p. 2875, identify the dorsal valve''s canals as a vascula media in living cranidds (though both are lateralia in Ordoviian craniides).  This character is therefore coded as ambiguous.';
+	TEXT TAXON=17 CHARACTER=38 TEXT='"In modern terebratulides, the vascula media are subordinate to the lemniscate or pinnate vascula genitalia" -- Williams et al. 1997 p417';
+	TEXT TAXON=27 CHARACTER=38 TEXT='Following table 15 in Williams et al. (2000).';
+	TEXT TAXON=48 CHARACTER=38 TEXT='From idealised morphology in Williams et al. (2000)';
+	TEXT TAXON=37 CHARACTER=38 TEXT='Williams et al. (2000, table 15) appear to use Palaeotrimerella (as drawn in Williams et al. 1997) as a model for Gasconsia, which pre-supposes a close relationship.  We are not aware of any report of mantle canals from Gasconsia itself.';
+	TEXT TAXON=38 CHARACTER=38 TEXT='Present and divergent (Williams et al. 2000).';
+	TEXT TAXON=32 CHARACTER=38 TEXT='Following Hadrotreta schematic in Williams et al. (2000).';
+	TEXT TAXON=54 CHARACTER=38 TEXT='Based on the figures and sketches in Zhang et al. 2014 (and supplementary material), the mantle canals are interpreted as lateral, with no clear vascula media present.';
+	TEXT TAXON=36 CHARACTER=38 TEXT='Fig. 5 in Balthasar 2009T.';
+	TEXT TAXON=51 CHARACTER=38 TEXT='Noted in Siphonobolus by Havlicek (1982).';
+	TEXT TAXON=31 CHARACTER=38 TEXT='Following Popov (1992, fig. 2)';
+	TEXT TAXON=41 CHARACTER=39 TEXT='Strong indication of medially directed vascula terminalia from vascula lateralia; see fig. 1.A1 in Balthasar & Butterfield 2009E';
+	TEXT TAXON=40 CHARACTER=39 TEXT='Coded uncertain in appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=50 CHARACTER=39 TEXT='Coded uncertain in appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=16 CHARACTER=39 TEXT='Peripheral and medial for all Lingulata (Williams et al. 2000).';
+	TEXT TAXON=26 CHARACTER=39 TEXT='Preservation not clear enough to score with certainty (Holmer & Caron 2006)';
+	TEXT TAXON=39 CHARACTER=39 TEXT='Inferred from Jin & Wang (1992).';
+	TEXT TAXON=42 CHARACTER=39 TEXT='Not described in Williams et al. (2000)';
+	TEXT TAXON=28 CHARACTER=39 TEXT='Peripheral only (Williams et al. 1998T; Williams et al. 2000).';
+	TEXT TAXON=29 CHARACTER=39 TEXT='Peripheral only (Williams et al. 1998T; Williams et al. 2000).';
+	TEXT TAXON=15 CHARACTER=39 TEXT='Following Lochkothele (Discinidae), fig. 43.4a in Williams et al. (2000).';
+	TEXT TAXON=14 CHARACTER=39 TEXT='Peripheral only (Williams et al. 2000, p.158).';
+	TEXT TAXON=17 CHARACTER=39 TEXT='Following idealised plectolophous terebratulid of Emig (1992).';
+	TEXT TAXON=27 CHARACTER=39 TEXT='Interomedial vascula terminalia not reported by Williams et al. (2000).';
+	TEXT TAXON=48 CHARACTER=39 TEXT='See schematics in Williams et al. (2000)';
+	TEXT TAXON=38 CHARACTER=39 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=36 CHARACTER=39 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=51 CHARACTER=39 TEXT='Not reported in Havlicek 1982 or Williams et al. 2000.';
+	TEXT TAXON=31 CHARACTER=39 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=40 CHARACTER=74 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=50 CHARACTER=74 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=28 CHARACTER=74 TEXT='Coded as rectimarginate in @Williams1998Thediversity, though note that the "ventral valve weakly to moderately sulcate" (Topper et al. 2013T); a similar description is provided by Williams et al. (2000).  Coded as ambiguous for these two states accordingly.';
+	TEXT TAXON=29 CHARACTER=74 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=17 CHARACTER=74 TEXT='"Anterior commissure rectimarginate to uniplicate" -- uniplicate in fig. 1425.1c of Williams et al. (2006).';
+	TEXT TAXON=38 CHARACTER=74 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=40 CHARACTER=131 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=50 CHARACTER=131 TEXT='Coded as uncertain in appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=28 CHARACTER=131 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=29 CHARACTER=131 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=15 CHARACTER=131 TEXT='Flexible (Williams et al. 1998T)';
+	TEXT TAXON=38 CHARACTER=131 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=36 CHARACTER=131 TEXT='Coded as flexible in Williams et al. 1998T, Appendix 2';
+	TEXT TAXON=31 CHARACTER=131 TEXT='Coded as flexible in Williams et al. 1998T, Appendix 2';
+	TEXT TAXON=9 CHARACTER=124 TEXT='A series of regularly spaced concentric ridges adorn the ventral valve; comparatively less regular lines ornament the operculum.';
+	TEXT TAXON=35 CHARACTER=124 TEXT='More or less concentric ridges occur on Eccentrotheca sclerites (Skovsted et al. 2011)';
+	TEXT TAXON=5 CHARACTER=124 TEXT='A series of regularly spaced concentric ridges adorn both valves (Moysiuk et al. 2017); these are more pronounced than mere growth lines.';
+	TEXT TAXON=40 CHARACTER=124 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=50 CHARACTER=124 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=39 CHARACTER=124 TEXT='The ornament on shell exterior is described as concentric fila (Chen et al., 2007, P.43), and also scored as it in Williams et al. (2000, pp.160-163).';
+	TEXT TAXON=28 CHARACTER=124 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=29 CHARACTER=124 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=15 CHARACTER=124 TEXT='Only growth lines evident (Williams et al. 2000)';
+	TEXT TAXON=14 CHARACTER=124 TEXT='Irregular ridges externally (Williams et al. 2000)';
+	TEXT TAXON=17 CHARACTER=124 TEXT='Single ridge evident in Williams et al. (2006) fig. 1425.1a interpreted as interruption ot growth rather than inherent feature, so coded as absent (i.e. smooth).';
+	TEXT TAXON=38 CHARACTER=124 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=45 CHARACTER=124 TEXT='Symmetric fila';
+	TEXT TAXON=31 CHARACTER=124 TEXT='Following Williams et al. 1998T, appendix 2.^nPustules are arranged along concentric growth lines (Skovsted & Holmer, 2005), so are not treated as a distinct ornamentation.';
+	TEXT TAXON=10 CHARACTER=124 TEXT='@Zhang2013';
+	TEXT TAXON=24 CHARACTER=124 TEXT='Ridges in shell parallel, but are more prominent than, growth lines.';
+	TEXT TAXON=21 CHARACTER=124 TEXT='No prominent ornamentat in Tonicella [@Connors2012]';
+	TEXT TAXON=4 CHARACTER=124 TEXT='Both valves covered with concentric growth lines [@Devaere2014], but no further ornament [@Wrona2003]';
+	TEXT TAXON=6 CHARACTER=124 TEXT='Surfaces of both valves covered with concentric growth lines [@Marek1972;@MartiMus2005]';
+	TEXT TAXON=8 CHARACTER=124 TEXT='Ventral side of ventral valve and whole dorsal valve covered with faint growth lines [@Valent2015].';
+	TEXT TAXON=3 CHARACTER=124 TEXT='Both valves with fine growth lines only [@Valent2012].';
+	TEXT TAXON=2 CHARACTER=124 TEXT='Broad symmetric ridges in some specimens [@Vendrasco2017]';
+	TEXT TAXON=44 CHARACTER=125 TEXT='No obvious asymmetry, even if not obviously symmetric either (Holmer et al. 2008).  Coded as ambiguous.';
+	TEXT TAXON=35 CHARACTER=125 TEXT='Ornament, such as it is, is asymmetric, with prominent outer faces (Skovsted et al. 2011).';
+	TEXT TAXON=40 CHARACTER=125 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=50 CHARACTER=125 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=25 CHARACTER=125 TEXT='Clear asymmetry (Skovsted et al. 2015).';
+	TEXT TAXON=39 CHARACTER=125 TEXT='See fig. 1715 in Williams et al. (2007)';
+	TEXT TAXON=28 CHARACTER=125 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=29 CHARACTER=125 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=14 CHARACTER=125 TEXT='Clear outer faces (Williams et al. 2000, fig. 100.2b)';
+	TEXT TAXON=27 CHARACTER=125 TEXT='Seemingly asymmetric (Williams et al. 2000, fig. 122.3c; Zhang et al. 2011A, Fig. 1)';
+	TEXT TAXON=37 CHARACTER=125 TEXT='Assymmetric [@Hanken1985Thetaxonomy, fig. 3]';
+	TEXT TAXON=38 CHARACTER=125 TEXT='Following appendix 2 in Williams et al. (1998T).';
+	TEXT TAXON=45 CHARACTER=125 TEXT='Symmetric fila (Balthasar 2004)';
+	TEXT TAXON=33 CHARACTER=121 TEXT='Bassett and Popov write "a dominant feature of the ventral umbo is a sub-oval perforation about 270 um long and 250 um wide": the width and height of this structure are almost identical, and we score it as (sub) circular.';
+	TEXT TAXON=40 CHARACTER=121 TEXT='The exact size and shape of the apical perforation is obscured by the emerging pedicle';
+	TEXT TAXON=50 CHARACTER=121 TEXT='Essentially circular (Holmer et al. 2009, fig. 4)';
+	TEXT TAXON=26 CHARACTER=121 TEXT='Too small to observe given quality of preservation (Holmer & Caron 2006)';
+	TEXT TAXON=39 CHARACTER=121 TEXT='Rhombic to oval -- seen as evidence for a discinid affinity (Chen et al. 2007)';
+	TEXT TAXON=47 CHARACTER=121 TEXT='"close to circular" (Holmer et al. 2018E)';
+	TEXT TAXON=30 CHARACTER=121 TEXT='Based on p.92, fig.4B.';
+	TEXT TAXON=27 CHARACTER=121 TEXT='Seemingly circular (Zhang et al. 2011A).';
+	TEXT TAXON=32 CHARACTER=121 TEXT='Taller than wide in some cases, but very nearly circular in others; see Topper et al. (2013R)';
+	TEXT TAXON=5 CHARACTER=123 TEXT='The carina of  H. carinatus is an angular elevation of the ventral valve surface, rather than a septum growing inward on the interior of shell.';
+	TEXT TAXON=46 CHARACTER=123 TEXT='"Some specimens also reveal that the vault had a slight median septum, which is now visible as a notch or a groove dividing the right from the left part" -- Balthasar 2008';
+	TEXT TAXON=26 CHARACTER=123 TEXT='Carbonaceous preservation confounds the identification of internal shell structures; it is possible that this feature is present, but not observable in the Burgess Shale material.';
+	TEXT TAXON=39 CHARACTER=123 TEXT='Reported on ''ventral'' valve by Chen et al. (2007); we consider the ''ventral'' valve to be the dorsal valve.';
+	TEXT TAXON=42 CHARACTER=123 TEXT='Medial septum visible in ventral valve in Williams et al. (2000), fig. 34.1c';
+	TEXT TAXON=29 CHARACTER=123 TEXT='Ventral ridge characteristic of Micromitra (Skovsted & Peel 2010)';
+	TEXT TAXON=15 CHARACTER=123 TEXT='Described as present in Discinisca by Chen et al. 2007; assumed present also in Pelagodiscus.';
+	TEXT TAXON=14 CHARACTER=123 TEXT='Valve thin and often unmineralized.';
+	TEXT TAXON=37 CHARACTER=123 TEXT='Evident in moulds of ventral valve [@Hanken1985Thetaxonomy;@Watkins2002Newrecord].';
+	TEXT TAXON=38 CHARACTER=123 TEXT='Neither evident nor reported in Williams et al. (2000).';
+	TEXT TAXON=32 CHARACTER=123 TEXT='A short medial ridge (septum) is present in the ventral valve (Topper et al. 2013R).';
+	TEXT TAXON=53 CHARACTER=123 TEXT='Following char. 42 in table 15 in Williams et al. 2000';
+	TEXT TAXON=36 CHARACTER=123 TEXT='Prominent median septum (fig. 4d, e in Balthasar 2009T)';
+	TEXT TAXON=51 CHARACTER=123 TEXT='Present; see Popov et al. 2009, fig. 5J';
+	TEXT TAXON=31 CHARACTER=123 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=39 CHARACTER=127 TEXT='The ''spines'' reported by Chen et al. (2007) are pyritized spinelike setae -- see pp. 2580-2590 in Williams et al. (2007).';
+	TEXT TAXON=47 CHARACTER=127 TEXT='Bears numerous small, hollow spines (Williams et al. 2000)';
+	TEXT TAXON=38 CHARACTER=127 TEXT='Neither evident nor reported in Williams et al. (2000).';
+	TEXT TAXON=21 CHARACTER=127 TEXT='Aesthete canals penetrate the main valves of certain chitons, but are not equivalent to the shell-penetrating spines of brachiopods.';
+	TEXT TAXON=41 CHARACTER=99 TEXT='It is not possible to determine, based on the material presented in Balthasar & Butterfield (2009E), whether the anterior projection of the visceral area in the dorsal valve corresponds to a medial septum in the underlying shell.';
+	TEXT TAXON=46 CHARACTER=99 TEXT='See pl. 2 panel 6 in Balthasar (2008).';
+	TEXT TAXON=40 CHARACTER=99 TEXT='Absent - fig. 129.1f in Williams et al. (2000)';
+	TEXT TAXON=26 CHARACTER=99 TEXT='Not described by Holmer & Caron (2006), but an unannotated linear feature corresponds to the position of a median septum.  Without detailed study of the specimen, we opt to score this as ambiguous.';
+	TEXT TAXON=39 CHARACTER=99 TEXT='Reported on ''ventral'' valve by Chen et al. (2007); we consider their ''ventral'' valve to be the dorsal valve.  ^n^nThe structure is unambiguously figured (e.g. fig. 5.1 in Chen et al. 2007), contra its coding as absent in Williams et al. 2000 and its lack of mention in Williams et al. 2007 or Zhang et al. 2009.^n^n';
+	TEXT TAXON=42 CHARACTER=99 TEXT='Very weakly developed but seemingly present between muscle scars in Lingulellotreta, more prominent in Aboriginella (also Lingulellotretidae) (Williams et al. 2000, fig. 34).';
+	TEXT TAXON=47 CHARACTER=99 TEXT='Fig. 125 in Williams et al. (2000)';
+	TEXT TAXON=14 CHARACTER=99 TEXT='Median process evident: Williams et al. (2000) fig. 100.2a, d';
+	TEXT TAXON=30 CHARACTER=99 TEXT='Weakly developed septum evident in internal cast: Williams et al. 2000, fig. 508.2e';
+	TEXT TAXON=48 CHARACTER=99 TEXT='Short medial process ("low median ridge", p. 724) present in dorsal valve; see Fig. 523.3b in Williams et al. (2000)^n';
+	TEXT TAXON=38 CHARACTER=99 TEXT='Neither evident nor reported in Williams et al. (2000).';
+	TEXT TAXON=32 CHARACTER=99 TEXT='Prominent process evident (Topper et al., 2013R)';
+	TEXT TAXON=53 CHARACTER=99 TEXT='Following char 42 in table 15 in Williams et al. 2000';
+	TEXT TAXON=36 CHARACTER=99 TEXT='A "median projection" is present (fig. 4g in Balthasar 2009T)';
+	TEXT TAXON=51 CHARACTER=99 TEXT='"Dorsal interior [...] bisected by a short median ridge." -- Popov et al. 2009';
+	TEXT TAXON=31 CHARACTER=99 TEXT='"dorsal interior with narrow anterior projection extending to midvalve, bisected by median ridge" -- Williams et al. 2000';
+	TEXT TAXON=8 CHARACTER=99 TEXT='@Marek1966';
+	TEXT TAXON=7 CHARACTER=99 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=39 CHARACTER=126 TEXT='See fig. 1715 in Williams et al. (2007)';
+	TEXT TAXON=28 CHARACTER=126 TEXT='"Ornament of irregularly developed, concentric growth lamellae; microornament of irregularly arranged, polygonal pits" -- Williams et al. 2000, p153; figs on p.155';
+	TEXT TAXON=37 CHARACTER=126 TEXT='"Ornament of indistinct low radial ribs" -- Williams et al. (2000, p167)';
+	TEXT TAXON=38 CHARACTER=126 TEXT='"Coarsely costate" - Williams et al. (2000, p710)';
+	TEXT TAXON=53 CHARACTER=126 TEXT='Unornamented.';
+	TEXT TAXON=36 CHARACTER=126 TEXT='Very faint costellae in some specimens but coded absent.';
+	TEXT TAXON=51 CHARACTER=126 TEXT='"Indistinct radial ribs accentuated by radial rows of tubercles" -- Popov et al. 2009';
+	TEXT TAXON=31 CHARACTER=126 TEXT='Following Williams et al. 1998T, Appendix 2';
+	TEXT TAXON=6 CHARACTER=126 TEXT='Lines radiate from the apex of the operculum [@Marek1972, pl.2 fig. 5] and ornament the conical valve [@Marek1972, pl. 2. fig. 3]';
+	TEXT TAXON=7 CHARACTER=126 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=52 CHARACTER=87 TEXT='Though Williams et al. (2000, p. 32) state that these muscles are absent in all carbonate-shelled brachiopods, their existence cannot be discounted with certainty in this taxon, which is therefore coded not presently available.';
+	TEXT TAXON=46 CHARACTER=87 TEXT='Though Williams et al. (2000, p. 32) state that these muscles are absent in all carbonate-shelled brachiopods, their existence cannot be discounted with certainty in this taxon, which is therefore coded not presently available.';
+	TEXT TAXON=33 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate-shelled brachiopods.';
+	TEXT TAXON=40 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate- shelled brachiopods, and the coding for kutorginids in Zhang et al. (2014).';
+	TEXT TAXON=50 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate- shelled brachiopods.';
+	TEXT TAXON=28 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that the presence of these muscles in paterinates is uncertain';
+	TEXT TAXON=29 CHARACTER=87 TEXT='Williams et al. (2000, p. 32) are uncertain about the presence of these muscles in the paterinates.  Zhang et al. (2014) code absence in Paterinida, but without specifying evidence; we follow their coding here.';
+	TEXT TAXON=47 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate- shelled brachiopods.';
+	TEXT TAXON=15 CHARACTER=87 TEXT='Musculature considered essentially equivalent to Lingula by Williams et al 2000, so Lingula coding followed here.';
+	TEXT TAXON=14 CHARACTER=87 TEXT='Following Zhang et al. (2014), and the statement of Williams et al. (2000) that such muscles are absent in all calcite-shelled brachiopods.';
+	TEXT TAXON=17 CHARACTER=87 TEXT='Williams et al. (2000, p. 32) state that these muscles are absent in all carbonate-shelled brachiopods.';
+	TEXT TAXON=30 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate- shelled brachiopods.';
+	TEXT TAXON=27 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate- shelled brachiopods.';
+	TEXT TAXON=48 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate- shelled brachiopods.';
+	TEXT TAXON=37 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate- shelled brachiopods.';
+	TEXT TAXON=38 CHARACTER=87 TEXT='According to the statement of Williams et al. (2000, p. 32) that these muscle are absent in all carbonate- shelled brachiopods.';
+	TEXT TAXON=32 CHARACTER=87 TEXT='This character is coded based on the score of Acrotreta in Zhang et al. (2014), and statement in Williams et al. (2000, P.32).';
+	TEXT TAXON=36 CHARACTER=87 TEXT='Not remarked upon by Balthasar (2009T).';
+	TEXT TAXON=51 CHARACTER=87 TEXT='Ventral musculature poorly constrained (Williams et al. 2000; Popov et al. 2009)';
+	TEXT TAXON=31 CHARACTER=87 TEXT='Implicitly taken as present in Popov (1992), though not marked in diagrams -- suggesting not strongly developed.';
+	TEXT TAXON=18 CHARACTER=147 TEXT='Phoronis has planktotrophic larvae. indicating a small egg size (Ruppert et al. 2004).  Carlson (1995) codes phoronids as polymorphic, as some members of the phylum have eggs of each size.';
+	TEXT TAXON=16 CHARACTER=147 TEXT='Following coding for class in Carlson (1995) appendix 1, character 7.';
+	TEXT TAXON=15 CHARACTER=147 TEXT='Following coding for class in Carlson (1995) appendix 1, character 7.';
+	TEXT TAXON=14 CHARACTER=147 TEXT='Following coding for class in Carlson (1995) appendix 1, character 7.';
+	TEXT TAXON=17 CHARACTER=147 TEXT='Following coding for class in Carlson (1995) appendix 1, character 7.';
+	TEXT TAXON=51 CHARACTER=147 TEXT='"the ventral brephic valve [was] 50 um across, [which] is close to the known lower limit of the brachiopod egg size" -- Popov et al. 2009';
+	TEXT TAXON=11 CHARACTER=147 TEXT='Tiny [@Nielsen1966]';
+	TEXT TAXON=12 CHARACTER=147 TEXT='"Mature eggs commonly measure about 200 um in diameter" -- @Franzen1977';
+	TEXT TAXON=19 CHARACTER=147 TEXT='c. 200 um in diameter [@Rice1988]';
+	TEXT TAXON=21 CHARACTER=147 TEXT='@BucklandNicks1988';
+	TEXT TAXON=22 CHARACTER=147 TEXT='Egg size can vary from 60-200 um in scaphopods, but in Dentalium the eggs are large [@DufresneDube1983].';
+	TEXT TAXON=20 CHARACTER=147 TEXT='c. 50 um in Hydroides [@Miles2007]';
+	TEXT TAXON=13 CHARACTER=147 TEXT='"Mature eggs commonly measure about 200 um in diameter" [@Franzen1977]; the larva is a similar size [@Reed1982]';
+	TEXT TAXON=18 CHARACTER=149 TEXT='Following coding for class in Carlson (1995) Appendix 1, character 9.';
+	TEXT TAXON=16 CHARACTER=149 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=15 CHARACTER=149 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=14 CHARACTER=149 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=17 CHARACTER=149 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=12 CHARACTER=149 TEXT='Ovicell [@Franzen1977]';
+	TEXT TAXON=13 CHARACTER=149 TEXT='Ovicell [@Franzen1977]';
+	TEXT TAXON=41 CHARACTER=42 TEXT='Preservation inadequate.';
+	TEXT TAXON=18 CHARACTER=42 TEXT='Following coding for higher group in Carlson 1995, appendix 1, character 36.';
+	TEXT TAXON=40 CHARACTER=42 TEXT='Tentacles "cannot be confidently demonstrated in the available specimens." -- Zhang et al. 2007R';
+	TEXT TAXON=16 CHARACTER=42 TEXT='Following coding for higher group in Carlson 1995, appendix 1, character 36.';
+	TEXT TAXON=26 CHARACTER=42 TEXT='Preservation insufficient to evaluate (Holmer & Caron 2006)';
+	TEXT TAXON=39 CHARACTER=42 TEXT='"Each lophophoral arm bears a row of long, slender flexible tentacles" -- Zhang et al. 2009';
+	TEXT TAXON=43 CHARACTER=42 TEXT='Preservation inadequate.';
+	TEXT TAXON=42 CHARACTER=42 TEXT='"The tentacles are clearly visible, and closely arranged in a single palisade" -- Zhang et al. 2004N^n^n';
+	TEXT TAXON=15 CHARACTER=42 TEXT='Following coding for higher group in Carlson 1995, appendix 1, character 36.';
+	TEXT TAXON=14 CHARACTER=42 TEXT='Following coding for higher group in Carlson 1995, appendix 1, character 36.';
+	TEXT TAXON=17 CHARACTER=42 TEXT='Following coding for higher group in Carlson 1995, appendix 1, character 36.';
+	TEXT TAXON=27 CHARACTER=42 TEXT='Preservation inadequate.';
+	TEXT TAXON=10 CHARACTER=42 TEXT='Tentacles seemingly occupy a single side of the lophophore [@Zhang2013]';
+	TEXT TAXON=11 CHARACTER=42 TEXT='Single side [@Nielsen1966]';
+	TEXT TAXON=12 CHARACTER=42 TEXT='Both sides [@Schwaha2015;@Shunkina2015]';
+	TEXT TAXON=19 CHARACTER=42 TEXT='Both sides in tentacle-breathers such as Themiste [@Ruppert1995;@Adrianov2006]; only one side in Sipunculus [@Ruppert1995;@Adrianov2006].';
+	TEXT TAXON=22 CHARACTER=42 TEXT='On rim of basal lobe only [@Morton1959]';
+	TEXT TAXON=13 CHARACTER=42 TEXT='Single side [@Temereva2016Thenervous]';
+	TEXT TAXON=18 CHARACTER=43 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=16 CHARACTER=43 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=15 CHARACTER=43 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=14 CHARACTER=43 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.  Also states in Williams et al. 2000, p. 158.';
+	TEXT TAXON=17 CHARACTER=43 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=11 CHARACTER=43 TEXT='Inapplicable';
+	TEXT TAXON=12 CHARACTER=43 TEXT='Inapplicable';
+	TEXT TAXON=13 CHARACTER=43 TEXT='[@Temereva2016Thenervous]';
+	TEXT TAXON=41 CHARACTER=44 TEXT='Preservation insufficient to evaluate';
+	TEXT TAXON=18 CHARACTER=44 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=40 CHARACTER=44 TEXT='Tentacles "cannot be confidently demonstrated in the available specimens." -- Zhang et al. 2007R';
+	TEXT TAXON=16 CHARACTER=44 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=26 CHARACTER=44 TEXT='Preservation insufficient to evaluate (Holmer & Caron 2006)';
+	TEXT TAXON=39 CHARACTER=44 TEXT='"The lophophoral arms bear laterofrontal tentacles with a double row of cilia along their lateral edge, as in extant lingulid brachiopods" -- Zhang et al. 2009';
+	TEXT TAXON=42 CHARACTER=44 TEXT='Single palisade (Zhang et al. 2004N)';
+	TEXT TAXON=15 CHARACTER=44 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=14 CHARACTER=44 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=17 CHARACTER=44 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 37.';
+	TEXT TAXON=54 CHARACTER=44 TEXT='"helical lophophore fringed with a single row of thick, widely spaced, parallel-sided and hollow tentacles" -- Zhang et al. 2014';
+	TEXT TAXON=10 CHARACTER=44 TEXT='Additional row not evident [@Zhang2013]';
+	TEXT TAXON=11 CHARACTER=44 TEXT='@Nielsen1966';
+	TEXT TAXON=13 CHARACTER=44 TEXT='[@Temereva2016Thenervous]';
+	TEXT TAXON=9 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=44 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=49 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=1 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=35 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=5 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=41 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=52 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=46 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=33 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=40 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=50 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=25 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=26 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=39 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=43 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=42 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=28 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=29 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=47 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=30 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=27 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=48 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=37 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=38 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=32 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=54 CHARACTER=45 TEXT='Lophophore ontogeny presently unknown.';
+	TEXT TAXON=11 CHARACTER=45 TEXT='@Nielsen1966';
+	TEXT TAXON=9 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=44 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=49 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=1 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=35 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=5 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=41 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=18 CHARACTER=53 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 55.';
+	TEXT TAXON=52 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=46 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=33 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=40 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=50 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=25 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=16 CHARACTER=53 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 55.';
+	TEXT TAXON=26 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=39 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=43 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=42 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=28 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=29 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=47 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=15 CHARACTER=53 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 55.';
+	TEXT TAXON=14 CHARACTER=53 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 55.';
+	TEXT TAXON=17 CHARACTER=53 TEXT='Following coding for higher taxon in Carlson (1995), appendix 1, character 55.';
+	TEXT TAXON=30 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=27 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=48 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=37 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=38 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=32 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=54 CHARACTER=53 TEXT='Preservation not adequate to evaluate presence or absence of this muscle.';
+	TEXT TAXON=18 CHARACTER=52 TEXT='Coiling in direction of anus (i.e. posteriad)';
+	TEXT TAXON=26 CHARACTER=52 TEXT='Arms proceed anteriad before recurving.';
+	TEXT TAXON=42 CHARACTER=52 TEXT='Arms proceed anteriad before recurving.';
+	TEXT TAXON=15 CHARACTER=52 TEXT='"converging anteriorly and coiling anterior to the body cavity" -- Zhang et al. 2009';
+	TEXT TAXON=10 CHARACTER=52 TEXT='Cannot establish without distinguishing gut from anus';
+	TEXT TAXON=11 CHARACTER=52 TEXT='Posterior (anal side) of lophophore has short stretch lacking tentacles.';
+	TEXT TAXON=12 CHARACTER=52 TEXT='Bryozoan arms reach in anal (i.e. posterior) direction [@Shunkina2015]';
+	TEXT TAXON=13 CHARACTER=52 TEXT='Bryozoan arms reach in anal (i.e. posterior) direction [@Shunkina2015]';
+	TEXT TAXON=43 CHARACTER=95 TEXT='No evidence or report of an opening at the hinge line in fossil material in Zhang et al. 2007A or Zhang et al. 2011T';
+	TEXT TAXON=31 CHARACTER=95 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=21 CHARACTER=95 TEXT='The deep V-shaped notch [@Schwabe2010, fig. 8] is positionally equivalent to the brachiopod notothyrium.';
+	TEXT TAXON=6 CHARACTER=95 TEXT='@Marek1972';
+	TEXT TAXON=7 CHARACTER=95 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=40 CHARACTER=83 TEXT='Following situation in Nisusia; see fig. 18.2 in Bassett et al. (2001)';
+	TEXT TAXON=50 CHARACTER=83 TEXT='Ventral musculature not clearly constrained (Holmer et al. 2009T)';
+	TEXT TAXON=26 CHARACTER=83 TEXT='"Individual muscle scars cannot be distinguished" -- Holmer & Caron 2006';
+	TEXT TAXON=42 CHARACTER=83 TEXT='See fig. 5 in Holmer et al. 1997E';
+	TEXT TAXON=28 CHARACTER=83 TEXT='Restricted to medial field, following the interpretation of the musculature presented by Williams et al. (2000), fig. 81.';
+	TEXT TAXON=29 CHARACTER=83 TEXT='Posteriomedial muscle field (Williams et al. 1998T, text-fig. 6) treated as equivalent to posterolateral muscles.';
+	TEXT TAXON=47 CHARACTER=83 TEXT='Posterolateral diductors (fig. 18.2 in Bassett et al. 2001)';
+	TEXT TAXON=15 CHARACTER=83 TEXT='Inapplicable as vascular system not directly equivalent to the canonical; see. fig 6b in Balthasar (2009T).';
+	TEXT TAXON=14 CHARACTER=83 TEXT='Posterior adductor muscles attach posterolaterally to ventral mantle canal (Robinson 2014)';
+	TEXT TAXON=27 CHARACTER=83 TEXT='Following reconstruction of Gorjansky & Popov (1986)';
+	TEXT TAXON=48 CHARACTER=83 TEXT='Not applicable: vascula lateralia not comparable to those of other taxa.';
+	TEXT TAXON=37 CHARACTER=83 TEXT='Musculature described in Hanken & Harper (1985), but location of mantle canals unknown';
+	TEXT TAXON=38 CHARACTER=83 TEXT='Posterolateral reflected by diductor attachments; see fig. 18.3.2 in Bassett et al. 2001.';
+	TEXT TAXON=32 CHARACTER=83 TEXT='Coded following Hadrotreta, as illustrated in Popov (1992)';
+	TEXT TAXON=34 CHARACTER=83 TEXT='See fig. 89 in Williams et al. (2000).';
+	TEXT TAXON=53 CHARACTER=83 TEXT='Internal anatomy not adequately preserved to evaluate [@Nikitin1984]';
+	TEXT TAXON=36 CHARACTER=83 TEXT='The ''laterals'' of Balthasar (2009T, fig. 5) are situated almost upon the vascula lateralia; they are interpreted as sitting posterolateral to them.';
+	TEXT TAXON=51 CHARACTER=83 TEXT='Coded following general siphonotretid condition described by Popov (1992, p. 407)';
+	TEXT TAXON=44 CHARACTER=4 TEXT='Smooth (Holmer et al. 2011F)';
+	TEXT TAXON=49 CHARACTER=4 TEXT='Polygonal texture present (Holmer et al. 2011F), as in the adult shell.';
+	TEXT TAXON=50 CHARACTER=4 TEXT='Smooth (Holmer et al. 2009T)';
+	TEXT TAXON=16 CHARACTER=4 TEXT='Smooth, following family-level codings of Williams et al. 2000, table 6';
+	TEXT TAXON=42 CHARACTER=4 TEXT='Smooth [@Holmer1997EarlyCambrian;@Li2004]';
+	TEXT TAXON=28 CHARACTER=4 TEXT='Indented with hexagonal pits (Williams et al. 1998T, appendix 2)';
+	TEXT TAXON=29 CHARACTER=4 TEXT='Pustolose in Paterinidae (Williams et al. 2000, table 6)';
+	TEXT TAXON=15 CHARACTER=4 TEXT='Smooth, following family-level codings of Williams et al. 2000, table 6';
+	TEXT TAXON=32 CHARACTER=4 TEXT='"Larval shells on both valves [...] are covered by fine, shallow pits" -- Topper et al. 2013R';
+	TEXT TAXON=36 CHARACTER=4 TEXT='Pitted (Williams et al. 2000, table 8)';
+	TEXT TAXON=51 CHARACTER=4 TEXT='"Smooth brephic shell" -- Popov et al. 2009';
+	TEXT TAXON=4 CHARACTER=4 TEXT='[@Wrona2003]';
+	TEXT TAXON=8 CHARACTER=4 TEXT='Essentially smooth in Recilites (Pauxillitidae) [@Dzik1978]';
+	TEXT TAXON=2 CHARACTER=4 TEXT='Perfectly smooth [@Skovsted2016]';
+	TEXT TAXON=46 CHARACTER=34 TEXT='Balthasar (2008, p. 274) identifies a canal as a probable impression of a pedicle nerve.';
+	TEXT TAXON=40 CHARACTER=34 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=50 CHARACTER=34 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=16 CHARACTER=34 TEXT='Present in many lingulids (Williams et al. 2000), and coded as present in Lingulidae (Williams et al. 2000, table 6).';
+	TEXT TAXON=42 CHARACTER=34 TEXT='Coded as present in Lingulellotretidae (Williams et al. 2000, table 6)';
+	TEXT TAXON=28 CHARACTER=34 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=29 CHARACTER=34 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=47 CHARACTER=34 TEXT='Not reported in Williams et al. 2000';
+	TEXT TAXON=15 CHARACTER=34 TEXT='Coded as present in Discinidae (Williams et al. 2000, table 6)';
+	TEXT TAXON=27 CHARACTER=34 TEXT='Not described by Williams et al. 2000';
+	TEXT TAXON=48 CHARACTER=34 TEXT='Not reported in Williams et al. 2000';
+	TEXT TAXON=38 CHARACTER=34 TEXT='Following Williams et al. 1998T, appendix 2';
+	TEXT TAXON=32 CHARACTER=34 TEXT='Coded as absent in Acrotretidae (Williams et al. 2000, table 6)';
+	TEXT TAXON=51 CHARACTER=34 TEXT='Coded as absent in Siphonotretidae (Williams et al. 2000, table 6)';
+	TEXT TAXON=31 CHARACTER=34 TEXT='Documented by Skovsted et al. 2017';
+	TEXT TAXON=42 CHARACTER=114 TEXT='Oval (Williams et al. 2000)';
+	TEXT TAXON=45 CHARACTER=114 TEXT='Wider than long: see fig. 10 in Balthasar 2004.';
+	TEXT TAXON=49 CHARACTER=68 TEXT='L-sclerites (Skovsted et al. 2009T)';
+	TEXT TAXON=21 CHARACTER=68 TEXT='The intermediate shell plates arise by subdivision of the posterior shell field  [@Wanninger2002C], and are thus treated as equivalent to the posterior valve rather than as distinct elements.^nThe girdle elements are homologous with annelid chaetae / brachiopod setae [@Leise1982], rather than sclerites.';
+	TEXT TAXON=22 CHARACTER=68 TEXT='The scaphopod valve arises posterior of the prototroch and is thus homologous with the posterior valves of Chiton, assuming that molluscan shell fields are homologous features.';
+	TEXT TAXON=4 CHARACTER=68 TEXT='[Reference needed: not found, but does this necessarily mean that they were absent?]';
+	TEXT TAXON=8 CHARACTER=68 TEXT='Not found by @Valent2015 or @Marek1966, but reconstructed as present by @Marek1976.';
+	TEXT TAXON=7 CHARACTER=68 TEXT='Helens absent, with no possible insertion point [@Zhang2018Ahyolithid]';
+	TEXT TAXON=2 CHARACTER=68 TEXT='Helens never observed and considered absent [@Skovsted2016]';
+	TEXT TAXON=21 CHARACTER=67 TEXT='As larvae, polyplacophorans exhibit an anterior and a posterior shell field  [@Wanninger2002C]; subsequent subdivision of the posterior field gives rise to the posterior seven valves. Tonicella is thus tentatively coded as ''bivalved'' to reflect the potential (if perhaps unlikely) homology with the paired elements of brachiopods.';
+	TEXT TAXON=18 CHARACTER=153 TEXT='Acrosome-like structure; no internal division or surrounding membrane, with possibility that much of the acrosome is secondarily lost (Reunov & Klepal 2004).';
+	TEXT TAXON=16 CHARACTER=153 TEXT='Clear differentiation of marginal area (Fukumoto 2003)';
+	TEXT TAXON=15 CHARACTER=153 TEXT='Following Discinisca tenuis, described in Hodgson & Reunov (1994).';
+	TEXT TAXON=14 CHARACTER=153 TEXT='"Along the inner and outer margins there are periodically banded layers, and between them there is a less dense layer" -- Afzelius & Ferraguti, 1978';
+	TEXT TAXON=17 CHARACTER=153 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=11 CHARACTER=153 TEXT='Not evident in Loxosoma [@Franzen2000]';
+	TEXT TAXON=12 CHARACTER=153 TEXT='No evidence of internal differentiation [in Tubulipora; @Franzen1984]';
+	TEXT TAXON=19 CHARACTER=153 TEXT='No differentiation within acrosomal vesicle [@Rice1993]';
+	TEXT TAXON=21 CHARACTER=153 TEXT='"One can distinguish two components in the acrosome, an apical and a basal granule" -- @BucklandNicks1988';
+	TEXT TAXON=22 CHARACTER=153 TEXT='Differentiated membrane only [@DufresneDube1983]';
+	TEXT TAXON=20 CHARACTER=153 TEXT='@Gherardi2011';
+	TEXT TAXON=13 CHARACTER=153 TEXT='No evidence of internal differentiation [in Tubulipora; @Franzen1984]';
+	TEXT TAXON=18 CHARACTER=155 TEXT='The mitochondria fuse in the middle stage of spermiogenesis to become a pair of mitochondria (Reunov & Klepal 2004).';
+	TEXT TAXON=16 CHARACTER=155 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=15 CHARACTER=155 TEXT='Following Discinisca tenuis, described in Hodgson & Reunov (1994).';
+	TEXT TAXON=14 CHARACTER=155 TEXT='Four mitochondria (Afzelius & Ferraguti, 1978)';
+	TEXT TAXON=17 CHARACTER=155 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=11 CHARACTER=155 TEXT='"The midpiece consists of two long mitochondrial rods connected with each other by a thin mitochondrial lamella" [@Franzen2000, in Loxosoma]; these are essentially a single organelle surrounding a central rod of electron-dense material.  ';
+	TEXT TAXON=12 CHARACTER=155 TEXT='Two mitochondrial derivatives in Flustra [@Franzen1981;@Franzen1977]; four in Tubulipora [@Franzen1984]';
+	TEXT TAXON=19 CHARACTER=155 TEXT='Ring of five mitochondria around the central centriole [@Rice1993]';
+	TEXT TAXON=22 CHARACTER=155 TEXT='@DufresneDube1983';
+	TEXT TAXON=20 CHARACTER=155 TEXT='Five mitochondria in ring [@Gherardi2011]';
+	TEXT TAXON=13 CHARACTER=155 TEXT='Two mitochondrial derivatives in Flustra [@Franzen1981;@Franzen1977]; four in Tubulipora [@Franzen1984]';
+	TEXT TAXON=18 CHARACTER=156 TEXT='Only one centriole in spermatzoon (Reunov & Klepal 2004, p. 7), but centrioles are perpendicularly oriented in spermatogonia (ibid., p. 2)';
+	TEXT TAXON=16 CHARACTER=156 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=15 CHARACTER=156 TEXT='Following Discinisca tenuis, described in Hodgson & Reunov (1994).';
+	TEXT TAXON=14 CHARACTER=156 TEXT='Two orthogonal centrioles (Afzelius & Ferraguti 1978)';
+	TEXT TAXON=17 CHARACTER=156 TEXT='Following Hodgson & Reunov (1994).';
+	TEXT TAXON=12 CHARACTER=156 TEXT='[@Franzen1981]';
+	TEXT TAXON=22 CHARACTER=156 TEXT='@DufresneDube1983';
+	TEXT TAXON=20 CHARACTER=156 TEXT='The proximal centriole is parallel to the flagellum [@Gherardi2011].';
+	TEXT TAXON=13 CHARACTER=156 TEXT='[@Franzen1981]';
+	TEXT TAXON=18 CHARACTER=152 TEXT='Needle-shaped (Reunov & Klepal, 2004)';
+	TEXT TAXON=16 CHARACTER=152 TEXT='Pear-shaped (Fukumoto 2003)';
+	TEXT TAXON=15 CHARACTER=152 TEXT='Pear-shaped (Hodgson & Reunov, 1994)';
+	TEXT TAXON=14 CHARACTER=152 TEXT='Needle-shaped (Afzelius & Ferraguti, 1978)';
+	TEXT TAXON=17 CHARACTER=152 TEXT='Disc-shaped (in Kraussina) (Hodgson & Reunov, 1994)';
+	TEXT TAXON=11 CHARACTER=152 TEXT='Conical/cylindrical acrosome-like extension in Loxosoma [@Franzen2000]';
+	TEXT TAXON=12 CHARACTER=152 TEXT='Conical [in Tubulipora; @Franzen1984]';
+	TEXT TAXON=19 CHARACTER=152 TEXT='A peaked disc in Phascolion [@Rice1993]';
+	TEXT TAXON=21 CHARACTER=152 TEXT='Elongate: cylindrical to conical [@BucklandNicks1988]';
+	TEXT TAXON=22 CHARACTER=152 TEXT='Low conical aspect [@DufresneDube1983]';
+	TEXT TAXON=20 CHARACTER=152 TEXT='@Gherardi2011';
+	TEXT TAXON=13 CHARACTER=152 TEXT='Conical [in Tubulipora; @Franzen1984]';
+	TEXT TAXON=18 CHARACTER=154 TEXT='The filament-like acrosome continues backwards as a tube-like structure (Franzen & Ahlfors, 1980, summarized in Jamieson 1991)';
+	TEXT TAXON=16 CHARACTER=154 TEXT='Filled with sub-acrosomal substance (Fukumoto 2003)';
+	TEXT TAXON=15 CHARACTER=154 TEXT='Subacrosomal material (in Discinisca) but no subacrosomal space (Hodgson & Reunov, 1994).';
+	TEXT TAXON=14 CHARACTER=154 TEXT='Prominent (Afzelius & Ferraguti, 1978)';
+	TEXT TAXON=17 CHARACTER=154 TEXT='No subacrosomal material, let alone a subacrosomal space (e.g. Hodgson & Reunov 1994)';
+	TEXT TAXON=11 CHARACTER=154 TEXT='Present in Loxosoma [@Franzen2000]';
+	TEXT TAXON=12 CHARACTER=154 TEXT='No distinct space [in Tubulipora; @Franzen1984]';
+	TEXT TAXON=19 CHARACTER=154 TEXT='@Rice1993';
+	TEXT TAXON=21 CHARACTER=154 TEXT='Not evident [@BucklandNicks1988]';
+	TEXT TAXON=22 CHARACTER=154 TEXT='@DufresneDube1983';
+	TEXT TAXON=20 CHARACTER=154 TEXT='@Gherardi2011';
+	TEXT TAXON=13 CHARACTER=154 TEXT='No distinct space [in Tubulipora; @Franzen1984]';
+	TEXT TAXON=4 CHARACTER=100 TEXT='No differentiation between cardinal shield and conical shield [@Wrona2003;@Devaere2014]';
+	TEXT TAXON=6 CHARACTER=100 TEXT='@Marek1972';
+	TEXT TAXON=3 CHARACTER=100 TEXT='No differentiation between the cardinal and conical shields';
+	TEXT TAXON=7 CHARACTER=100 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=2 CHARACTER=100 TEXT='Narrow cardinal shield [@Skovsted2016]';
+	TEXT TAXON=4 CHARACTER=103 TEXT='"Processes and clavicle-like structures are absent" -- @Devaere2014';
+	TEXT TAXON=6 CHARACTER=103 TEXT='Single pair [@Marek1972]';
+	TEXT TAXON=8 CHARACTER=103 TEXT='@Marek1966';
+	TEXT TAXON=7 CHARACTER=103 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=2 CHARACTER=103 TEXT='"No traces of clavicles" [@Skovsted2016]';
+	TEXT TAXON=18 CHARACTER=157 TEXT='Basal body in deep nuclear fossa';
+	TEXT TAXON=16 CHARACTER=157 TEXT='Basal body in deep nuclear fossa';
+	TEXT TAXON=14 CHARACTER=157 TEXT='Basal body in deep nuclear fossa';
+	TEXT TAXON=11 CHARACTER=157 TEXT='Basal body in deep nuclear fossa';
+	TEXT TAXON=12 CHARACTER=157 TEXT='Proximal centriole fused anterior to distal centriole';
+	TEXT TAXON=19 CHARACTER=157 TEXT='Proximal centriole fused anterior to distal centriole';
+	TEXT TAXON=21 CHARACTER=157 TEXT='Proximal centriole fused lateral to distal centriole and offset';
+	TEXT TAXON=22 CHARACTER=157 TEXT='Proximal centriole fused anterior to distal centriole [@DufresneDube1983]';
+	TEXT TAXON=13 CHARACTER=157 TEXT='Proximal centriole fused anterior to distal centriole';
+	TEXT TAXON=11 CHARACTER=160 TEXT='in Loxosoma [@Franzen2000]';
+	TEXT TAXON=12 CHARACTER=160 TEXT='"Typical cristae"; "Randomly oriented" -- @Franzen1984 (in Tubulipora)';
+	TEXT TAXON=13 CHARACTER=160 TEXT='"Typical cristae"; "Randomly oriented" -- @Franzen1984 (in Tubulipora)';
+	TEXT TAXON=11 CHARACTER=159 TEXT='Elongate rods in Loxosoma [@Franzen2000]';
+	TEXT TAXON=12 CHARACTER=159 TEXT='Rods [@Franzen1981]';
+	TEXT TAXON=21 CHARACTER=159 TEXT='See @BucklandNicks1988';
+	TEXT TAXON=13 CHARACTER=159 TEXT='Rods [@Franzen1981]';
+	TEXT TAXON=11 CHARACTER=161 TEXT='As long as the flagellum in Loxosoma [@Franzen2000]';
+	TEXT TAXON=12 CHARACTER=161 TEXT='Long [@Franzen1981]';
+	TEXT TAXON=19 CHARACTER=161 TEXT='Short ring of five mitochondria around the central centriole [@Rice1993]. ';
+	TEXT TAXON=20 CHARACTER=161 TEXT='Five mitochondria surround the base of the flagellum in short midpiece, comparable to that of Sipunculus and Dentalium [@Gherardi2011]';
+	TEXT TAXON=13 CHARACTER=161 TEXT='Long [@Franzen1981]';
+	TEXT TAXON=18 CHARACTER=151 TEXT='Nucleus "almost round" [@Reunov2004Ultrastructuralstudy]';
+	TEXT TAXON=15 CHARACTER=151 TEXT='Present in Discinisca tenuis (Hodgson & Reunov, 1994).';
+	TEXT TAXON=17 CHARACTER=151 TEXT='No anterior invagination [@Hodgson1994Ultrastructureof]';
+	TEXT TAXON=11 CHARACTER=151 TEXT='Present in Loxosoma [@Franzen2000]';
+	TEXT TAXON=12 CHARACTER=151 TEXT='Present [in Tubulipora; @Franzen1984]';
+	TEXT TAXON=19 CHARACTER=151 TEXT='Prominent in Phascolion [@Rice1993]';
+	TEXT TAXON=21 CHARACTER=151 TEXT='@BucklandNicks1988';
+	TEXT TAXON=22 CHARACTER=151 TEXT='@DufresneDube1983';
+	TEXT TAXON=20 CHARACTER=151 TEXT='Absent: subacrosomal space does not impinge on nuclear envelope [@Gherardi2011]';
+	TEXT TAXON=13 CHARACTER=151 TEXT='Present [in Tubulipora; @Franzen1984]';
+	TEXT TAXON=11 CHARACTER=150 TEXT='Elongate in Loxosoma [@Franzen2000]';
+	TEXT TAXON=12 CHARACTER=150 TEXT='Elongate [@Franzen1981]';
+	TEXT TAXON=21 CHARACTER=150 TEXT='Profoundly elongated nucleus [@BucklandNicks1988]';
+	TEXT TAXON=22 CHARACTER=150 TEXT='Elongate nucleus, 4-6 times longer than wide [@DufresneDube1983]';
+	TEXT TAXON=20 CHARACTER=150 TEXT='@Gherardi2011';
+	TEXT TAXON=13 CHARACTER=150 TEXT='Elongate [@Franzen1981]';
+	TEXT TAXON=18 CHARACTER=163 TEXT='"Cleavage is holoblastic and results in approximately equal sized, or adequal, blastomeres." -- @Pennerstorfer2012';
+	TEXT TAXON=16 CHARACTER=163 TEXT='Equal, in all brachiopods [@Williams1997Introduction]';
+	TEXT TAXON=15 CHARACTER=163 TEXT='Equal, in all brachiopods [@Williams1997Introduction]';
+	TEXT TAXON=14 CHARACTER=163 TEXT='Equal, in all brachiopods [@Williams1997Introduction]';
+	TEXT TAXON=17 CHARACTER=163 TEXT='Equal, in all brachiopods [@Williams1997Introduction]';
+	TEXT TAXON=18 CHARACTER=166 TEXT='"The observed cleavage displays several characters consistent with the pattern of spiral cleavage" [@Pennerstorfer2012]';
+	TEXT TAXON=12 CHARACTER=166 TEXT='"While entoprocts are spiral cleavers, ectoprocts show a radial cleavage pattern" -- @Fuchs2008';
+	TEXT TAXON=13 CHARACTER=166 TEXT='"While entoprocts are spiral cleavers, ectoprocts show a radial cleavage pattern" -- @Fuchs2008';
+	TEXT TAXON=18 CHARACTER=162 TEXT='Uniform size [@Pennerstorfer2012]';
+	TEXT TAXON=16 CHARACTER=162 TEXT='@Williams1997Introduction';
+	TEXT TAXON=17 CHARACTER=162 TEXT='@Williams1997Introduction';
+	TEXT TAXON=12 CHARACTER=162 TEXT='In Membranipora, "cleavage is slightly unequal resulting in little larger central^nblastomeres" [@Gruhl2010M]';
+	TEXT TAXON=19 CHARACTER=162 TEXT='Prominent differentiation in Phascolosoma [@Adrianov2011]';
+	TEXT TAXON=13 CHARACTER=162 TEXT='In Membranipora, "cleavage is slightly unequal resulting in little larger central^nblastomeres" [@Gruhl2010M]';
+	TEXT TAXON=17 CHARACTER=167 TEXT='@Williams1997Introduction';
+	TEXT TAXON=17 CHARACTER=179 TEXT='@Williams1997Introduction';
+	TEXT TAXON=17 CHARACTER=181 TEXT='@Williams1997Introduction';
+	TEXT TAXON=12 CHARACTER=181 TEXT='Cyclostomes are covered in cilia but not arranged in food groove.';
+	TEXT TAXON=13 CHARACTER=181 TEXT='Coronal cilia do not form a food groove [@Reed1982]';
+	TEXT TAXON=19 CHARACTER=182 TEXT='"Taxa such as Sipuncula [...] have a metatroch and do not have downstream larval-feeding" -- @Rouse2000';
+	TEXT TAXON=20 CHARACTER=182 TEXT='"Groups such as Sabellariidae [...] have evolved downstream-feeding without the aid of a metatroch" -- [@Rouse2000]';
+	TEXT TAXON=12 CHARACTER=185 TEXT='Present, following schematic in @Gruhl2016';
+	TEXT TAXON=13 CHARACTER=185 TEXT='Nodular nerve ring underlies corona [@Reed1982]';
+	TEXT TAXON=17 CHARACTER=9 TEXT='@Williams1997Introduction';
+	TEXT TAXON=12 CHARACTER=9 TEXT='Absent [@Zimmer2013]';
+	TEXT TAXON=20 CHARACTER=9 TEXT='@Luter2000 contends that annelid larvae lack setae, but chaetae are present on day 16 of the larval development of Serpula [@Keay2007].';
+	TEXT TAXON=8 CHARACTER=9 TEXT='Following Recilites (Pauxillitidae) [@Dzik1978]';
+	TEXT TAXON=13 CHARACTER=9 TEXT='[@Reed1982]';
+	TEXT TAXON=17 CHARACTER=180 TEXT='@Williams1997Introduction';
+	TEXT TAXON=12 CHARACTER=180 TEXT='Absent [@Zimmer2013]';
+	TEXT TAXON=13 CHARACTER=180 TEXT='Absent; single ciliary field lacks telotroch equivalent [@Reed1982]';
+	TEXT TAXON=18 CHARACTER=168 TEXT='Not evident [@Santagata2004, fig. 2C]';
+	TEXT TAXON=12 CHARACTER=168 TEXT='Median muscles extending from apical organ [@Gruhl2008]';
+	TEXT TAXON=22 CHARACTER=168 TEXT='Apical organ has disappeared before musculature is set in place [@Wanninger2002M]';
+	TEXT TAXON=13 CHARACTER=168 TEXT='Median muscles extending from apical organ [@Gruhl2008]';
+	TEXT TAXON=12 CHARACTER=178 TEXT='Metamorphose almost immediately after release from gonozooid [@Zimmer2013]; most bryozoans are lecithotrophic [@Reed1982]';
+	TEXT TAXON=13 CHARACTER=178 TEXT='Lecithotrophic [@Reed1982]';
+	TEXT TAXON=1 CHARACTER=20 TEXT='Not evident';
+	TEXT TAXON=25 CHARACTER=20 TEXT='Unknown whether sclerites are serially repeated, or whether metameres were present in underlying soft anatomy';
+	TEXT TAXON=24 CHARACTER=20 TEXT='Elements of the Halkieria scleritome adhere to a quincunx arrangement, with different spacing of elements in each zone; there is no evidence of a metameric arrangement.';
+	TEXT TAXON=4 CHARACTER=20 TEXT='The soft anatomy of this taxon is unknown, so it is impossible to rule out the presence of serial repetition.';
+	TEXT TAXON=6 CHARACTER=20 TEXT='The soft anatomy of this taxon is unknown, so it is impossible to rule out the presence of serial repetition.';
+	TEXT TAXON=8 CHARACTER=20 TEXT='The soft anatomy of this taxon is unknown, so it is impossible to rule out the presence of serial repetition.';
+	TEXT TAXON=3 CHARACTER=20 TEXT='The soft anatomy of this taxon is unknown, so it is impossible to rule out the presence of serial repetition.';
+	TEXT TAXON=11 CHARACTER=173 TEXT='Coelomoducts absent [@Haszprunar2000]';
+	TEXT TAXON=18 CHARACTER=23 TEXT='"large coelomic funnels serving as genital ducts" [@Goodrich1945]';
+	TEXT TAXON=11 CHARACTER=23 TEXT='Two coelomoducts pass outwards, meet, and open by a common pore [@Goodrich1945]';
+	TEXT TAXON=12 CHARACTER=23 TEXT='Multiple ciliated ducts leading to a common gonopore [@Goodrich1945]';
+	TEXT TAXON=12 CHARACTER=176 TEXT='Hypostegal coelom separated from principal (perigastric) body cavity in cheilostomata -- but this is not clearly equivalent to the paired coelom intended by this character.  The coelom of Fredericella is not paired [@Gruhl2010F].';
+	TEXT TAXON=13 CHARACTER=176 TEXT='No evidence of pairing [@Reed1982]';
+	TEXT TAXON=11 CHARACTER=174 TEXT='A foot is present in the creeping-type larva of Loxosomella murmanica, though absent in L. atkinsae and the many other entoprocts that have swimming-type larvae [@Fuchs2008]';
+	TEXT TAXON=19 CHARACTER=174 TEXT='@Wingstrand1985 considers the annelid neurotroch to be potentially homologous with the molluscan and entoproct foot';
+	TEXT TAXON=20 CHARACTER=174 TEXT='@Wingstrand1985 considers the annelid neurotroch to be potentially homologous with the molluscan and entoproct foot';
+	TEXT TAXON=10 CHARACTER=21 TEXT='The stalk may conceivably be homologous with the entoproct foot, but the evidence for homology is weak.';
+	TEXT TAXON=11 CHARACTER=21 TEXT='See @Haszprunar2008';
+	TEXT TAXON=19 CHARACTER=21 TEXT=' LISTED AS PRESENT IN @Smith2012: WHY? ';
+	TEXT TAXON=24 CHARACTER=21 TEXT='The ventral surface of Halkieria is unarmoured, but its soft anatomy is unknown.';
+	TEXT TAXON=17 CHARACTER=186 TEXT='Present [@Luter1995]';
+	TEXT TAXON=20 CHARACTER=186 TEXT='Present in certain annelids; not verified in Serpula';
+	TEXT TAXON=20 CHARACTER=187 TEXT='Following Harmothoe [@Holborow1969]';
+	TEXT TAXON=20 CHARACTER=188 TEXT='Basal foot in Magelona is connected to cytoplasmic microtubules [@Bartolomaeus1995].';
+	TEXT TAXON=13 CHARACTER=188 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=189 TEXT='Thin to thick, but not blurry [@Luter1995]';
+	TEXT TAXON=20 CHARACTER=189 TEXT='Broad and ''blurry'' in Magelona [@Bartolomaeus1995]';
+	TEXT TAXON=13 CHARACTER=189 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=190 TEXT='Absent [@Luter1995]';
+	TEXT TAXON=13 CHARACTER=190 TEXT='Present [@Reed1982]';
+	TEXT TAXON=20 CHARACTER=191 TEXT='Following Enchytraeus [@Reger1967], Magelona [@Bartolomaeus1995] and Harmothoe [@Holborow1969]';
+	TEXT TAXON=13 CHARACTER=191 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=192 TEXT='[@Luter1995]';
+	TEXT TAXON=20 CHARACTER=192 TEXT='Not evident in Enchytraeus [@Reger1967], Magelona [@Bartolomaeus1995] or Harmothoe [@Holborow1969]';
+	TEXT TAXON=13 CHARACTER=192 TEXT='@Reed1982';
+	TEXT TAXON=20 CHARACTER=193 TEXT='@Nielsen1987';
+	TEXT TAXON=13 CHARACTER=193 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=195 TEXT='Homogeneous [@Luter1995]';
+	TEXT TAXON=13 CHARACTER=195 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=196 TEXT='[@Luter1995]';
+	TEXT TAXON=13 CHARACTER=196 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=197 TEXT='Long [@Luter1995]';
+	TEXT TAXON=11 CHARACTER=197 TEXT='Details of ciliary ultrastructure are illustrated in @Nielsen1976';
+	TEXT TAXON=13 CHARACTER=197 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=198 TEXT='Conical: tapering to a point [@Luter1995]';
+	TEXT TAXON=20 CHARACTER=198 TEXT='Conical in Enchytraeus [@Reger1967] and Magelona [@Bartolomaeus1995] ';
+	TEXT TAXON=13 CHARACTER=198 TEXT='@Reed1982';
+	TEXT TAXON=13 CHARACTER=199 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=194 TEXT='"The coelothelial cells of the metacoel are monociliated"; "even some epithelial muscle cells are monociliated" -- @Luter1995';
+	TEXT TAXON=17 CHARACTER=200 TEXT='"Very small" -- @Luter1995';
+	TEXT TAXON=20 CHARACTER=200 TEXT='Short in Enchytraeus [@Reger1967], Magelona [@Bartolomaeus1995] and Harmothoe [@Holborow1969]';
+	TEXT TAXON=13 CHARACTER=200 TEXT='@Reed1982';
+	TEXT TAXON=17 CHARACTER=201 TEXT='Too small to evaluate';
+	TEXT TAXON=20 CHARACTER=201 TEXT='Conical in Magelona [@Bartolomaeus1995]';
+	TEXT TAXON=13 CHARACTER=201 TEXT='@Reed1982';
+	TEXT TAXON=18 CHARACTER=213 TEXT='"In P. australis [...] all the myofibrils belong to the smooth type" -- @Pardos1991';
+	TEXT TAXON=16 CHARACTER=213 TEXT='In brachiopods, myofibrils "are striated on the frontal face and smooth on the abfrontal face" [@Pardos1991]';
+	TEXT TAXON=15 CHARACTER=213 TEXT='In brachiopods, myofibrils "are striated on the frontal face and smooth on the abfrontal face" [@Pardos1991]';
+	TEXT TAXON=14 CHARACTER=213 TEXT='In brachiopods, myofibrils "are striated on the frontal face and smooth on the abfrontal face" [@Pardos1991]';
+	TEXT TAXON=17 CHARACTER=213 TEXT='In brachiopods, myofibrils "are striated on the frontal face and smooth on the abfrontal face" [@Pardos1991]';
+	TEXT TAXON=12 CHARACTER=213 TEXT='In Bryozoa, myofibrils are "all striated" [@Pardos1991]';
+	TEXT TAXON=13 CHARACTER=213 TEXT='In Bryozoa, myofibrils are "all striated" [@Pardos1991]';
+	TEXT TAXON=11 CHARACTER=25 TEXT='See @Haszprunar2008';
+	TEXT TAXON=12 CHARACTER=25 TEXT='As Brachiopods, sipunculans and relatives [@Ruppert1983]';
+	TEXT TAXON=19 CHARACTER=25 TEXT='Open circulatory system';
+	TEXT TAXON=21 CHARACTER=25 TEXT='See @Haszprunar2008';
+	TEXT TAXON=22 CHARACTER=25 TEXT='See @Haszprunar2008';
+	TEXT TAXON=13 CHARACTER=25 TEXT='As Brachiopods, sipunculans and relatives [@Ruppert1983]';
+	TEXT TAXON=18 CHARACTER=56 TEXT='Ciliated ridge in oesophagus [@Torrey1901]';
+	TEXT TAXON=22 CHARACTER=57 TEXT='Present, but secondarily reduced';
+	TEXT TAXON=23 CHARACTER=59 TEXT='Subdivided, presumably functionally, but with some ambiguity [@Smith2012M;Smith2014]';
+	TEXT TAXON=4 CHARACTER=59 TEXT='[@Devaere2014]';
+	TEXT TAXON=23 CHARACTER=60 TEXT='Annex to midgut interpreted as a gland [@Smith2012M]';
+	TEXT TAXON=5 CHARACTER=55 TEXT='No candidate observed despite exceptional preservation';
+	TEXT TAXON=41 CHARACTER=55 TEXT='No candidate observed despite exceptional preservation';
+	TEXT TAXON=40 CHARACTER=55 TEXT='No candidate observed despite exceptional preservation';
+	TEXT TAXON=26 CHARACTER=55 TEXT='No candidate observed despite exceptional preservation';
+	TEXT TAXON=39 CHARACTER=55 TEXT='No candidate observed despite exceptional preservation';
+	TEXT TAXON=43 CHARACTER=55 TEXT='No candidate observed despite exceptional preservation';
+	TEXT TAXON=42 CHARACTER=55 TEXT='No candidate observed despite exceptional preservation';
+	TEXT TAXON=54 CHARACTER=55 TEXT='No candidate observed despite exceptional preservation';
+	TEXT TAXON=23 CHARACTER=55 TEXT='@Smith2012M';
+	TEXT TAXON=18 CHARACTER=202 TEXT='Present [@Storch1978]';
+	TEXT TAXON=16 CHARACTER=202 TEXT='"In Brachiopoda, podocytes have never been observed" -- @Luter1995';
+	TEXT TAXON=15 CHARACTER=202 TEXT='"In Brachiopoda, podocytes have never been observed" -- @Luter1995';
+	TEXT TAXON=14 CHARACTER=202 TEXT='"In Brachiopoda, podocytes have never been observed" -- @Luter1995';
+	TEXT TAXON=17 CHARACTER=202 TEXT='"In Brachiopoda, podocytes have never been observed" -- @Luter1995';
+	TEXT TAXON=20 CHARACTER=202 TEXT='Present in serpulids [@Bartolomaeus2005]';
+	TEXT TAXON=16 CHARACTER=204 TEXT='"The excretory function of the metanephridia in Brachiopoda must be questioned" -- @Luter1995';
+	TEXT TAXON=15 CHARACTER=204 TEXT='"The excretory function of the metanephridia in Brachiopoda must be questioned" -- @Luter1995';
+	TEXT TAXON=14 CHARACTER=204 TEXT='"The excretory function of the metanephridia in Brachiopoda must be questioned" -- @Luter1995';
+	TEXT TAXON=17 CHARACTER=204 TEXT='"The excretory function of the metanephridia in Brachiopoda must be questioned" -- @Luter1995';
+	TEXT TAXON=1 CHARACTER=144 TEXT='Budding well documented [e.g. @Zhuravlev2015Ediacaranskeletal]';
+	TEXT TAXON=13 CHARACTER=146 TEXT='Brood pouches in abandoned lophophore';
+	TEXT TAXON=13 CHARACTER=145 TEXT='Hermaphroditic [@Reed1988]';
+	TEXT TAXON=18 CHARACTER=148 TEXT='Eggs "are surrounded by a delicate fertilization membrane" [@Pennerstorfer2012]';
+	TEXT TAXON=12 CHARACTER=148 TEXT='"Eggs have a loose consistency and are capable of changing form" [@Franzen1977]';
+	TEXT TAXON=13 CHARACTER=148 TEXT='"Eggs have a loose consistency and are capable of changing form" [@Franzen1977]';
+	TEXT TAXON=18 CHARACTER=218 TEXT='Glial cells are "abundant" [@Temereva2016Phoronida]';
+	TEXT TAXON=13 CHARACTER=217 TEXT='@Temereva2016Thenervous';
+	TEXT TAXON=13 CHARACTER=219 TEXT='@Temereva2016Thenervous';
+	TEXT TAXON=16 CHARACTER=170 TEXT='"both the larval apical ganglion and the ventral ganglion must be retained as^nthe adult nervous system" [@HaySchmidt1992], but not necessarily as the brain';
+	TEXT TAXON=12 CHARACTER=221 TEXT='"The cerebral ganglion in all bryozoans is formed as an invagination of a portion^nof epithelium" -- @Temereva2016Thenervous';
+	TEXT TAXON=13 CHARACTER=221 TEXT='"The cerebral ganglion in all bryozoans is formed as an invagination of a portion^nof epithelium" -- @Temereva2016Thenervous';
+	TEXT TAXON=18 CHARACTER=222 TEXT='We treat the dorsal ganglion, which is formed by two ends of the tentacular nerve ring [@Temereva2016Phoronida], as cerebral.';
+	TEXT TAXON=13 CHARACTER=222 TEXT='@Temereva2016Thenervous';
+	TEXT TAXON=13 CHARACTER=223 TEXT='Fused [@Temereva2016Thenervous]';
+	TEXT TAXON=13 CHARACTER=225 TEXT='@Temereva2016Thenervous';
+	TEXT TAXON=5 CHARACTER=40 TEXT='@Moysiuk2017Hyolithsare';
+	TEXT TAXON=10 CHARACTER=40 TEXT='The tentacular crown [@Zhang2013] is interpreted as a lophophore';
+	TEXT TAXON=22 CHARACTER=40 TEXT='The scaphopod captacula is conceivably equivalent to the tentacular apparatus of other lophotrochozoans.  It is developmentally pre-oral, and has tentatively been homologised with the pre-oral tentacles of Monoplacophora and Gastropoda [@Steiner1992], though their musculature and late development suggests instead that they may derive from the molluscan foot, as do the arms of cephalopods [@Wanninger2002M]';
+	TEXT TAXON=25 CHARACTER=69 TEXT='Following the reconstruction of @Skovsted2015Theearly';
+	TEXT TAXON=35 CHARACTER=70 TEXT='@Skovsted2008Thescleritome';
+	TEXT TAXON=5 CHARACTER=70 TEXT='Helens are symmetrical';
+	TEXT TAXON=6 CHARACTER=70 TEXT='Helens are symmetrical';
+	TEXT TAXON=8 CHARACTER=70 TEXT='Helens are symmetrical';
+	TEXT TAXON=49 CHARACTER=35 TEXT='Not evident';
+	TEXT TAXON=53 CHARACTER=35 TEXT='Not preserved along muscle scars [@Nikitin1984], presumably owing to quality of preservation rather than genuine absence.';
+	TEXT TAXON=7 CHARACTER=35 TEXT='Not impressed on valves, despite fine preservation of muscular attachment [@Zhang2018Ahyolithid]';
+	TEXT TAXON=2 CHARACTER=35 TEXT='Not observed despite excellent preservation';
+	TEXT TAXON=18 CHARACTER=46 TEXT='Following @Temereva2017Innervationof -- though in larvae, tentacles are added at the tips of the developing lophophore.';
+	TEXT TAXON=16 CHARACTER=46 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=15 CHARACTER=46 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=14 CHARACTER=46 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=17 CHARACTER=46 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=12 CHARACTER=46 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=19 CHARACTER=46 TEXT='New branches added at each lateral extreme, behind mouth [@Adrianov2006]';
+	TEXT TAXON=13 CHARACTER=46 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=18 CHARACTER=48 TEXT='[@Temereva2017Innervationof]';
+	TEXT TAXON=16 CHARACTER=48 TEXT='@Temereva2017Thefirst';
+	TEXT TAXON=14 CHARACTER=48 TEXT='Probably only a single ring is present, but only available illustrations are 19th century sketches [@Luter2016]';
+	TEXT TAXON=17 CHARACTER=48 TEXT='In Gryphus [@Temereva2017Thefirst]';
+	TEXT TAXON=11 CHARACTER=48 TEXT='Nerves present in tentacles, but not forming rings [@Fuchs2006]';
+	TEXT TAXON=12 CHARACTER=48 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=13 CHARACTER=48 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=18 CHARACTER=49 TEXT='@Temereva2017Thefirst';
+	TEXT TAXON=16 CHARACTER=49 TEXT='@Temereva2017Innervationof';
+	TEXT TAXON=14 CHARACTER=49 TEXT='Probably only a single ring is present, but only available illustrations are 19th century sketches [@Luter2016]';
+	TEXT TAXON=17 CHARACTER=49 TEXT='@Temereva2017Innervationof';
+	TEXT TAXON=11 CHARACTER=49 TEXT='Nerves present in tentacles, but not forming rings [@Fuchs2006]';
+	TEXT TAXON=12 CHARACTER=49 TEXT='"Most species of bryozoans have only the inner" nerve ring -- @Temereva2017Innervationof';
+	TEXT TAXON=13 CHARACTER=49 TEXT='Following @Temereva2017Innervationof; only one tentacle nerve ring evident in @Temereva2016Thenervous';
+	TEXT TAXON=18 CHARACTER=41 TEXT='At the posterior of the head, at the late larval stage [@Santagata2004]';
+	TEXT TAXON=14 CHARACTER=41 TEXT='"At metamorphosis [....] the second pair of coelomic sacs develop small attachment areas at the edge of the dorsal valve and become the lophophore coelom" [@Nielsen1991]^n^n"The larval lobes are retained during the first steps of metamorphosis and are^nsubsequently remodeled to form the lophophore and other adult organs" -- @Altenburger2013';
+	TEXT TAXON=17 CHARACTER=41 TEXT='Lophophore of Terebratalia arises post metamorphosis [@Young2002]; lophophore conceivably arising from vesicular bodies at base of apical lobe?';
+	TEXT TAXON=11 CHARACTER=41 TEXT='Arising after metamorphosis [@Nielsen1971]';
+	TEXT TAXON=12 CHARACTER=41 TEXT='The tentacles appear at metamorphosis, seemingly from below the corona (=prototroch) [@Young2002]';
+	TEXT TAXON=19 CHARACTER=41 TEXT='[@Adrianov2006]';
+	TEXT TAXON=22 CHARACTER=41 TEXT='The captacula arise close to the mouth after metamorphosis [@Wanninger2002M], in a position not dissimilar from that of the phoronid tentacles [@Santagata2004].';
+	TEXT TAXON=11 CHARACTER=47 TEXT='Tentacle nerves originate laterally from the cerebral ganglion, branching three times and leading to a single nerve within each tentacle [@Fuchs2006]';
+	TEXT TAXON=12 CHARACTER=47 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=19 CHARACTER=47 TEXT='@Rice1993';
+	TEXT TAXON=22 CHARACTER=47 TEXT='The captacula each bear an individual nerve fibre emanating from the cerebral ganglia, which is also associated with the circumoesophageal nerve ring [@SumnerRooney2015], recalling the situation in annelids and sipunculans.';
+	TEXT TAXON=20 CHARACTER=47 TEXT='@Orrhage2005';
+	TEXT TAXON=13 CHARACTER=47 TEXT='Following @Temereva2017Innervationof';
+	TEXT TAXON=18 CHARACTER=208 TEXT='Collagen fibres in tentacle cuticle [@Bartolomaeus2001U]; chitin only present in tubes [@Jeuniaux1971]';
+	TEXT TAXON=16 CHARACTER=208 TEXT='The brachiopod pedicle has a chitinous cuticle  [@Williams1997Introduction;@MacKay1978], but the tentacles are associated with collagen [@Williams1997Introduction]; marked as polymorphic.';
+	TEXT TAXON=15 CHARACTER=208 TEXT='The brachiopod pedicle has a chitinous cuticle  [@Williams1997Introduction;@MacKay1978], but the tentacles are associated with collagen [@Williams1997Introduction]; marked as polymorphic.';
+	TEXT TAXON=14 CHARACTER=208 TEXT='No (chitinous) pedicle, so only collagenous cuticle present [@Williams1997Introduction]';
+	TEXT TAXON=17 CHARACTER=208 TEXT='The brachiopod pedicle has a chitinous cuticle  [@Williams1997Introduction;@MacKay1978], but the tentacles are associated with collagen [@Williams1997Introduction]; marked as polymorphic.';
+	TEXT TAXON=11 CHARACTER=208 TEXT='Absent [@Haszprunar2008]. Chitin is occasionally present in certain species, perhaps in regions where rigidity is necessary [@Borisanova2015].';
+	TEXT TAXON=12 CHARACTER=208 TEXT='Collagenous [@Schopf1967], though chitin is associated with the exoskeleton [@Hunt1972]';
+	TEXT TAXON=19 CHARACTER=208 TEXT='Collagenous [@Goffinet1978]';
+	TEXT TAXON=21 CHARACTER=208 TEXT='@Haszprunar2008';
+	TEXT TAXON=22 CHARACTER=208 TEXT='@Haszprunar2008';
+	TEXT TAXON=13 CHARACTER=208 TEXT='Collagenous [@Schopf1967], though chitin is associated with the exoskeleton [@Hunt1972]';
+	TEXT TAXON=13 CHARACTER=224 TEXT='@Temereva2016Thenervous';
+	TEXT TAXON=13 CHARACTER=220 TEXT='@Temereva2016Thenervous';
+	TEXT TAXON=18 CHARACTER=169 TEXT='Multiple shapes of cells present [@Santagata2002]; resembles the linguliform arrangement [@Altenburger2010]';
+	TEXT TAXON=16 CHARACTER=169 TEXT='Cluster of "numerous" serotonergic cells [@HaySchmidt1992;@Altenburger2010]; more than, but probably equivalent to, the flask-shaped cells of Terebratalia [@Luter2016]';
+	TEXT TAXON=14 CHARACTER=169 TEXT='Four flask-shaped cells [@Altenburger2010]';
+	TEXT TAXON=17 CHARACTER=169 TEXT='Eight in Terebratalia [@Luter2016]';
+	TEXT TAXON=11 CHARACTER=169 TEXT='Six to eight apical cells; eight peripheral cells [@Wanninger2007], indicating a probable equivalence to polyplacophorans [@Haszprunar2008]';
+	TEXT TAXON=12 CHARACTER=169 TEXT='Concentration of 30--40 serotonergic perikarya [in Fredericella; @Gruhl2010F]';
+	TEXT TAXON=19 CHARACTER=169 TEXT='Cluster of around eight cells, though not quite countable [@Wanninger2005]';
+	TEXT TAXON=21 CHARACTER=169 TEXT='Eight in Ischnochiton and Mopalia [@Wanninger2007]';
+	TEXT TAXON=13 CHARACTER=169 TEXT='Concentration of 30--40 serotonergic perikarya [in Fredericella; @Gruhl2010F]';
+	TEXT TAXON=18 CHARACTER=209 TEXT='Outer layer seemingly fibrous [@BereiterHahn1984]';
+	TEXT TAXON=16 CHARACTER=209 TEXT='Pedicle cuticle entirely homogeneous [@Williams1997Introduction]';
+	TEXT TAXON=15 CHARACTER=209 TEXT='Microvilli in otherwise homogeneous epidermis [@Williams1997Introduction]';
+	TEXT TAXON=17 CHARACTER=209 TEXT='Not evident in Notosaria [@BereiterHahn1984;@Williams1997Introduction]';
+	TEXT TAXON=11 CHARACTER=209 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=12 CHARACTER=209 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=19 CHARACTER=209 TEXT='Fibrous collagen only [@BereiterHahn1984]';
+	TEXT TAXON=21 CHARACTER=209 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=22 CHARACTER=209 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=20 CHARACTER=209 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=13 CHARACTER=209 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=18 CHARACTER=210 TEXT='Not evident [@BereiterHahn1984]';
+	TEXT TAXON=16 CHARACTER=210 TEXT='Pedicle cuticle entirely homogeneous [@Williams1997Introduction]';
+	TEXT TAXON=15 CHARACTER=210 TEXT='Microvilli in otherwise homogeneous epidermis [@Williams1997Introduction]';
+	TEXT TAXON=17 CHARACTER=210 TEXT='Cuticle is homogeneous in Notosaria [@BereiterHahn1984;@Williams1997Introduction]';
+	TEXT TAXON=11 CHARACTER=210 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=12 CHARACTER=210 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=19 CHARACTER=210 TEXT='Fibrous collagen only [@BereiterHahn1984]';
+	TEXT TAXON=21 CHARACTER=210 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=22 CHARACTER=210 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=20 CHARACTER=210 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=13 CHARACTER=210 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=18 CHARACTER=212 TEXT='Present on outer epithelium [@BereiterHahn1984]';
+	TEXT TAXON=15 CHARACTER=212 TEXT='Microvillios inner epithelium in Discina [@Williams1997Introduction]';
+	TEXT TAXON=11 CHARACTER=212 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=12 CHARACTER=212 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=19 CHARACTER=212 TEXT='Fibrous collagen only [@BereiterHahn1984]';
+	TEXT TAXON=21 CHARACTER=212 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=22 CHARACTER=212 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=20 CHARACTER=212 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=13 CHARACTER=212 TEXT='Following table 2 in @Borisanova2015.';
+	TEXT TAXON=19 CHARACTER=11 TEXT='No evidence of microvillar secretion [e.g. @Schulze2005]';
+	TEXT TAXON=19 CHARACTER=14 TEXT='Enzymatic test for chitin proved negative [@Rice1993]';
+	TEXT TAXON=16 CHARACTER=12 TEXT='Widest in centre [@Luter2000]';
+	TEXT TAXON=15 CHARACTER=12 TEXT='Slight decrease towards margin in Discinisca [@Luter2003]';
+	TEXT TAXON=17 CHARACTER=12 TEXT='Decreases towards margin in Terebratalia larvae [@Gustus1972]';
+	TEXT TAXON=21 CHARACTER=12 TEXT='Uniform [@Fischer1980;@Leise1982]';
+	TEXT TAXON=20 CHARACTER=12 TEXT='Following Scolelepis [@Hausen2005]; Diasoma [@Orrhage1971]';
+	TEXT TAXON=13 CHARACTER=12 TEXT='No trend in microvillar size [@Gordon1975]';
+	TEXT TAXON=15 CHARACTER=15 TEXT='Enamel layer apparent in Discina [@Williams1997Introduction, fig. 47.1]';
+	TEXT TAXON=17 CHARACTER=15 TEXT='Present in the terebratulid Calloria (and the Rhynchonellid Notosaria) [@Luter2000]';
+	TEXT TAXON=21 CHARACTER=15 TEXT='Not evident [@Leise1988;@Fischer1980]';
+	TEXT TAXON=20 CHARACTER=15 TEXT='Present in Nereis [@Gustus1973]';
+	TEXT TAXON=13 CHARACTER=15 TEXT='Not evident [@Gordon1975]';
+	TEXT TAXON=13 CHARACTER=17 TEXT='Cytoplasmic intrusion into a central cavity [@Gordon1975]';
+	TEXT TAXON=8 CHARACTER=104 TEXT='Three pairs of clavicles [@Marek1966]';
+	TEXT TAXON=7 CHARACTER=104 TEXT='@Zhang2018Ahyolithid';
+	TEXT TAXON=6 CHARACTER=102 TEXT='Dorsal teeth figured in @MartiMus2005.';
+	TEXT TAXON=8 CHARACTER=102 TEXT='Present [@Marek1966]';
+	TEXT TAXON=5 CHARACTER=22 TEXT='Internal cavities indicated by differentiation of internal organs [see @Moysiuk2017Hyolithsare]';
+	TEXT TAXON=18 CHARACTER=22 TEXT='@Temereva2017Innervationof';
+	TEXT TAXON=11 CHARACTER=22 TEXT='"Adult entoprocts are acoelomate" -- @Fuchs2008';
+	TEXT TAXON=12 CHARACTER=22 TEXT='"Adult ectoprocts differentiate true coelomic cavities" -- @Fuchs2008';
+	TEXT TAXON=4 CHARACTER=22 TEXT='The soft anatomy of this taxon is unknown, so it is impossible to determine the presence of a coelom.';
+	TEXT TAXON=6 CHARACTER=22 TEXT='The soft anatomy of this taxon is unknown, so it is impossible to determine the presence of a coelom.';
+	TEXT TAXON=8 CHARACTER=22 TEXT='The soft anatomy of this taxon is unknown, so it is impossible to determine the presence of a coelom.';
+	TEXT TAXON=3 CHARACTER=22 TEXT='The soft anatomy of this taxon is unknown, so it is impossible to determine the presence of a coelom.';
+	TEXT TAXON=13 CHARACTER=175 TEXT='Ciliated clef corresponds to position of foot [@Reed1982], but dedicated foot not present.';
+	TEXT TAXON=7 CHARACTER=110 TEXT='"Very short" semicircular ligula [@Zhang2018Ahyolithid]';
+	TEXT TAXON=18 CHARACTER=50 TEXT='[@Pardos1991]';
+	TEXT TAXON=16 CHARACTER=50 TEXT='"Inner coelomic epithelium underlain by muscle fibers, or in the tentacles, myoepithelial cells." -- @Williams1997Introduction';
+	TEXT TAXON=15 CHARACTER=50 TEXT='"Inner coelomic epithelium underlain by muscle fibers, or in the tentacles, myoepithelial cells." -- @Williams1997Introduction';
+	TEXT TAXON=14 CHARACTER=50 TEXT='"Inner coelomic epithelium underlain by muscle fibers, or in the tentacles, myoepithelial cells." -- @Williams1997Introduction';
+	TEXT TAXON=17 CHARACTER=50 TEXT='"Inner coelomic epithelium underlain by muscle fibers, or in the tentacles, myoepithelial cells." -- @Williams1997Introduction';
+	TEXT TAXON=11 CHARACTER=50 TEXT='Outer main tentacle muscle; two pairs of inner longitudinal muscles [@Fuchs2006]';
+	TEXT TAXON=19 CHARACTER=50 TEXT='Peripheral to main tentacle cavity [@Pilger1982]';
+	TEXT TAXON=22 CHARACTER=50 TEXT='Six to eight elongate muscle cells in core [@Shimek1988], surrounded by circular muscles [@Byrum1994]';
+	TEXT TAXON=20 CHARACTER=50 TEXT='Peripheral muscle fibres [@Hanson1949]';
+	TEXT TAXON=16 CHARACTER=18 TEXT='@Luter2000';
+	TEXT TAXON=15 CHARACTER=18 TEXT='Discinisca sports individual peripheral spines [@Williams1997Introduction;@Luter2003].^nNote that the "embryonic" setae of Discinids correspond to the "larval setae" of other brachiopods, and the "larval setae" of juvenile discinids correspond to adult setae [@Luter2003].';
+	TEXT TAXON=17 CHARACTER=18 TEXT='Individual peripheral spines [in Calloria; @Luter2000]';
+	TEXT TAXON=20 CHARACTER=18 TEXT='Surface smooth [@Sun2012]';
+	TEXT TAXON=16 CHARACTER=13 TEXT='Polygonal [@Luter2000]';
+	TEXT TAXON=15 CHARACTER=13 TEXT='Reported as hexagonal in Discina [@Luter2000]';
+	TEXT TAXON=17 CHARACTER=13 TEXT='Polygonal in Calloria [@Luter2000]';
+	TEXT TAXON=23 CHARACTER=13 TEXT='The loose spacing of pyrite infills of microvillar canals in Wiwaxia sclerites [@Smith2014] argues against a close-packed arrangement.';
+	TEXT TAXON=21 CHARACTER=13 TEXT='Round [@Fischer1980]';
+	TEXT TAXON=20 CHARACTER=13 TEXT='Annelid setae are prominently round, with gaps between each microvillar chamber [@Orrhage1971]';
+	TEXT TAXON=13 CHARACTER=13 TEXT='Polygonal [@Gordon1975]';
+	TEXT TAXON=44 CHARACTER=136 TEXT='Micrina exhibits polygonal imprints on the internal surfaces of successive second-order laminae, suggesting the existence of a polygonal organization of these layers [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=49 CHARACTER=136 TEXT='Present [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=35 CHARACTER=136 TEXT='Present [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=46 CHARACTER=136 TEXT='It is conceivable that the rods (Balthasar 2008) correspond to the polygonal ornament observed in other taxa; coded as ambiguous.';
+	TEXT TAXON=33 CHARACTER=136 TEXT='@Dewing2004';
+	TEXT TAXON=50 CHARACTER=136 TEXT='Prominently present [@Holmer2009Theenigmatic]';
+	TEXT TAXON=25 CHARACTER=136 TEXT='Polygonal structures on external surface of sclerites only [@Skovsted2015Theearly]; not reported from other camenellans [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=16 CHARACTER=136 TEXT='Absent in Lingula, though potentially equivalent, if superficial [@Balthasar2009Homologousskeletal], features adorn Lingulella [@Curry1983]';
+	TEXT TAXON=28 CHARACTER=136 TEXT='Present [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=29 CHARACTER=136 TEXT='Lamination present, with no imprints of presumed mantle cells [following @Williams1998Thediversity, appendix 2]';
+	TEXT TAXON=15 CHARACTER=136 TEXT='@Williams1998Chemicostructural';
+	TEXT TAXON=14 CHARACTER=136 TEXT='@Parkinson2005';
+	TEXT TAXON=37 CHARACTER=136 TEXT='@Hanken1985Thetaxonomy';
+	TEXT TAXON=32 CHARACTER=136 TEXT='Epithelial cell moulds present on inner shell layer in acrotretids [@Zhang2016Epithelialcell]';
+	TEXT TAXON=34 CHARACTER=136 TEXT='[@Williams1997Introduction, fig. 249.1]';
+	TEXT TAXON=36 CHARACTER=136 TEXT='Lamination present, with no imprints of presumed mantle cells [following @Williams1998Thediversity, appendix 2]';
+	TEXT TAXON=51 CHARACTER=136 TEXT='(Williams et al. 2004)';
+	TEXT TAXON=31 CHARACTER=136 TEXT='Lamination present, with no imprints of presumed mantle cells [following @Williams1998Thediversity, appendix 2]';
+	TEXT TAXON=6 CHARACTER=136 TEXT='Coded following helen microstructure described in the similar material of ''Hyolithes'' [@MartiMus2007]';
+	TEXT TAXON=49 CHARACTER=134 TEXT='Particularly apparent [@Larsson2014iPaterimitra].';
+	TEXT TAXON=33 CHARACTER=134 TEXT='@Dewing2004';
+	TEXT TAXON=50 CHARACTER=134 TEXT='Laminae seem to terminate at superficial ridges [@Holmer2009Theenigmatic]';
+	TEXT TAXON=25 CHARACTER=134 TEXT='Each lamina corresponds to a ridge on the surface [@Skovsted2015Theearly]';
+	TEXT TAXON=28 CHARACTER=134 TEXT='@Topper2013Theoldest';
+	TEXT TAXON=15 CHARACTER=134 TEXT='@Williams1998Chemicostructural';
+	TEXT TAXON=14 CHARACTER=134 TEXT='@Parkinson2005';
+	TEXT TAXON=36 CHARACTER=134 TEXT='@Balthasar2007Anearly';
+	TEXT TAXON=51 CHARACTER=134 TEXT='(Williams et al. 2004)';
+	TEXT TAXON=6 CHARACTER=134 TEXT='Coded following helen microstructure described in the similar material of ''Hyolithes'' [@MartiMus2007]';
+	TEXT TAXON=44 CHARACTER=135 TEXT='Matrix filled chambers [@Balthasar2009Homologousskeletal, fig. DR1]';
+	TEXT TAXON=49 CHARACTER=135 TEXT='Contiguous in some regions, but large internal cavities present [@Balthasar2009Homologousskeletal; see fig. DR3]';
+	TEXT TAXON=35 CHARACTER=135 TEXT='Contiguous [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=46 CHARACTER=135 TEXT='Seemingly contiguous [@Balthasar2008iMummpikia]';
+	TEXT TAXON=33 CHARACTER=135 TEXT='@Dewing2004';
+	TEXT TAXON=50 CHARACTER=135 TEXT='Polygonally-filled voids [@Holmer2009Theenigmatic]';
+	TEXT TAXON=25 CHARACTER=135 TEXT='Contiguous [@Skovsted2015Theearly, figs. 54-55]';
+	TEXT TAXON=28 CHARACTER=135 TEXT='Contiguous [@Balthasar2009Homologousskeletal]';
+	TEXT TAXON=15 CHARACTER=135 TEXT='@Williams1998Chemicostructural';
+	TEXT TAXON=14 CHARACTER=135 TEXT='Not in Novocrania, though possibly present in Neoancistrocrania [@Parkinson2005]';
+	TEXT TAXON=37 CHARACTER=135 TEXT='@Hanken1985Thetaxonomy';
+	TEXT TAXON=32 CHARACTER=135 TEXT='Acrotretid laminae are separated by column-supported voids';
+	TEXT TAXON=34 CHARACTER=135 TEXT='[@Williams1997Introduction, fig. 249.1]';
+	TEXT TAXON=45 CHARACTER=135 TEXT='[@Balthasar2004Shellstructure]';
+	TEXT TAXON=36 CHARACTER=135 TEXT='Essentially contiguous, notwithstanding occasional laminae of calcite/chlorite [@Balthasar2007Anearly]';
+	TEXT TAXON=51 CHARACTER=135 TEXT='(Williams et al. 2004)';
+	TEXT TAXON=31 CHARACTER=135 TEXT='Skovsted & Holmer 2003';
+	TEXT TAXON=6 CHARACTER=135 TEXT='Coded following helen microstructure described in the similar material of ''Hyolithes'' [@MartiMus2007]';
+	TEXT TAXON=4 CHARACTER=73 TEXT='"The diameter of orthothecid opercula is generally slightly smaller than the diameter of the conch aperture. This observation is confirmed [in Conotheca] and further supported by the recurrent presence of opercula preserved withdrawn inside the conch" -- @Devaere2014';
+	TEXT TAXON=6 CHARACTER=73 TEXT='@MartiMus2005';
+	TEXT TAXON=8 CHARACTER=73 TEXT='Following depiction in @Marek1976';
+	TEXT TAXON=3 CHARACTER=73 TEXT='Operculum interpreted as sitting inside conical shell [@Marek1976]';
+	TEXT TAXON=7 CHARACTER=73 TEXT='Articulated specimens unknown';
+	TEXT TAXON=2 CHARACTER=73 TEXT='"The width range of opercula matches that of the apertures" [@Sun2018], but it is not possible to determine whether this is an exact match or whether the operculum may have been slightly smaller, and hence retractable, as anticipated for orthothecids.';
+	TEXT TAXON=44 CHARACTER=75 TEXT='Mitral valve aperture essentially round [@Holmer2008TheEarly]';
+	TEXT TAXON=49 CHARACTER=75 TEXT='Broad posterior sinus: not directly comparable with brachiopod condition.';
+	TEXT TAXON=41 CHARACTER=75 TEXT='Round [@Balthasar2009EarlyCambrian]';
+	TEXT TAXON=52 CHARACTER=75 TEXT='Essentially round, sulcus notwithstanding [@Streng2016Anew]';
+	TEXT TAXON=46 CHARACTER=75 TEXT='Polygonal [@Balthasar2008iMummpikia]';
+	TEXT TAXON=33 CHARACTER=75 TEXT='Lateral margins subparallel, cf. Askepasma [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=40 CHARACTER=75 TEXT='Lateral margins subparallel [@Williams2000LinguliformeaCraniiformea, fig. 125]; clear angular corners in K. chengjiangensis [@Holmer2018Theattachment]';
+	TEXT TAXON=50 CHARACTER=75 TEXT='Short subparallel stretch of lateral sides of adult shell [@Holmer2009Theenigmatic, fig. 1a], recalling D-shaped profile of Askepasma';
+	TEXT TAXON=26 CHARACTER=75 TEXT='Round [@Holmer2006Aspinose]';
+	TEXT TAXON=42 CHARACTER=75 TEXT='Linear, diverging lateral margins [@Zhang2007Noteon]';
+	TEXT TAXON=28 CHARACTER=75 TEXT='Lateral margins subparallel, cf. Askepasma [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=29 CHARACTER=75 TEXT='Lateral margins subparallel, cf. Askepasma [@Robson2001Cambrianand]';
+	TEXT TAXON=47 CHARACTER=75 TEXT='Lateral margins subparallel, cf. Askepasma [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=15 CHARACTER=75 TEXT='Essentially round [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=14 CHARACTER=75 TEXT='Essentially round [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=30 CHARACTER=75 TEXT='Lateral margins subparallel, cf. Askepasma [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=27 CHARACTER=75 TEXT='Sub-triangular [@Zhang2011Anobolellate]';
+	TEXT TAXON=48 CHARACTER=75 TEXT='Essentially round, hinge notwithstanding [@Williams2000LinguliformeaCraniiformea, fig. 523]';
+	TEXT TAXON=37 CHARACTER=75 TEXT='Round, hinge notwithstanding [@Hanken1985Thetaxonomy]';
+	TEXT TAXON=38 CHARACTER=75 TEXT='Lateral margins subparallel, cf. Askepasma [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=32 CHARACTER=75 TEXT='Round [@Topper2013Reappraisalof]';
+	TEXT TAXON=54 CHARACTER=75 TEXT='Polygonal [@Zhang2014Anearly]';
+	TEXT TAXON=34 CHARACTER=75 TEXT='Round [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=53 CHARACTER=75 TEXT='Essentially round, hinge notwithstanding [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=45 CHARACTER=75 TEXT='Round [@Balthasar2004Shellstructure]';
+	TEXT TAXON=36 CHARACTER=75 TEXT='Essentially triangular [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=51 CHARACTER=75 TEXT='Round [@Williams2000LinguliformeaCraniiformea]';
+	TEXT TAXON=31 CHARACTER=75 TEXT='Diverging lateral margins [@Li2004]';
+	TEXT TAXON=24 CHARACTER=75 TEXT='Anterior shell essentially triangular';
+	TEXT TAXON=22 CHARACTER=75 TEXT='Opening essentially polygonal (a rolled rectangle)';
+	TEXT TAXON=8 CHARACTER=75 TEXT='Subtriangular [@Malinky1987]';
+	TEXT TAXON=3 CHARACTER=75 TEXT='Operculum essentially round, though becoming flattened on functionally ventral surface [@Dzik1980Ontogenyof]';
+	TEXT TAXON=7 CHARACTER=75 TEXT='Polygonal [@Zhang2018Ahyolithid]';
+	TEXT TAXON=6 CHARACTER=76 TEXT='Initially diverging, becoming subparallel [@MartiMus2005]';
+ENDBLOCK;
+
+BEGIN TREES;
+	TRANSLATE
+		1	Namacalathus,
+		2	Cupitheca_holocyclata,
+		3	Bactrotheca,
+		4	Conotheca,
+		5	Haplophrentis_carinatus,
+		6	Maxilites,
+		7	Paramicrocornus,
+		8	Pauxillites,
+		9	Pedunculotheca_diania,
+		10	Cotyledion_tylodes,
+		11	Loxosomella,
+		12	Flustra,
+		13	Amathia,
+		14	Novocrania,
+		15	Pelagodiscus_atlanticus,
+		16	Lingula,
+		17	Terebratulina,
+		18	Phoronis,
+		19	Sipunculus,
+		20	Serpula,
+		21	Tonicella,
+		22	Dentalium,
+		23	Wiwaxia_corrugata,
+		24	Halkieria_evangelista,
+		25	Dailyatia,
+		26	Acanthotretella_spinosa,
+		27	Alisina,
+		28	Askepasma_toddense,
+		29	Micromitra,
+		30	Antigonambonites_planus,
+		31	Botsfordia,
+		32	Clupeafumosus_socialis,
+		33	Coolinia_pecten,
+		34	Craniops,
+		35	Eccentrotheca,
+		36	Eoobolus,
+		37	Gasconsia,
+		38	Glyptoria,
+		39	Heliomedusa_orienta,
+		40	Kutorgina_chengjiangensis,
+		41	Lingulosacculus,
+		42	Lingulellotreta_malongensis,
+		43	Longtancunella_chengjiangensis,
+		44	Micrina,
+		45	Mickwitzia_muralensis,
+		46	Mummpikia_nuda,
+		47	Nisusia_sulcata,
+		48	Orthis,
+		49	Paterimitra,
+		50	Salanygolina,
+		51	Siphonobolus_priscus,
+		52	Tomteluva_perturbata,
+		53	Ussunia,
+		54	Yuganotheca_elegans
+	;
+	TREE * BAYESIAN.2499500 = [&U] (((((23,(21,22)),(19,20)),((12,((1,((53,((9,(2,((7,((6,5),8)),(4,3)))),((34,14),(((((32,(41,(51,26))),((46,(31,36)),42)),16),15),((39,(45,(44,49))),(((28,29),((33,30),(((38,(43,((17,48),27))),(47,40)),(52,(54,50))))),37)))))),18)),13)),(35,25))),24),10,11);
+	TREE * BAYESIAN.2550500 = [&U] (((35,((25,24),10)),((13,12),((1,(((9,((7,(5,(8,6))),(4,3))),2),(34,(((39,53),(((44,49),(((((47,40),((30,33),(43,((52,50),54)))),(38,(48,(17,27)))),(28,29)),37)),(45,((((42,((31,36),46)),16),((41,(51,26)),32)),15)))),14)))),18))),((19,20),((22,21),23)),11);
+	TREE * BAYESIAN.2601500 = [&U] ((20,(19,((21,22),23))),(10,(((24,(((((9,2),((7,(5,(8,6))),(4,3))),((14,(((((45,(49,44)),(37,((((50,(43,(54,52))),(((48,(17,27)),38),(40,47))),(33,30)),(29,28)))),(((15,(32,(41,(26,51)))),(42,(31,(46,36)))),16)),39),53)),34)),18),(1,(12,13)))),25),35)),11);
+	TREE * BAYESIAN.2652500 = [&U] ((24,(((12,1),13),((((34,(((39,45),((((41,((49,44),32)),(51,26)),((16,(((43,(50,(54,52))),((((30,33),(27,(48,17))),38),(40,47))),((37,28),29))),(((36,46),31),42))),15)),14)),53),(((3,4),(((8,6),5),7)),(9,2))),18))),(((20,(((21,22),23),19)),(25,35)),10),11);
+	TREE * BAYESIAN.2703500 = [&U] ((10,((((25,24),49),(((18,1),((((((((33,30),(((17,48),27),(38,(((54,43),(50,52)),(40,47))))),(28,29)),37),(15,((((42,((26,51),(32,41))),46),(31,36)),16))),((44,39),45)),(53,(14,34))),(((9,2),(((5,8),6),7)),(4,3)))),(13,12))),35)),(((23,21),22),(19,20)),11);
+	TREE * BAYESIAN.2754500 = [&U] (((13,12),(1,((((9,((3,(7,(5,(8,6)))),4)),2),(((((45,39),((16,((((((((41,(44,49)),32),(51,26)),46),36),(((37,29),28),(((54,50),52),((33,30),((38,((43,27),(17,48))),(40,47)))))),31),42)),15)),14),53),34)),18))),(35,((((((23,21),22),(19,20)),24),25),10)),11);
+	TREE * BAYESIAN.2805500 = [&U] (((((((14,(15,(16,((((36,((((53,37),(28,29)),((30,33),(((52,(50,40)),47),(((54,43),((48,17),27)),38)))),46)),31),42),((26,(51,(45,39))),(41,(32,(49,44)))))))),34),((9,2),((7,((6,8),5)),(4,3)))),18),((10,(35,(13,12))),(24,25))),1),((19,((21,22),23)),20),11);
+	TREE * BAYESIAN.2856500 = [&U] (((10,35),((25,24),((12,13),((18,(((2,((4,3),(7,(5,(6,8))))),9),((53,(14,34)),(((37,(((((30,33),(43,(50,(52,54)))),(38,((17,27),48))),(47,40)),(28,29))),(45,((49,44),(15,(((32,(26,51)),(41,(42,((31,46),36)))),16))))),39)))),1)))),(((21,22),23),(20,19)),11);
+	TREE * BAYESIAN.2907500 = [&U] ((((22,21),23),(20,19)),(((((12,13),(1,(18,((((((4,3),(9,2)),(((6,5),8),7)),53),((14,((45,39),((((((30,33),((27,(17,48)),(38,(47,40)))),(43,(54,(52,50)))),(28,29)),(49,44)),((16,(15,((42,46),(36,31)))),(((41,32),26),51))))),34)),37)))),10),35),(24,25)),11);
+	TREE * BAYESIAN.2958500 = [&U] (((19,20),(23,(22,21))),((((53,((2,(9,((4,3),(7,((8,6),5))))),(34,(14,(39,((37,(((((50,43),(52,54)),((40,47),((30,33),(38,((17,27),48))))),28),29)),(((42,(((26,51),((49,44),45)),(41,32))),((31,36),(46,16))),15))))))),18),(1,(12,13))),(((24,25),10),35)),11);
+	TREE * BAYESIAN.3009500 = [&U] ((((((18,(1,(((((((((((38,(((17,48),27),43)),(40,(47,(54,(50,52))))),(33,30)),(28,29)),37),((49,44),(51,(((41,32),26),((42,(46,(36,31))),(15,16)))))),45),39),14),(53,((4,((7,(5,(8,6))),(9,2))),3))),34))),(13,12)),35),(25,24)),10),((19,(23,(21,22))),20),11);
+	TREE * BAYESIAN.3060500 = [&U] ((1,(10,(((((22,21),23),35),(19,20)),(24,25)))),((13,12),(((34,((((29,(28,((33,30),(((54,52),(43,50)),((((17,27),48),38),(40,47)))))),37),((45,39),((51,((((49,44),41),(32,26)),(42,(36,(46,31))))),(16,15)))),14)),(((2,9),((((5,6),8),7),(3,4))),53)),18)),11);
+	TREE * BAYESIAN.3111500 = [&U] (((24,25),35),((((23,(21,22)),(19,20)),((1,(18,(((((9,2),(((8,6),5),7)),3),4),(53,(34,(((37,((28,29),((((48,(17,27)),38),(47,40)),((((33,30),50),(43,54)),52)))),(((41,((51,26),((((42,46),(31,36)),16),15))),(32,(49,44))),(39,45))),14)))))),(12,13))),10),11);
+	TREE * BAYESIAN.3162500 = [&U] (((19,20),(23,(21,22))),(((((13,12),35),((1,(((53,((14,(15,((((26,(41,32)),(51,(((37,((29,28),(((30,33),(((54,50),52),43)),((47,40),((27,(17,48)),38))))),(44,49)),(39,45)))),((31,(36,46)),42)),16))),34)),((3,((((5,6),8),7),4)),(9,2))),18)),10)),24),25),11);
+	TREE * BAYESIAN.3213500 = [&U] (((13,12),((((((4,3),((5,(6,8)),7)),(9,2)),((45,39),((49,44),(((46,((16,((53,(34,14)),15)),(42,(36,31)))),(32,((26,51),41))),(((30,(33,54)),((((((17,48),27),43),38),(47,40)),(52,50))),(37,(28,29))))))),18),1)),((((((20,19),((23,22),21)),10),35),24),25),11);
+	TREE * BAYESIAN.3264500 = [&U] (((10,(35,((13,12),((1,18),(53,(((2,9),(((5,(6,8)),7),(4,3))),(((15,(((((((32,41),44),26),((39,45),51)),(42,((36,46),31))),(37,(29,(((50,(43,54)),((33,30),((((17,27),48),38),((47,52),40)))),28)))),16)),14),34))))))),((25,49),24)),(23,((19,20),(21,22))),11);
+	TREE * BAYESIAN.3315500 = [&U] (10,(24,((25,((1,(13,12)),(18,((2,(9,((7,((8,6),5)),(4,3)))),((34,(14,(((39,45),(((((((50,(54,43)),47),(40,52)),(33,30)),(38,((17,27),48))),(28,29)),37)),((16,(((26,((44,41),32)),51),(46,((36,31),42)))),15)))),53))))),(49,(35,((19,20),(23,(22,21))))))),11);
+	TREE * BAYESIAN.3366500 = [&U] ((((13,12),(1,(18,(((14,(((45,39),(37,((16,((((41,(((31,36),46),42)),((44,49),32)),(26,51)),15)),((29,28),((33,30),(((17,48),27),(38,((40,47),(43,((54,52),50)))))))))),53)),34),((9,2),((3,4),((5,(6,8)),7))))))),10),((35,19),((23,(22,21)),((25,24),20))),11);
+	TREE * BAYESIAN.3417500 = [&U] ((35,(25,(24,(((18,((((5,(6,8)),7),((3,4),(9,2))),(53,(34,(((45,39),((44,49),(((((36,31),(46,42)),(15,16)),(51,(26,(32,41)))),((29,28),(((38,((48,17),27)),(43,((30,33),((47,40),((52,54),50))))),37))))),14))))),(1,(12,13))),10)))),((23,(21,22)),(20,19)),11);
+	TREE * BAYESIAN.3468500 = [&U] ((10,(((13,12),((18,1),(((14,((53,(((((((38,(48,(27,17))),(((50,(54,52)),43),(47,40))),(33,30)),28),29),(((44,49),39),45)),37)),(15,(16,(((31,(36,46)),42),(((51,26),32),41)))))),34),(3,(4,(((7,((6,8),5)),9),2)))))),(24,25))),(35,((20,19),((21,23),22))),11);
+	TREE * BAYESIAN.3519500 = [&U] (35,(((25,24),(20,(19,((21,22),23)))),(10,(((12,13),1),(18,((((53,39),(((45,(44,49)),(37,((51,((26,(32,41)),(16,((46,15),(42,(36,31)))))),((28,29),(((47,(38,((17,48),(27,43)))),40),((30,33),((52,54),50))))))),14)),((3,4),(((7,((6,8),5)),9),2))),34))))),11);
+	TREE * BAYESIAN.3570500 = [&U] (1,((((22,21),23),(20,19)),(35,(((12,13),49),(10,(((18,24),(((4,3),(2,((((6,8),5),7),9))),(34,(53,(14,((45,(((29,(28,((30,33),(((54,43),50),(((52,(38,((17,27),48))),40),47))))),37),(((((46,42),(36,31)),(15,16)),((41,26),(44,32))),51))),39)))))),25))))),11);
+	TREE * BAYESIAN.3621500 = [&U] ((10,(35,((20,((23,(21,22)),19)),(24,25)))),((18,(((34,((14,(39,(45,(((44,49),((((((41,(26,51)),32),(31,36)),(42,46)),16),15)),(37,(((30,33),(((43,(54,52)),((38,(48,(27,17))),(40,47))),50)),(28,29))))))),53)),((7,(5,(6,8))),((9,2),(3,4)))),1)),(12,13)),11);
+	TREE * BAYESIAN.3672500 = [&U] ((25,24),((((13,12),((((14,((((16,(((42,(46,(32,(41,(26,51))))),31),36)),15),(((29,(28,((47,40),(((43,(54,(50,52))),(30,33)),(((17,27),48),38))))),37),((49,44),(45,39)))),(53,34))),(((9,(3,4)),2),(7,((6,8),5)))),1),18)),(20,(((21,22),23),19))),(35,10)),11);
+	TREE * BAYESIAN.3723500 = [&U] ((20,(19,(23,(22,21)))),(10,((((24,(12,13)),35),25),((1,(((34,(37,53)),((((5,(8,6)),7),(3,4)),(9,2))),(14,((((28,((((38,(47,(40,52))),(43,(27,(17,48)))),((33,30),(54,50))),29)),(49,44)),(((((46,(15,16)),(31,36)),42),((32,26),41)),51)),(39,45))))),18))),11);
+	TREE * BAYESIAN.3775000 = [&U] (((24,25),((20,(19,(23,(22,21)))),35)),((18,((((14,34),((((15,(16,((((36,46),31),42),(41,((32,(44,49)),(26,51)))))),45),((((33,(30,(((17,27),38),48))),(47,(40,(((52,54),43),50)))),(28,29)),37)),39)),53),((3,(4,(7,(5,(6,8))))),(9,2)))),((1,10),(13,12))),11);
+	TREE * BAYESIAN.3826000 = [&U] (10,(((1,(13,12)),(18,(53,((34,(((((((((50,52),43),54),(((33,30),(48,(17,27))),((40,47),38))),(28,29)),37),(39,45)),((16,((((36,31),46),42),(51,((32,41),(26,(49,44)))))),15)),14)),((9,2),(((6,(8,5)),7),(3,4))))))),((35,((19,(23,(22,21))),20)),(25,24))),11);
+	TREE * BAYESIAN.3877000 = [&U] ((10,(((((34,(((53,((((((33,30),((47,(40,(52,((54,50),43)))),(38,(48,(17,27))))),(29,28)),(44,49)),(((((42,(36,(31,46))),(((41,32),26),51)),16),15),45)),37)),39),14)),((4,3),(((7,(5,(8,6))),9),2))),(18,1)),(13,12)),(24,25))),(35,(((22,21),23),(19,20))),11);
+	TREE * BAYESIAN.3928000 = [&U] (((10,(24,25)),((((18,(((34,(14,((45,39),((44,49),(((51,((26,(41,32)),((15,16),(46,((42,31),36))))),((((52,(54,50)),(47,40)),(((48,38),((43,27),17)),(33,30))),(28,29))),37))))),53),(9,(2,((4,3),(7,((6,8),5))))))),(12,13)),1),((20,19),(23,(21,22))))),35,11);
+	TREE * BAYESIAN.3979000 = [&U] ((((24,25),(10,((12,13),((18,(34,((53,(((3,4),(7,((6,8),5))),(2,9))),(14,(39,((37,((28,29),(((50,43),54),((33,30),((47,(40,52)),(38,((17,27),48))))))),((49,44),(((32,41),(51,26)),(((42,((46,36),31)),16),(15,45)))))))))),1)))),((20,19),(23,(22,21)))),35,11);
+	TREE * BAYESIAN.4030000 = [&U] (((((13,12),(18,(1,(((34,14),(53,(((16,((42,((31,36),((32,41),(26,51)))),46)),15),((44,(45,39)),((((50,(52,54)),((43,(33,30)),(((27,(48,17)),38),(40,47)))),(28,29)),37))))),(((9,2),(7,((6,8),5))),(3,4)))))),10),((24,25),35)),((((21,22),23),(19,20)),49),11);
+	TREE * BAYESIAN.4081000 = [&U] (((25,24),((((1,(((((((49,44),((32,((26,51),((((31,(36,46)),42),(16,15)),41))),(45,((28,(((38,(27,(48,17))),((40,47),((54,52),((50,43),(30,33))))),29)),37)))),39),14),34),(53,((2,9),(((7,((8,6),5)),3),4)))),18)),(12,13)),10),35)),((21,(22,23)),(19,20)),11);
+	TREE * BAYESIAN.4132000 = [&U] ((((((((3,4),((7,((8,6),5)),(9,2))),(34,(53,(14,(((49,44),(37,(((28,((33,30),((50,(52,54)),((43,(47,40)),(38,(27,(17,48))))))),29),((((42,(36,((46,15),31))),16),((32,41),26)),51)))),(45,39)))))),18),1),10),(13,12)),(35,((25,24),(((23,(21,22)),20),19))),11);
+	TREE * BAYESIAN.4183000 = [&U] ((25,24),(35,(10,(((1,(18,(((2,9),((3,4),(7,((6,8),5)))),((14,(34,(53,(((((33,30),(((48,((27,43),17)),38),(47,((50,52),40)))),(29,28)),37),((15,(16,((42,(31,(36,46))),(51,((44,32),(41,26)))))),(45,39)))))),54)))),((12,13),49)),(((23,(22,21)),20),19)))),11);
+	TREE * BAYESIAN.4234000 = [&U] ((10,(35,((13,12),(((((4,((6,(5,8)),7)),(3,(2,9))),(((51,(((32,41),(44,26)),(((31,(36,46)),42),(15,16)))),(((29,((((30,33),(((48,17),27),38)),((40,47),((43,(54,52)),50))),28)),37),((34,14),53))),(39,45))),18),1)))),((25,(24,((23,(21,22)),(19,20)))),49),11);
+	TREE * BAYESIAN.4285000 = [&U] (((10,24),(35,(25,((18,(1,((((3,4),(7,((5,6),8))),(9,2)),(53,((14,34),((((((42,(31,(36,46))),(51,((32,41),26))),(49,44)),(16,((29,(37,(((54,43),(50,52)),((40,47),((30,33),((48,(27,17)),38)))))),28))),(45,39)),15)))))),(12,13))))),(((21,22),23),(20,19)),11);
+	TREE * BAYESIAN.4336000 = [&U] ((25,24),(((13,12),((((3,((((8,6),5),7),(9,2))),4),(53,((14,(((((41,(51,(26,32))),(42,((46,36),31))),16),15),(((44,49),((((((43,54),50),(((33,30),(38,(27,(17,48)))),((40,52),47))),29),28),37)),(45,39)))),34))),(1,18))),(10,(35,(20,(19,((22,21),23)))))),11);
+	TREE * BAYESIAN.4387000 = [&U] (((20,19),((22,21),23)),(10,(((25,24),((1,((((9,2),((7,(5,(8,6))),(4,3))),(34,(14,(((39,45),53),((37,(((51,(26,((41,(49,44)),32))),((42,((31,46),36)),16)),15)),((((((54,50),43),((40,52),47)),(30,(33,(38,(48,(17,27)))))),28),29)))))),18)),(13,12))),35)),11);
+	TREE * BAYESIAN.4438000 = [&U] (10,(((((20,19),((21,22),23)),((13,12),((18,1),((53,(((4,3),(2,9)),(((6,8),5),7))),((((37,(((47,(((50,(54,43)),52),40)),(38,((48,(17,27)),(30,33)))),(29,28))),((15,((((31,(46,36)),((26,(32,41)),51)),42),16)),((39,(49,44)),45))),14),34))))),(24,25)),35),11);
+	TREE * BAYESIAN.4489000 = [&U] (((35,(24,25)),10),(((23,(22,21)),(19,20)),(((53,((((39,(((44,49),(37,((29,28),((38,((17,27),48)),(((43,54),(30,33)),((52,50),(40,47))))))),(45,((16,(((26,(41,32)),51),(42,(31,(36,46))))),15)))),14),((9,((3,4),(((6,8),5),7))),2)),34)),18),(1,(12,13)))),11);
+	TREE * BAYESIAN.4540000 = [&U] (((((13,12),1),(18,((((9,2),(7,((8,6),5))),(4,3)),(53,((14,(((((((((47,40),(43,(52,54))),((30,33),50)),(38,((27,17),48))),28),29),37),((39,45),(44,49))),((((31,(36,46)),(42,((41,32),(51,26)))),16),15))),34))))),(35,(10,(24,25)))),((20,19),(23,(21,22))),11);
+	TREE * BAYESIAN.4591000 = [&U] (((((((44,49),(((((14,34),53),(37,((29,28),((((43,(54,52)),50),(((48,38),(27,17)),(33,30))),(40,47))))),((16,(15,(42,((31,46),36)))),((51,26),(32,41)))),(45,39))),((9,2),((7,((6,8),5)),(4,3)))),18),((13,12),1)),10),((25,(((20,19),(23,(22,21))),24)),35),11);
+	TREE * BAYESIAN.4642000 = [&U] ((((((((((2,(((7,((8,6),5)),(4,3)),9)),(34,(14,((37,((29,((38,((40,((50,43),(54,52))),47)),((48,(17,27)),(33,30)))),28)),((45,39),(15,((49,44),(16,((51,(26,(32,41))),(((46,36),31),42)))))))))),53),18),1),(13,12)),24),25),(35,10)),((19,(23,(21,22))),20),11);
+	TREE * BAYESIAN.4693000 = [&U] (((((24,((19,20),(23,(22,21)))),25),((13,12),((1,18),(((14,(((45,(37,(((((33,30),((50,(54,52)),((47,40),(38,((48,17),(43,27)))))),28),29),(((((42,(41,(32,(51,26)))),46),(31,36)),15),16)))),(44,49)),39)),34),(53,((9,2),(((5,(6,8)),7),(4,3)))))))),10),35,11);
+	TREE * BAYESIAN.4744000 = [&U] (((23,(21,22)),((35,20),19)),(25,(((18,(((34,53),((((((51,((32,(26,(44,49))),41)),(16,(42,(46,(31,36))))),(((28,29),((30,33),(((38,(27,(17,48))),(52,(47,40))),((50,43),54)))),37)),(39,45)),15),14)),((((9,2),(7,((6,8),5))),4),3))),((10,(13,12)),1)),24)),11);
+	TREE * BAYESIAN.4795000 = [&U] (((1,(((((14,((((((30,33),(((38,(48,(27,17))),(40,(52,47))),(54,43))),50),(29,28)),(37,(45,39))),(51,((26,(((49,44),32),41)),(((42,(31,(36,46))),16),15))))),((9,((4,3),(7,(5,(6,8))))),2)),34),53),18)),(20,(19,(23,(22,21))))),((12,13),((35,(25,24)),10)),11);
+	TREE * BAYESIAN.4846000 = [&U] (35,(((((((((14,((((16,(((46,31),36),(42,(((32,(51,26)),41),(49,44))))),15),(37,((28,29),((30,33),(((47,40),(38,((27,17),48))),((54,(50,43)),52)))))),(45,39))),34),53),(4,((2,(9,(7,((8,6),5)))),3))),18),1),(12,13)),10),((((19,(23,(22,21))),20),25),24)),11);
+	TREE * BAYESIAN.4897000 = [&U] (10,((((1,(((53,(34,(((((45,39),(16,(((((49,44),51),26),(32,41)),((31,(46,36)),42)))),15),(((28,29),(((40,47),((50,(54,43)),52)),(30,((38,(48,(27,17))),33)))),37)),14))),((((7,(5,(6,8))),(2,9)),4),3)),18)),(13,12)),((((21,22),23),19),20)),(35,(25,24))),11);
+	TREE * BAYESIAN.4948000 = [&U] (((23,(21,22)),(19,20)),(((13,12),(24,25)),((35,(18,(((2,((4,3),(7,((8,6),5)))),9),((((16,(((26,(41,32)),51),(42,(31,(46,36))))),15),(((44,49),(39,45)),(37,((29,28),(((33,30),((40,47),(52,(43,(54,50))))),(38,((17,48),27))))))),(14,(53,34)))))),(10,1))),11);
+	TREE * BAYESIAN.4999500 = [&U] ((((22,21),23),(20,19)),((25,24),((35,((1,(18,(((4,3),((9,2),((6,(5,8)),7))),(((16,((((41,(32,((51,((45,(49,44)),(((39,53),37),((((47,((((17,27),48),38),40)),((30,33),(((52,54),43),50))),28),29)))),26))),42),((36,31),46)),15)),14),34)))),(12,13))),10)),11);
+	
+	TREE * BGSEW = [&R] (11,(((12,13),((1,18),((10,35),(25,(24,(49,((9,((5,(8,6)),(7,(2,(3,4))))),(54,((((16,(36,(31,((46,15),(42,(41,(32,(51,26)))))))),(37,(53,(14,34)))),((50,(((52,(47,40)),(38,(43,(27,(17,48))))),(30,33))),(28,29))),(44,(45,39))))))))))),((19,20),(23,(21,22)))));
+	TREE * BGSEW = [&R] (11,(((13,12),(1,(18,(35,(10,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,(41,(32,(51,26))))))))),((50,(((52,(38,(43,(27,(17,48))))),(47,40)),(30,33))),(28,29))),(44,(45,39))))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((12,13),(1,(18,(35,(10,(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((46,15),(42,(32,(41,(26,51))))))))),((29,28),(50,((33,30),((52,(40,47)),(38,(43,(27,(48,17))))))))),(44,(39,45))))))))))))),((23,(22,21)),(20,19))));
+	TREE * BGSEW = [&R] (11,(((13,12),((18,1),(10,(35,(25,(24,(49,((9,((7,(2,(3,4))),(5,(8,6)))),(54,((((29,28),(50,((30,33),((52,(40,47)),(38,(43,(27,(48,17)))))))),((37,(53,(14,34))),(16,(36,(31,((46,15),(42,(41,(32,(51,26)))))))))),(44,(45,39)))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((19,20),(23,(21,22))),((13,12),(18,(1,((10,35),(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((44,(39,45)),(((37,(53,(14,34))),(16,(36,(31,((46,15),(42,(41,(32,(51,26))))))))),((29,28),(50,((30,33),((52,(38,(43,(27,(17,48))))),(47,40))))))))))))))))));
+	TREE * BGSEW = [&R] (11,(((13,12),((1,18),(10,(35,(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((15,46),(42,((32,41),(26,51)))))))),((50,((33,30),((52,(47,40)),(38,(43,(27,(48,17))))))),(29,28))),(44,(39,45)))))))))))),((19,20),(23,(22,21)))));
+	TREE * BGSEW = [&R] (11,(((12,13),(18,(1,(10,(35,(25,(24,(49,((54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,(32,(41,(51,26))))))))),((50,(52,(((47,40),(38,(43,(27,(17,48))))),(30,33)))),(28,29))),(44,(45,39)))),(9,((7,(5,(8,6))),(2,(3,4))))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),(18,(1,(10,(35,(25,(24,(49,((9,((7,(2,(3,4))),(5,(8,6)))),(54,((((37,(53,(14,34))),(16,(36,(31,((42,((41,32),(51,26))),(46,15)))))),((28,29),(50,((30,33),((47,(40,52)),(38,(43,(27,(17,48))))))))),(44,(45,39))))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),((18,1),(35,(10,(25,(24,(49,((9,((7,(2,(3,4))),(5,(8,6)))),(54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,((41,32),(51,26)))))))),((50,((30,33),((52,(40,47)),(38,(43,(27,(17,48))))))),(28,29))),(44,(45,39)))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),((18,1),((35,10),(25,(24,(49,((9,((7,(2,(3,4))),(5,(8,6)))),(54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,(41,(32,(51,26))))))))),((29,28),(50,((30,33),((52,(38,(43,(27,(17,48))))),(47,40)))))),(44,(45,39))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),(1,(18,(35,(10,(25,(24,(49,((9,((7,(2,(3,4))),(5,(8,6)))),(54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,(32,(41,(26,51))))))))),((50,(((52,(47,40)),(38,(43,(27,(17,48))))),(30,33))),(28,29))),(44,(45,39))))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),(1,(18,((10,35),(25,(24,(49,((9,((7,(2,(3,4))),(5,(8,6)))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,(41,(32,(51,26))))))))),((28,29),(50,(((52,(38,(43,(27,(17,48))))),(40,47)),(30,33))))),(44,(45,39)))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),((18,1),(35,(10,(25,(24,(49,((54,((44,(45,39)),(((50,((30,33),((40,(47,52)),(38,(43,(27,(48,17))))))),(28,29)),((37,(53,(14,34))),(16,(36,(31,((46,15),(42,((41,32),(51,26))))))))))),(9,((7,(5,(8,6))),(2,(3,4)))))))))))),((20,19),(23,(21,22)))));
+	TREE * BGSEW = [&R] (11,(((12,13),(1,(18,((35,10),(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((15,46),(42,(41,(32,(26,51))))))))),((28,29),(50,((33,30),((47,(40,52)),(38,(43,(27,(48,17))))))))),(44,(39,45)))))))))))),((19,20),(23,(21,22)))));
+	TREE * BGSEW = [&R] (11,((((18,1),(35,(10,(25,(24,(49,((9,((7,(2,(4,3))),(5,(6,8)))),(54,((44,(39,45)),(((37,(53,(34,14))),(16,(36,(31,((15,46),(42,(41,(32,(26,51))))))))),((50,((33,30),((40,(52,47)),(38,(43,(27,(48,17))))))),(29,28)))))))))))),(12,13)),((23,(22,21)),(20,19))));
+	TREE * BGSEW = [&R] (11,(((13,12),((18,1),((35,10),(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((42,((41,32),(51,26))),(46,15)))))),((50,(((40,(52,47)),(38,(43,(27,(48,17))))),(30,33))),(29,28))),(44,(45,39))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),((18,1),(10,(35,(25,(24,(49,((9,((7,(2,(3,4))),(5,(8,6)))),(54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,((41,32),(51,26)))))))),((28,29),(50,((30,33),((52,(38,(43,(27,(17,48))))),(40,47)))))),(44,(45,39)))))))))))),((23,(22,21)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),(1,(18,((10,35),(25,(24,(49,((9,((7,(2,(4,3))),(5,(8,6)))),(54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,((32,41),(51,26)))))))),((28,29),(50,((30,33),((52,(38,(43,(27,(17,48))))),(40,47)))))),(44,(45,39)))))))))))),((20,19),(23,(21,22)))));
+	TREE * BGSEW = [&R] (11,(((13,12),((1,18),((10,35),(25,(24,(49,((9,((7,(2,(3,4))),(5,(8,6)))),(54,((((16,(36,(31,((46,15),(42,(32,(41,(51,26)))))))),(37,(53,(34,14)))),((50,(((52,(38,(43,(27,(17,48))))),(40,47)),(30,33))),(28,29))),(44,(45,39))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((12,13),((1,18),(35,(10,(25,(24,(49,((54,((((37,(53,(34,14))),(16,(36,(31,((15,46),(42,(41,(32,(26,51))))))))),((28,29),(50,((33,30),((47,(40,52)),(38,(43,(27,(48,17))))))))),(44,(39,45)))),(9,((7,(2,(4,3))),(5,(6,8)))))))))))),((23,(22,21)),(20,19))));
+	TREE * BGSEW = [&R] (11,(((12,13),(18,(1,(35,(10,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,((41,32),(51,26)))))))),((50,(52,((40,(47,(38,(43,(27,(17,48)))))),(30,33)))),(28,29))),(44,(45,39))))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,((((1,18),(10,(35,(25,(24,(49,((9,((7,(2,(4,3))),(5,(6,8)))),(54,((44,(39,45)),(((37,(53,(34,14))),(16,(36,(31,((42,(32,(41,(26,51)))),(15,46)))))),((50,((33,30),((47,(52,40)),(38,(43,(27,(48,17))))))),(29,28)))))))))))),(12,13)),((23,(22,21)),(20,19))));
+	TREE * BGSEW = [&R] (11,(((1,(18,(35,(10,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,(32,(41,(51,26))))))))),((50,((30,33),((47,(52,40)),(38,(43,(27,(17,48))))))),(28,29))),(44,(45,39)))))))))))),(13,12)),((20,19),(23,(21,22)))));
+	TREE * BGSEW = [&R] (11,(((13,12),(1,(18,(10,(35,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((46,15),(42,((32,41),(51,26)))))))),((28,29),(50,((30,33),((52,(47,40)),(38,(43,(27,(48,17))))))))),(44,(39,45))))))))))))),((23,(21,22)),(19,20))));
+	TREE * BGSEW = [&R] (11,(((13,12),(18,(1,((10,35),(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(34,14))),(16,(36,(31,((42,(41,(32,(26,51)))),(15,46)))))),((29,28),(50,((33,30),((38,(43,(27,(48,17)))),(40,(47,52))))))),(44,(39,45)))))))))))),((23,(22,21)),(20,19))));
+	
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(21,22))),((13,12),(1,(18,(10,(35,(25,(24,(49,((54,((((37,(53,(34,14))),(16,(36,(31,((15,46),(42,(32,(41,(51,26))))))))),((28,29),(50,((33,30),((47,40),(52,(38,(43,(27,(48,17)))))))))),(44,(45,39)))),(9,((7,(5,(6,8))),(2,(4,3)))))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((12,13),(1,(18,((35,10),(25,(24,(49,((9,((2,(3,4)),(7,(5,(8,6))))),(54,((((37,(53,(14,34))),(16,(36,(31,((42,((32,41),(26,51))),(15,46)))))),((29,28),(50,(((52,(38,(43,(27,(17,48))))),(47,40)),(30,33))))),(44,(45,39))))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((12,13),((18,1),(10,(35,(25,(24,(49,((9,((2,(4,3)),(7,(5,(8,6))))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,(41,(32,(26,51))))))))),((29,28),(50,(((52,(38,(43,(27,(48,17))))),(47,40)),(30,33))))),(44,(45,39))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(22,21))),((13,12),((1,18),(35,(10,(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((15,46),(42,(41,(32,(51,26))))))))),((50,(((52,(38,(43,(27,(17,48))))),(40,47)),(33,30))),(28,29))),(44,(39,45))))))))))))));
+	TREE * BGSIW = [&R] (11,(((12,13),(1,(18,(10,(35,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,((32,41),(26,51)))))))),((29,28),(50,(((52,(38,(43,(27,(48,17))))),(47,40)),(30,33))))),(44,(45,39))))))))))))),((19,20),(23,(21,22)))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((12,13),(1,(18,((35,10),(25,(24,(49,((9,((2,(3,4)),(7,(5,(8,6))))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,((32,41),(26,51)))))))),((29,28),(50,((30,33),((47,40),(52,(38,(43,(27,(17,48)))))))))),(44,(39,45))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(21,22))),((12,13),(18,(1,((10,35),(25,(24,(49,((54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,(41,(32,(26,51))))))))),((29,28),(50,(((52,(38,(43,(27,(17,48))))),(47,40)),(30,33))))),(44,(45,39)))),(9,((7,(5,(8,6))),(2,(3,4))))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(22,21))),((13,12),(18,(1,((35,10),(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((46,15),(42,(32,(41,(51,26))))))))),((28,29),(50,((33,30),((47,40),(52,(38,(43,(27,(48,17)))))))))),(44,(39,45))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(22,21))),((13,12),((18,1),((35,10),(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((46,15),(42,((32,41),(51,26)))))))),((28,29),(50,((33,30),((52,(38,(43,(27,(48,17))))),(40,47)))))),(44,(39,45)))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(22,21))),((13,12),(1,(18,((10,35),(25,(24,(49,((9,((2,(4,3)),(7,(5,(6,8))))),(54,((((37,(53,(34,14))),(16,(36,(31,((46,15),(42,(41,(32,(51,26))))))))),((28,29),(50,((33,30),((47,40),(52,(38,(43,(27,(48,17)))))))))),(44,(39,45))))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((12,13),((1,18),(35,(10,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,(32,(41,(26,51))))))))),((29,28),(50,(((47,40),(52,(38,(43,(27,(17,48)))))),(30,33))))),(44,(45,39))))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((13,12),(1,(18,(10,(35,(25,(24,(49,((9,((2,(3,4)),(7,(5,(8,6))))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,(32,(41,(26,51))))))))),((29,28),(50,(((52,(38,(43,(27,(17,48))))),(40,47)),(30,33))))),(44,(45,39)))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(22,21))),((13,12),(1,(18,((10,35),(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((50,(((52,(38,(43,(27,(48,17))))),(47,40)),(33,30))),(28,29)),((37,(53,(34,14))),(16,(36,(31,((46,15),(42,((41,32),(51,26))))))))),(44,(39,45))))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((12,13),((1,18),((35,10),(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,((32,41),(26,51)))))))),((29,28),(50,((30,33),((52,(38,(43,(27,(48,17))))),(47,40)))))),(44,(45,39)))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(22,21))),((12,13),((18,1),((35,10),(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((44,(45,39)),(((37,(53,(14,34))),(16,(36,(31,((46,15),(42,(32,(41,(26,51))))))))),((29,28),(50,((30,33),((40,47),(52,(38,(43,(27,(17,48)))))))))))))))))))));
+	TREE * BGSIW = [&R] (11,(((13,12),(18,(1,(10,(35,(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((46,15),(42,((32,41),(51,26)))))))),((50,(((47,40),(52,(38,(43,(27,(48,17)))))),(33,30))),(28,29))),(44,(39,45))))))))))))),((20,19),(23,(21,22)))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((13,12),(1,(18,(35,(10,(25,(24,(49,((9,((2,(4,3)),(7,(5,(8,6))))),(54,((((28,29),(50,((33,30),((47,40),(52,(38,(43,(27,(17,48))))))))),((37,(53,(14,34))),(16,(36,(31,((42,(41,(32,(26,51)))),(15,46))))))),(44,(39,45)))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(21,22))),((13,12),((18,1),(35,(10,(25,(24,(49,((9,((2,(4,3)),(7,(5,(6,8))))),(54,((((37,(53,(34,14))),(16,(36,(31,((46,15),(42,((41,32),(51,26)))))))),((28,29),(50,(((52,(38,(43,(27,(48,17))))),(40,47)),(33,30))))),(44,(39,45))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(21,22))),((12,13),(1,(18,(35,(10,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(34,14))),(16,(36,(31,((15,46),(42,(32,(41,(26,51))))))))),((29,28),(50,(((40,47),(52,(38,(43,(27,(17,48)))))),(30,33))))),(44,(45,39)))))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((13,12),((18,1),(10,(35,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((29,28),(50,(((47,40),(52,(38,(43,(27,(48,17)))))),(30,33)))),((37,(53,(14,34))),(16,(36,(31,((15,46),(42,(32,(41,(26,51)))))))))),(44,(45,39))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(22,21))),((13,12),((1,18),(10,(35,(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((15,46),(42,(41,(32,(51,26))))))))),((29,28),(50,(((52,(38,(43,(27,(48,17))))),(47,40)),(33,30))))),(44,(39,45))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(22,21))),((13,12),(18,(1,(35,(10,(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((15,46),(42,((32,41),(51,26)))))))),((29,28),(50,(((40,47),(52,(38,(43,(27,(17,48)))))),(33,30))))),(44,(39,45)))))))))))))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(21,22))),((12,13),(1,(18,(10,(35,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((37,(53,(14,34))),(16,(36,(31,((15,46),(42,(41,(32,(26,51))))))))),((28,29),(50,((30,33),((52,(38,(43,(27,(17,48))))),(47,40)))))),(44,(45,39)))))))))))))));
+	TREE * BGSIW = [&R] (11,(((20,19),(23,(22,21))),((18,(1,(10,(35,(25,(24,(49,((9,((7,(5,(6,8))),(2,(4,3)))),(54,((((37,(53,(34,14))),(16,(36,(31,((46,15),(42,(32,(41,(51,26))))))))),((28,29),(50,(((52,(38,(43,(27,(48,17))))),(40,47)),(33,30))))),(44,(39,45)))))))))))),(13,12))));
+	TREE * BGSIW = [&R] (11,(((19,20),(23,(22,21))),((12,13),(1,(18,(10,(35,(25,(24,(49,((9,((7,(5,(8,6))),(2,(3,4)))),(54,((((16,(36,(31,((42,(32,(41,(51,26)))),(15,46))))),(37,(53,(14,34)))),((29,28),(50,((30,33),((52,(38,(43,(27,(17,48))))),(47,40)))))),(44,(45,39)))))))))))))));
+	
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((((2,9),(7,(5,(6,8)))),(3,4)),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(41,(32,(26,51)))))))))),((((38,(43,(27,(17,48)))),(40,47)),((30,33),(50,(52,54)))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((4,(3,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,(41,(32,(26,51)))),(36,(31,46)))))),(28,(29,(((38,(43,(27,(17,48)))),(40,47)),((30,33),(52,(50,54))))))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),(3,(4,(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(32,(41,(26,51)))))))))),((((38,(48,(17,27))),(40,47)),(43,((30,33),(50,(52,54))))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((4,(3,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,(32,(41,(26,51)))),(36,(31,46)))))),(28,(29,(((38,(43,(27,(17,48)))),(40,47)),((30,33),(50,(52,54))))))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((((2,9),(7,(5,(6,8)))),(3,4)),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,(41,(32,(26,51)))),(36,(31,46)))))),((((38,(48,(17,27))),(40,47)),(43,((30,33),(50,(52,54))))),(28,29))))))))),(11,(((35,(10,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((4,(3,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(32,(41,(26,51)))))))))),(28,(29,(((38,(43,(27,(17,48)))),(40,47)),((30,33),(52,(50,54))))))))))))),(11,(((35,(10,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((((2,9),(7,(5,(6,8)))),(3,4)),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,(41,(32,(26,51)))),(36,(31,46)))))),((((38,(43,(27,(17,48)))),(40,47)),((30,33),(50,(52,54)))),(28,29))))))))),(11,(((10,(35,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((4,(3,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,(41,(32,(26,51)))),(36,(31,46)))))),((((38,(27,(17,48))),(40,47)),(43,((30,33),(50,(52,54))))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),(4,(3,(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,((26,51),(32,41))))))))),((29,((38,((48,(17,27)),(30,33))),(40,47))),(28,(50,(43,(52,54)))))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((((2,9),(7,(5,(6,8)))),(3,4)),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,((26,51),(32,41))),(36,(31,46)))))),((((38,(43,(27,(17,48)))),(40,47)),((30,33),(52,(50,54)))),(28,29))))))))),(11,(((10,(35,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),(3,(4,(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,((26,51),(32,41))))))))),(((38,(27,(17,48))),((43,((30,33),(50,(52,54)))),(40,47))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),((3,4),(7,(5,(6,8))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(32,(41,(26,51)))))))))),((((38,(43,(27,(17,48)))),(40,47)),((30,33),(50,(52,54)))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((4,(3,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(32,(41,(26,51)))))))))),((((38,(48,(17,27))),(40,47)),(43,((30,33),(50,(52,54))))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),((3,4),(7,(5,(6,8))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,((26,51),(32,41))),(36,(31,46)))))),((29,((38,((48,(17,27)),(30,33))),(40,47))),(28,(50,(43,(52,54)))))))))))),(11,(((10,(35,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),((3,4),(7,(5,(6,8))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,((26,51),(32,41))),(36,(31,46)))))),((((38,(43,(27,(17,48)))),(40,47)),((30,33),(50,(52,54)))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((4,(3,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,((26,51),(32,41))),(36,(31,46)))))),(((38,(27,(17,48))),((43,((30,33),(50,(52,54)))),(40,47))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),(3,(4,(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,((26,51),(32,41))))))))),((((38,(27,(17,48))),(40,47)),(43,((30,33),(50,(52,54))))),(28,29))))))))),(11,(((35,(10,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((((2,9),(7,(5,(6,8)))),(3,4)),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,(32,(41,(26,51)))),(36,(31,46)))))),((29,((38,((48,(17,27)),(30,33))),(40,47))),(28,(50,(43,(52,54)))))))))))),(11,(((10,(35,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),(3,(4,(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,((26,51),(32,41))))))))),((((38,(43,(27,(17,48)))),(40,47)),((30,33),(52,(50,54)))),(28,29))))))))),(11,(((10,(35,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),((3,4),(7,(5,(6,8))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,((26,51),(32,41))))))))),(28,(29,(((38,(43,(27,(17,48)))),(40,47)),((30,33),(52,(50,54))))))))))))),(11,(((35,(10,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,(((2,9),((3,4),(7,(5,(6,8))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,((42,(41,(32,(26,51)))),(36,(31,46)))))),(28,(29,(((38,(43,(27,(17,48)))),(40,47)),((30,33),(52,(50,54))))))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((((2,9),(7,(5,(6,8)))),(3,4)),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(41,(32,(26,51)))))))))),(((38,(27,(17,48))),((43,((30,33),(50,(52,54)))),(40,47))),(28,29))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((3,(4,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(32,(41,(26,51)))))))))),((((38,(43,(27,(17,48)))),(40,47)),((30,33),(52,(50,54)))),(28,29))))))))),(11,(((35,(10,(24,25))),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((3,(4,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(41,(32,(26,51)))))))))),(28,(29,(((38,(43,(27,(17,48)))),(40,47)),((30,33),(50,(52,54))))))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+	TREE * TNTEW = [&R] (12,(13,((18,(1,((4,(3,((2,9),(7,(5,(6,8)))))),(39,(45,(44,(((37,(53,(14,34))),(15,(16,(36,(46,(31,(42,(32,(41,(26,51)))))))))),((29,((38,((48,(17,27)),(30,33))),(40,47))),(28,(50,(43,(52,54)))))))))))),(11,((((10,35),(24,25)),(22,(23,(21,49)))),(19,20))))));
+END;

--- a/dev/benchmarks/data-na/lobo.nex
+++ b/dev/benchmarks/data-na/lobo.nex
@@ -1,0 +1,1812 @@
+#NEXUS
+
+    [ File output by Morphobank v3.0 (http://www.morphobank.org); 2023-05-09 11.38.24 ]
+
+    BEGIN TAXA;
+    DIMENSIONS NTAX=102;
+    TAXLABELS
+    		'Gastrotricha'
+		'Lineus'
+		'Solenogastres'
+		'Nereis annelida'
+		'Eokinorhynchus rara'
+		'K antygomonas paulae'
+		'K cateria gerlachi'
+		'K campyloderes cf vanhoeffeni'
+		'K centroderes spinosus'
+		'K dracoderes abei'
+		'K echinoderes dujardinii'
+		'K zelinkaderes klepali'
+		'K paracentrophyes anurus'
+		'K pycnophyes zelinkaei'
+		'K franciscideres kalenesos'
+		'Nanaloricus mysticus'
+		'Pliciloricus'
+		'Eolorica deadwoodensis'
+		'Sirilorica carlsbergi'
+		'Orstenoloricus shergoldii'
+		'Acosmia'
+		'Shergoldana australiensis'
+		'Gordioid nmorpha Chordodes'
+		'Nematomorpha nectonema'
+		'Nematoda kinonchulus'
+		'Nematoda anatonchus'
+		'Acanthopriapulus horridus'
+		'Halicryptus spinulosus'
+		'Maccabeus'
+		'Meiopriapulus fijiensis'
+		'Priapulopsis bicaudatus'
+		'Priapulus caudatus'
+		'Tubiluchus lemburgi'
+		'Tubiluchus vanuatensis'
+		'Markuelia lauriei'
+		'Ancalagon minor'
+		'Eopriapulites sphinx'
+		'Eximipriapulus globocaudata'
+		'Fieldia lanceolata'
+		'Laojieella thecata'
+		'Ottoia prolifica'
+		'Ottoia tricuspida'
+		'Palaeopriapulites parvus'
+		'Paratubiluchus bicaudatus'
+		'Priapulites konecniorum'
+		'Scolecofurca rara'
+		'Selkirkia columbia'
+		'Paraselkirkia sinica'
+		'Sicyophorus rarus'
+		'Xiaoheiqingella peculiaris'
+		'CHALAZOSCOLEX pharkus'
+		'CORYNETIS brevis'
+		'CRICOCOSMIA jinningensis'
+		'GUANDUSCOLEX minor'
+		'LOUISELLA pedunculata'
+		'MAFANGSCOLEX'
+		'MAOTIANSHANIA cylindrica'
+		'PALAEOSCOLEX piscatorum'
+		'SCHISTOSCOLEX umbilicatus'
+		'SCATHASCOLEX minor'
+		'TABELLISCOLEX hexagonus'
+		'TYLOTITES petiolaris'
+		'WRONASCOLEX antiquus'
+		'WRONASCOLEX iacoborum'
+		'XYSTOSCOLEX boreogyrus'
+		'YUNNANOSCOLEX magnus'
+		'Aysheaia'
+		'Siberion'
+		'Onychodictyon ferox'
+		'Onychodictyon gracilis'
+		'Diania'
+		'Xenusion'
+		'Paucipodia'
+		'Microdictyon'
+		'Cardiodictyon'
+		'Hallucigenia sparsa'
+		'Hallucigenia fortis'
+		'Hallucigenia hongmeia'
+		'Luolishania'
+		'Collins monster Emu Bay'
+		'Orstenotubulus'
+		'Antennacanthopodia'
+		'Ilyodes'
+		'Euperipatoides onychophora'
+		'Actinarctus heterotardigrada'
+		'Halobiotus eutardigrada'
+		'Siberian orsten tardigrade'
+		'Megadictyon'
+		'Jianshanopodia'
+		'Hadranax'
+		'Kerygmachela'
+		'Pambdelurion'
+		'Opabinia'
+		'Anomalocaris'
+		'Peytoia'
+		'Hurdia'
+		'Fuxianhuia'
+		'Chengjiangocaris'
+		'Leanchoilia'
+		'Alalcomenaeus'
+		'Misszhouia longicaudata'
+		'Kuamaia lata'
+    ;
+    ENDBLOCK;
+
+    BEGIN CHARACTERS;
+	DIMENSIONS NCHAR=251;
+	FORMAT DATATYPE=STANDARD GAP=- MISSING=? SYMBOLS="0123456";
+	CHARLABELS
+		 [1] 'Paired appendages'
+		 [2] 'Mouth opening orientation'
+		 [3] 'Anterior region covered by sclerites'
+		 [4] 'Head shield formed by fused cephalic segments'
+		 [5] 'Arcuate anterior sclerite associated with eye-stalks'
+		 [6] 'Serially repeated mid-gut glands'
+		 [7] 'Polythyridium'
+		 [8] 'Nature of post-ocular (post-protocerebral) body appendages'
+		 [9] 'Sclerotization of pre-ocular (protocerebral) limb pair'
+		 [10] 'Pre-ocular (protocerebral) limb pair with arthrodial membranes'
+		 [11] 'Nature of post-ocular lobopodous inner branch'
+		 [12] 'Nature of first post-ocular (deutocerebral) appendage'
+		 [13] 'Deutocerebral limb pair structurally differentiated from rest of trunk appendages'
+		 [14] 'Position of pre-ocular (protocerebral) appendage pair'
+		 [15] 'Pre-ocular (protocerebral) appendage pair fused'
+		 [16] 'Nature of pre-ocular (protocerebral) appendage fusion'
+		 [17] 'Spines/spinules on pre-ocular (protocerebral) appendage'
+		 [18] 'Number of spine/spinule series on pre-ocular (protocerebral) frontal appendage'
+		 [19] 'Coplanar spine/spinule series in pre-ocular (protocerebral) frontal appendages'
+		 [20] 'Multifurcate distal termination of protocerebral appendage'
+		 [21] 'Eyes'
+		 [22] 'Eye attachment'
+		 [23] 'Type of eyes'
+		 [24] 'Aspect ratio of body length to (maximum) trunk width in adult'
+		 [25] 'Clear differentiation of dorsal and ventral trunk'
+		 [26] 'Epidermal segmentation'
+		 [27] 'Annulations'
+		 [28] 'Organization of trunk annulation'
+		 [29] 'Circular body musculature'
+		 [30] 'Skeletal musculature'
+		 [31] 'Distinct introvert'
+		 [32] 'Differentiated region of anterior trunk'
+		 [33] 'Undifferentiated anterior trunk annulations become indistinct'
+		 [34] 'Posterior trunk with localised bulbous widening'
+		 [35] 'Tergal plates, connected by arthrodial membranes'
+		 [36] 'Sternites connected by arthrodial membranes'
+		 [37] 'Anterior margin of first sternite bears lateral projections'
+		 [38] 'Anterior margin of first sternites bears medial notch'
+		 [39] 'Posterior ventral spine on first sternite'
+		 [40] 'Second segment is a single ring'
+		 [41] 'Sternal plates in trunk segments 7+'
+		 [42] 'Sternal plates in third and fourth segment'
+		 [43] 'Sternal plates in terminal segment'
+		 [44] 'Lateroventral notches in posterior sternite margins'
+		 [45] 'Dorsal extension of posterior sternite margins'
+		 [46] 'Dorsal extension of posterior sternite margins extended into spinose process'
+		 [47] 'Dorsal bands of lanceolate blades'
+		 [48] 'Setae on sternal plates'
+		 [49] 'Posterior sternal plate bears lateral terminal spines'
+		 [50] 'Posterior sternal plate bears lateral accessory spines'
+		 [51] 'Posterior sternal plate bears medial spine'
+		 [52] 'Adult trunk covered with epidermal papillae or plates'
+		 [53] 'Epidermal plates constitution'
+		 [54] 'Epidermal plates shape'
+		 [55] 'Epidermal plates include trunk tubuli'
+		 [56] 'Epidermal plates profile'
+		 [57] 'Epidermal plates nodes'
+		 [58] 'Epidermal plate nodes number of rings'
+		 [59] 'Epidermal plate nodes number in central ring'
+		 [60] 'Epidermal plate nodes number in central ring is constant'
+		 [61] 'Epidermal plate nodes exact number of nodes in central ring (if four to six)'
+		 [62] 'Epidermal plates distribution'
+		 [63] 'Epidermal papillae distribution in two ventral rows'
+		 [64] 'Epidermal plate rows distribution'
+		 [65] 'Epidermal plate rows number of plate fields'
+		 [66] 'Epidermal plate rows distribution of plates within fields'
+		 [67] 'Epidermal plates platelets present in addition to plates'
+		 [68] 'Epidermal platelets with radial supporting buttresses'
+		 [69] 'Epidermal plates microplates present in addition to plates'
+		 [70] 'Epidermal plates tessellation'
+		 [71] 'Regularly spaced dorsolateral epidermal specializations'
+		 [72] 'Nature of paired epidermal specialization'
+		 [73] 'Proportions of epidermal trunk evaginations'
+		 [74] 'Trunk epidermal evaginations with acute distal termination'
+		 [75] 'Acute distal termination in epidermal evagination is curved'
+		 [76] 'Sclerotization of epidermal evaginations'
+		 [77] 'Dorsal trunk sclerite ornament'
+		 [78] 'Sclerites consist of a stack of constituent elements'
+		 [79] 'Maximum number of dorsal epidermal specializations in each transverse band'
+		 [80] 'Trunk exites'
+		 [81] 'Form of exite'
+		 [82] 'Exite and endopod fused (biramy)'
+		 [83] 'Antero-posteriorly compressed protopodite with gnathobasic endites in post-deutocerebral appendage pair'
+		 [84] 'Secondary structures on lobopodous limbs'
+		 [85] 'Nature of secondary structure'
+		 [86] 'Papillae on lobopodous limbs'
+		 [87] 'Finger-like elements in distal tip of limbs'
+		 [88] 'Terminal claws on trunk limbs'
+		 [89] 'Terminal claws with multiple branches '
+		 [90] 'Number of claws on trunk limbs '
+		 [91] 'External branch expressed as lateral flaps (body extends laterally into imbricated, unsclerotized flaps)'
+		 [92] 'Longitudinal (gill-like) wrinkling on distal part of (outer branch) flaps'
+		 [93] 'Strengthening rays in lateral flaps'
+		 [94] 'Posterior tapering of lateral flaps'
+		 [95] 'Lobopodous limbs differentiated into two batches of multiple anterior/long and posterior/short limbs'
+		 [96] 'Appendages comprise 15 or more podomeres'
+		 [97] 'Posterior tagma composed of three paired lateral flaps'
+		 [98] 'Posteriormost pair of trunk appendages structurally differentiated'
+		 [99] 'Nature of differentiated posteriormost appendages'
+		 [100] 'Nature of appendicular tail'
+		 [101] 'Direction of claws on posteriormost appendage pair'
+		 [102] 'Invaginable introvert'
+		 [103] 'Extent of introvert invagination'
+		 [104] 'Two rings of introvert retractors attach through the collar-shaped brain'
+		 [105] 'Eversible pharynx'
+		 [106] 'Zone III eversible'
+		 [107] 'Pharynx permanently everted'
+		 [108] 'Size of pharynx when everted'
+		 [109] 'Introvert or pharynx employed in locomotion'
+		 [110] 'Pharyngeal lumina symmetry'
+		 [111] 'Introvert symmetry pentaradial'
+		 [112] 'Introvert symmetry twentyfive-fold'
+		 [113] 'Introvert symmetry hexaraidal'
+		 [114] 'Introvert symmetry nineteen-fold'
+		 [115] 'Elements that comprise first three circlets define number of longitudinal rows of elements on the introvert'
+		 [116] 'Zone III wider than Zone II'
+		 [117] 'Bulb at terminal pharynx'
+		 [118] 'Large dorsal tooth'
+		 [119] 'Zone I armature'
+		 [120] 'Zone I armature direction'
+		 [121] 'Zone I armature number of circlets'
+		 [122] 'Zone I armature elements in two superposed series'
+		 [123] 'Zone I armature arrangement,'
+		 [124] 'Zone I armature: row orientation'
+		 [125] 'Zone I armature cuticularized'
+		 [126] 'Zone I armature elements solid'
+		 [127] 'Zone I armature elements elongate'
+		 [128] 'Zone I armature elements curved'
+		 [129] 'Zone I armature elements bifurcating'
+		 [130] 'Zone I armature elements dentate'
+		 [131] 'Zone I armature elements comprising articulated units'
+		 [132] 'Zone I armature elements bearing setules'
+		 [133] 'Zone I armature elements telescopic'
+		 [134] 'Zone I armature elements hooded'
+		 [135] 'Zone II armature'
+		 [136] 'Zone II armature element constitution'
+		 [137] 'Zone II armature differentiated scalids'
+		 [138] 'Zone II armature number of elements in proximal circlet'
+		 [139] 'Zone II armature element morphology'
+		 [140] 'Zone II armature elements with multiple cusps'
+		 [141] 'Proximal circlet of Zone II armature fused to introvert'
+		 [142] 'Zone III armature'
+		 [143] 'Zone III armature retained to adulthood'
+		 [144] 'Zone III armature composition'
+		 [145] 'Zone III armature number of circlets'
+		 [146] 'Zone III armature number of pentagonal circlets in proximal region'
+		 [147] 'Proximal circlet of Zone III armature number of elements'
+		 [148] 'Proximal circlet of Zone III armature which multiple of five'
+		 [149] 'Proximal circlet of Zone III armature dorsal element reduced'
+		 [150] 'Proximal circlet of Zone III armature massively reduced'
+		 [151] 'Proximal circlet of Zone III armature of alternating size'
+		 [152] 'Proximal circlet of Zone III armature is morphologically differentiated'
+		 [153] 'Proximal circlet of Zone III armature elements with prominent central spine'
+		 [154] 'Proximal circlet of Zone III armature prominent central spine recurved (hooked)'
+		 [155] 'Proximal circlet of Zone III armature elements bear additional robust spines (multispinose) or pectinate fringe'
+		 [156] 'Proximal circlet of Zone III armature elements comprise articulated units'
+		 [157] 'Middle circlets of Zone III armature present'
+		 [158] 'Middle circlets of Zone III armature element morphology'
+		 [159] 'Distal circlets of Zone III armature morphologically distinct'
+		 [160] 'Distal circlets of Zone III armature element morphology'
+		 [161] 'Distal circlets of Zone III armature trend of element size'
+		 [162] 'Neck forms segment-like ring'
+		 [163] 'Trichoscalids'
+		 [164] 'Trichoscalids nature of separation between trichoscalids and Zone I armature'
+		 [165] 'Trichoscalids number'
+		 [166] 'Trichoscalids basal plates'
+		 [167] 'Lorica in larval stage'
+		 [168] 'Lorica in adult stage'
+		 [169] 'Lorica number of cuticular plates in anteriormost ring'
+		 [170] 'Lorica second series of lorical plates'
+		 [171] 'Lorica cuticle thickened in dorsal and ventral lorical plates'
+		 [172] 'Lorica ornament of plates'
+		 [173] 'Lorical plates shape of distal margins'
+		 [174] 'Neck encircled by ring of cuticular plates'
+		 [175] 'Cuticular neck plates form closing mechanism when adult head retracted into trunk'
+		 [176] 'Cuticular neck plate closing apparatus symmetry'
+		 [177] 'Cuticular neck plates number'
+		 [178] 'Cuticular neck plates distal margin shape'
+		 [179] 'Cuticular neck plates attachment to first trunk segment'
+		 [180] 'Middle of trunk bears single pair of elongated lateral cuspidate spines'
+		 [181] 'Flosculi or sensory spots'
+		 [182] 'Type of sensory spots'
+		 [183] 'Flosculi with petals'
+		 [184] 'Number of petals in flosculi'
+		 [185] 'Clavulae'
+		 [186] 'Clavula stalk length'
+		 [187] 'Clavula has distal bulb'
+		 [188] 'Bullulae'
+		 [189] 'Tube'
+		 [190] 'Posterior projections (i.e. spines or hooks)'
+		 [191] 'Posterior projections are sclerotized'
+		 [192] 'Posterior projections with basal diameter >20% trunk diameter'
+		 [193] 'Posterior projections number'
+		 [194] 'Posterior projections arrangement'
+		 [195] 'Posterior ring papillae'
+		 [196] 'Posterior abdomen greatly extensible'
+		 [197] 'Anus position'
+		 [198] 'Posterior trunk divided into appendages'
+		 [199] 'Caudal appendages'
+		 [200] 'Caudal appendage eversible'
+		 [201] 'Caudal appendage length'
+		 [202] 'Caudal appendages divided'
+		 [203] 'Caudal appendage single'
+		 [204] 'Caudal appendage position'
+		 [205] 'Caudal appendage surface'
+		 [206] 'Posterior warts'
+		 [207] 'Posterior wart size'
+		 [208] 'Circumpharyngeal brain'
+		 [209] 'Circumpharyngeal brain: Subpharyngeal main region with weak suprapharyngeal commissure'
+		 [210] 'Dorsal condensed brain'
+		 [211] 'Number of neuromeres integrated into the dorsal condensed brain'
+		 [212] 'Mouth innervation relative to brain neuromeres'
+		 [213] 'Nerve cord lateralized'
+		 [214] 'Ventral nerve cord is paired'
+		 [215] 'Ventral nerve cord with paired ganglia'
+		 [216] 'Ventral nerve cords merge caudally'
+		 [217] 'Dorsal nerve cord'
+		 [218] 'Dorsal nerve cord paired'
+		 [219] 'Brain neuropil sandwiched by perikarya'
+		 [220] 'Apical brain composed of perikarya'
+		 [221] 'Tooth ganglia connected by diagonal nerve net'
+		 [222] 'Tanycytes'
+		 [223] 'Developmental mode'
+		 [224] 'Larval cuticle dorso-ventrally flattened with six accordion-like lateral plates'
+		 [225] 'Larval neck crenulated like an accordion'
+		 [226] 'Collar region present in neck during larval  stage'
+		 [227] 'Larvae/juveniles with long pharynx retractor muscles'
+		 [228] 'Larval body divided into proboscis + abdomen'
+		 [229] 'Diaphragm separates larval thorax from abdomen'
+		 [230] 'Pair of spines at anterior of larval abdomen'
+		 [231] 'Caudal spines or appendages at posterior of larval abdomen'
+		 [232] 'Larval buccal canal morphology'
+		 [233] 'Larva large mesenchyme cells'
+		 [234] 'Cloaca in both sexes'
+		 [235] 'Protonephridia'
+		 [236] 'Protonephridia integrated into the gonad'
+		 [237] 'Protonephridia compound filter, built by two or more terminal cells'
+		 [238] 'Protonephridial sieve plates'
+		 [239] 'Protonephridia terminal cells with circumciliary microvilli'
+		 [240] 'Urogenital system attached to the body wall by a ligament'
+		 [241] 'Flagellate spermatozoa'
+		 [242] 'Perigenital setae'
+		 [243] 'Primary constituent of cuticle'
+		 [244] 'Layer of cuticle containing abundant chitin'
+		 [245] 'Middle layer of cuticle has distinct composition'
+		 [246] 'Cross-wise fibres in cuticle'
+		 [247] 'Large helical fibres in cuticle'
+		 [248] 'Voluminous primary body cavity'
+		 [249] 'Heart'
+		 [250] 'Muscle cell organization '
+		 [251] 'Nucleation of "peritoneal" membrane'
+	;
+	STATELABELS
+		1
+		'absent'
+		'present'
+		,
+		2
+		'anterior'
+		'ventral'
+		'posterior'
+		,
+		3
+		'absent'
+		'present'
+		,
+		4
+		'absent'
+		'present'
+		,
+		5
+		'absent'
+		'present'
+		,
+		6
+		'absent'
+		'reniform, submillimetric lamellar'
+		,
+		7
+		'absent'
+		'present'
+		,
+		8
+		'''lobopodous'' (unsclerotized; arthrodial membranes absent)'
+		'arthropodized (sclerotized; arthrodial membranes present)'
+		'parapodia'
+		,
+		9
+		'not sclerotized'
+		'sclerotized'
+		,
+		10
+		'absent'
+		'present'
+		,
+		11
+		'cylindrical/subconical appendage'
+		'laterally expanded swimming flap'
+		,
+		12
+		'lobopodous limb'
+		'sclerotized jaw'
+		'arthropodized antenniform with distinct podomeres'
+		'arthropodized short great-appendage'
+		,
+		13
+		'undifferentiated, or differentiated in size only'
+		'structurally differentiated'
+		,
+		14
+		'lateral'
+		'ventral'
+		'terminal'
+		,
+		15
+		'not fused'
+		'fused'
+		,
+		16
+		'basal only, with separate distal elements'
+		'fused into a reduced labrum'
+		,
+		17
+		'absent'
+		'present(anomalocaridids, gilled lobopodians, certain lobopodians)'
+		,
+		18
+		'one series (e.g. Aysheaia, Kerygmachela, Opabinia)'
+		'two series (e.g. anomalocaridids, Onychodictyon ferox)'
+		,
+		19
+		'no (as in Radiodonta)'
+		'yes (as in Onychodictyon ferox)'
+		,
+		20
+		'absent'
+		'present'
+		,
+		21
+		'absent'
+		'present'
+		,
+		22
+		'eyes sessile'
+		'eyes stalked'
+		,
+		23
+		'ocellus-like or pigment spots'
+		'multiple visual units (including compound eyes)'
+		,
+		24
+		'<10'
+		'10-20'
+		'>20'
+		,
+		25
+		'trunk cylindrical and undifferentiated on dorsoventral axis'
+		'dorsal and/or ventral surface recognizable by shape, armature, or location of appendages'
+		,
+		26
+		'absent'
+		'present'
+		,
+		27
+		'absent'
+		'present'
+		,
+		28
+		'homonomous'
+		'heteronomous'
+		,
+		29
+		'absent'
+		'present'
+		,
+		30
+		'peripheral longitudinal and circular muscle'
+		'metamerically arranged skeletal muscle'
+		,
+		31
+		'absent'
+		'present'
+		,
+		32
+		'trunk of uniform construction'
+		'anterior trunk differentiated from posterior trunk by abrupt change in thickness, annulations, armature and/or appendage construction'
+		,
+		33
+		'annulations continue unaltered for full length of anterior trunk'
+		'annulations becoming indistinct anteriad'
+		,
+		34
+		'absent'
+		'present'
+		,
+		35
+		'absent'
+		'present'
+		,
+		36
+		'absent'
+		'present'
+		,
+		37
+		'projections absent'
+		'angular projections on anterolateral corners of first sternites'
+		,
+		38
+		'straight'
+		'medially incised'
+		,
+		39
+		'absent'
+		'spinose midventral process'
+		,
+		40
+		'second segment an undivided ring'
+		'second segment divided into sternites and tergites'
+		,
+		41
+		'one tergal plate with midventral articulation'
+		'one tergal and two sternal plates'
+		,
+		42
+		'as in segments 7+'
+		'differentiated'
+		,
+		43
+		'as in segments 7+'
+		'differentiated'
+		,
+		44
+		'entire'
+		'deep lateroventral notches, with or without spines'
+		,
+		45
+		'absent'
+		'present'
+		,
+		46
+		'not extended'
+		'spinose process extending well beyond posterior segment margin'
+		,
+		47
+		'absent'
+		'present'
+		,
+		48
+		'absent'
+		'present'
+		,
+		49
+		'absent'
+		'lateral terminal spines present'
+		,
+		50
+		'absent'
+		'lateral terminal accessory spines present'
+		,
+		51
+		'absent'
+		'midterminal spine present'
+		,
+		52
+		'absent'
+		'present'
+		,
+		53
+		'sclerotized'
+		'mineralized'
+		,
+		54
+		'essentially circular'
+		'elongated parallel to body axis'
+		,
+		55
+		'absent'
+		'present'
+		,
+		56
+		'flat disc, with or without nodes'
+		'conical spine'
+		'central element stands proud of flat basal region'
+		,
+		57
+		'absent'
+		'present'
+		,
+		58
+		'single ring'
+		'two rings'
+		,
+		59
+		'four to six'
+		'eight to ten'
+		,
+		60
+		'variable within an individual'
+		'constant number'
+		,
+		61
+		'three'
+		'four'
+		'five'
+		,
+		62
+		'disordered'
+		'in transverse fields'
+		'in longitudinal fields'
+		,
+		63
+		'absent'
+		'two transverse rows of accentuated papillae present'
+		,
+		64
+		'linear; each transverse row identical to last'
+		'alternate transverse rows offset, so sclerites produce quincunx'
+		'no direct correspondence between plates of one row to the next'
+		,
+		65
+		'single primary field of large plates on each annulation'
+		'two separate primary fields of large plates on each annulation, one on each margin'
+		,
+		66
+		'single series of plates'
+		'plates occur in pairs along each field'
+		'three rows of plates within each field'
+		'four rows of plates within each field'
+		,
+		67
+		'single size of sclerite (plates) only'
+		'large plates and smaller platelets (or tumuli)'
+		,
+		68
+		'absent'
+		'radial buttresses, giving stellate appearance'
+		,
+		69
+		'single size of sclerite (plates) only'
+		'large plates and smaller platelets'
+		,
+		70
+		'gaps between plates'
+		'tessellate to cover entire surface of organism'
+		,
+		71
+		'absent'
+		'present'
+		,
+		72
+		'epidermal depressions'
+		'epidermal evaginations'
+		,
+		73
+		'wider than tall (e.g. nodes or plates)'
+		'taller than wide (e.g. spines)'
+		,
+		74
+		'absent'
+		'present'
+		,
+		75
+		'absent'
+		'present'
+		,
+		76
+		'absent'
+		'present'
+		,
+		77
+		'unornamented'
+		'net-like'
+		'scaly'
+		,
+		78
+		'absent'
+		'present'
+		,
+		79
+		'one'
+		'two'
+		'three'
+		'four'
+		,
+		80
+		'absent'
+		'present'
+		,
+		81
+		'lanceolate blades in association with lateral lobes'
+		'simple oval paddle with marginal spines'
+		'bipartite shaft with lamellar setae'
+		,
+		82
+		'not fused'
+		'fused'
+		,
+		83
+		'absent'
+		'present'
+		,
+		84
+		'absent'
+		'present'
+		,
+		85
+		'spines/setae'
+		'appendicules'
+		,
+		86
+		'absent'
+		'present'
+		,
+		87
+		'absent'
+		'present'
+		,
+		88
+		'absent'
+		'present'
+		'Number of claws on trunk limbs'
+		,
+		89
+		'absent'
+		'present'
+		,
+		90
+		'one'
+		'two'
+		'three'
+		'four'
+		'seven'
+		,
+		91
+		'absent'
+		'present'
+		,
+		92
+		'absent'
+		'present'
+		,
+		93
+		'absent'
+		'present'
+		,
+		94
+		'absent'
+		'present'
+		,
+		95
+		'absent'
+		'present'
+		,
+		96
+		'Fewer than 15 podomeres'
+		'15 or more podomeres'
+		,
+		97
+		'absent'
+		'present'
+		,
+		98
+		'undifferentiated'
+		'differentiated'
+		,
+		99
+		'appendicular tail'
+		'partially fused/reduced walking legs'
+		'????'
+		,
+		100
+		'tail rami'
+		'tail flaps'
+		,
+		101
+		'same direction as claws on other appendages'
+		'rotated anteriad'
+		,
+		102
+		'introvert not present or not invaginable'
+		'introvert invaginable'
+		,
+		103
+		'invaginable to part of Zone I or equivalent'
+		'completely invaginable into the trunk (i.e. to the base of Zone I)'
+		,
+		104
+		'absent'
+		'present'
+		,
+		105
+		'pharynx (mouth cone) permanently inverted'
+		'pharynx eversible'
+		,
+		106
+		'complete'
+		'incomplete (but beyond proximal teeth only)'
+		'restricted (only as far as proximal teeth)'
+		,
+		107
+		'pharynx eversible and invaginable'
+		'pharynx permanently everted'
+		,
+		108
+		'diminutive (<2% of animal length)'
+		'very large (>30% of animal length)'
+		'enlarged base (e.g. Onychophora claws)'
+		,
+		109
+		'neither introvert nor pharynx involved in locomotion'
+		'introvert or pharynx involved in locomotion'
+		,
+		110
+		'round'
+		'triradiate'
+		,
+		111
+		'not a multiple of five'
+		'a multiple of five'
+		,
+		112
+		'not a multiple of 25'
+		'a multiple of 25'
+		,
+		113
+		'not a multiple of six'
+		'a multiple of six'
+		,
+		114
+		'not a multiple of nineteen'
+		'a multiple of nineteen'
+		,
+		115
+		'no'
+		'yes'
+		,
+		116
+		'not substantially (i.e. less than 2??) wider'
+		'substantially (at least 2??) wider'
+		,
+		117
+		'absent'
+		'present'
+		,
+		118
+		'absent'
+		'present'
+		,
+		119
+		'unarmed'
+		'armed (whether in larva or adult)'
+		,
+		120
+		'concave surface directed anteriad when introvert is everted (or equivalent)'
+		'concave surface directed posteriad when introvert is everted'
+		,
+		121
+		'single circlet'
+		'multiple circlets'
+		,
+		122
+		'elements as a single series, whether or not morphology differs'
+		'elements organized into two or more transverse bands or series, possibly with different element morphologies within each series, but the sequence of morphologies being comparable between subsequent series'
+		,
+		123
+		'not in rows'
+		'in prominent rows (excepting transverse rows)'
+		,
+		124
+		'discrete parallel longitudinal rows'
+		'rows aligned diagonal to the anterior-posterior axis of the animal, possibly producing a quincunx'
+		,
+		125
+		'papillae only'
+		'cuticularized spines, hooks or scalids'
+		,
+		126
+		'hollow'
+		'solid'
+		,
+		127
+		'not elongate'
+		'extreme elongation'
+		'more than 20 times longer than wide'
+		,
+		128
+		'dead straight'
+		'spinose/conical'
+		'curved or hooked'
+		,
+		129
+		'not bifurcate'
+		'bifurcating'
+		,
+		130
+		'edentate'
+		'dentate'
+		'pectinate'
+		,
+		131
+		'lacking articulation'
+		'articulated joints'
+		,
+		132
+		'absent'
+		'present'
+		,
+		133
+		'not telescopic'
+		'telescopic'
+		,
+		134
+		'without hood'
+		'with hood'
+		,
+		135
+		'absent'
+		'radially arranged circumpharyngeal structures present at base of introvert Zone II'
+		,
+		136
+		'labile papillae or lamellae'
+		'cuticularized scalids or plates'
+		,
+		137
+		'undifferentiated'
+		'three or four scalids are enlarged (i.e. Radiodonta)'
+		,
+		138
+		'six'
+		'seven'
+		'eight'
+		'nine'
+		'many'
+		,
+		139
+		'less than four times longer than wide'
+		'elongate spines'
+		'at least ten times longer than wide'
+		,
+		140
+		'ring commissures incomplete or absent'
+		'polycuspate'
+		,
+		141
+		'unfused'
+		'fused to introvert'
+		,
+		142
+		'unarmed'
+		'armed (whether in larvae or adults)'
+		,
+		143
+		'lost at metamorphosis, or primarily absent'
+		'retained to adulthood'
+		,
+		144
+		'composed exclusively of cuticle'
+		'outer covering of cuticle with central cavity'
+		,
+		145
+		'one'
+		'four'
+		'many'
+		'State 3?'
+		'State 4?'
+		'State 5?'
+		,
+		146
+		'five'
+		'six'
+		'seven'
+		'eight'
+		,
+		147
+		'multiple of five'
+		'multiple of six'
+		'multiple of eight'
+		,
+		148
+		'five'
+		'ten'
+		,
+		149
+		'not reduced'
+		'reduced'
+		,
+		150
+		'not reduced'
+		'reduced'
+		,
+		151
+		'uniform size'
+		'alternate elements large then small'
+		,
+		152
+		'armature not differentiated'
+		'armature of proximal circlet (or few proximal circlets) is morphologically differentiated from rest of Zone III armature'
+		,
+		153
+		'without prominent central spine'
+		'with prominent central spine'
+		,
+		154
+		'straight'
+		'strongly recurved (hooked)'
+		'appendicules'
+		,
+		155
+		'absent  #TODO Check that 1 actually means abasent!'
+		'present'
+		'needle-like'
+		,
+		156
+		'not articulated'
+		'articulated'
+		,
+		157
+		'reduced'
+		'not reduced'
+		,
+		158
+		'papillae or simple cone (no spine, wider than tall)'
+		'single spine'
+		'multiple spines'
+		'pectinate'
+		,
+		159
+		'distal circlets not differentiated, or only differentiated in size or aspect ratio'
+		'teeth in distal armature field morphologically distinct from teeth in other circlets'
+		,
+		160
+		'papillae (no spine, wider and longer than tall)'
+		'single spine'
+		'multiple spines'
+		'pectinate'
+		,
+		161
+		'approximately equal'
+		'decreasing distally (distalmost elements less than half the size of proximal)'
+		,
+		162
+		'no segment-like ring'
+		'neck forms segment-like ring'
+		,
+		163
+		'absent'
+		'present'
+		,
+		164
+		'constriction (as in loriciferans)'
+		'insertion of muscles (as in kinorhynchs)'
+		,
+		165
+		'six'
+		'seven'
+		'nine'
+		'fourteen'
+		'fifteen'
+		,
+		166
+		'absent; trichoscalids attach directly to introvert'
+		'trichoscalid plate present'
+		,
+		167
+		'absent'
+		'Ring of cuticular plates post-introvert (i.e. girdling neck / cervical region) present at any point in ontogeny'
+		,
+		168
+		'absent'
+		'present'
+		,
+		169
+		'six'
+		'seven'
+		'fourteen'
+		'twenty'
+		,
+		170
+		'absent'
+		'present'
+		,
+		171
+		'absent'
+		'present'
+		,
+		172
+		'smooth'
+		'longitudinal rows of narrow (sub)rectangular fields'
+		,
+		173
+		'straight'
+		'rectangular with straight margin and angular corners'
+		'spikes present on anterior margin of plate'
+		,
+		174
+		'absent'
+		'present (placids or lips)'
+		,
+		175
+		'absent'
+		'present'
+		,
+		176
+		'radial'
+		'bilateral'
+		,
+		177
+		'six'
+		'seven'
+		'nine'
+		'fourteen'
+		'sixteen'
+		,
+		178
+		'straight'
+		'rectangular with straight margin and angular corners'
+		'tripartite'
+		'spikes present on anterior margin of plate'
+		,
+		179
+		'fused with first trunk segment'
+		'articulated'
+		,
+		180
+		'absent'
+		'present at some point during ontogeny'
+		,
+		181
+		'absent'
+		'present'
+		,
+		182
+		'flosculi, including N-flosculi and P-flosculi'
+		'sensory spots'
+		,
+		183
+		'no petals'
+		'petals'
+		,
+		184
+		'variable'
+		'invariably eight'
+		,
+		185
+		'absent'
+		'present'
+		,
+		186
+		'short'
+		'long'
+		,
+		187
+		'distal bulb absent'
+		'distal bulb present'
+		,
+		188
+		'absent'
+		'present'
+		,
+		189
+		'absent'
+		'tube composed of plant debris'
+		'tube comprised of chitin'
+		,
+		190
+		'absent'
+		'present'
+		,
+		191
+		'tubulae'
+		'sclerites or setae'
+		,
+		192
+		'smaller'
+		'larger'
+		,
+		193
+		'two'
+		'three'
+		'four'
+		'six'
+		'eight'
+		,
+		194
+		'irregular'
+		'bilateral arc'
+		'radial ring'
+		,
+		195
+		'absent'
+		'present'
+		,
+		196
+		'absent'
+		'present'
+		,
+		197
+		'terminal'
+		'in abdomen'
+		,
+		198
+		'absent'
+		'present'
+		'tubular portion of the body extends beyond the last observable appendage pair'
+		,
+		199
+		'absent'
+		'present'
+		,
+		200
+		'not eversible'
+		'eversible'
+		,
+		201
+		'shorter than body'
+		'longer than body'
+		,
+		202
+		'undivided'
+		'pseudo-segmented'
+		,
+		203
+		'single'
+		'bicaudal'
+		,
+		204
+		'terminal'
+		'dorso-medial'
+		,
+		205
+		'smooth'
+		'vesiculate'
+		'bearing large warts'
+		,
+		206
+		'absent'
+		'present'
+		,
+		207
+		'small'
+		'large'
+		,
+		208
+		'absent'
+		'present'
+		,
+		209
+		'absent'
+		'present'
+		,
+		210
+		'absent'
+		'present'
+		,
+		211
+		'one'
+		'two'
+		'three'
+		,
+		212
+		'protocerebral innervation'
+		'deutocerebral innervation'
+		'innervation from multiple neuromeres'
+		'tritocerebral innervation'
+		,
+		213
+		'absent (Alalcomenaeus, Fuxianhuia, Tardigrada)'
+		'present (Onychophora)'
+		,
+		214
+		'unpaired throughout full length'
+		'papired'
+		,
+		215
+		'absent'
+		'present'
+		,
+		216
+		'absent'
+		'present'
+		,
+		217
+		'absent'
+		'present'
+		,
+		218
+		'unpaired'
+		'paired'
+		,
+		219
+		'equal distribution of perikarya'
+		'brain consisting of perikarya-neuropil-perikarya'
+		,
+		220
+		'apical perikarya lost'
+		'apical perikarya retained'
+		,
+		221
+		'absent'
+		'present'
+		,
+		222
+		'absent'
+		'present'
+		,
+		223
+		'direct'
+		'biphasic'
+		,
+		224
+		'absent'
+		'present'
+		,
+		225
+		'larval neck smooth'
+		'larval neck crenulated'
+		,
+		226
+		'absent'
+		'present'
+		,
+		227
+		'absent'
+		'present'
+		,
+		228
+		'division not evident'
+		'body divided'
+		,
+		229
+		'absent'
+		'present'
+		,
+		230
+		'absent'
+		'present'
+		,
+		231
+		'absent'
+		'present'
+		,
+		232
+		'short, linear or sacculose'
+		'elongate, curving'
+		,
+		233
+		'not present in both sexes'
+		'present in both sexes'
+		,
+		234
+		'absent'
+		'present'
+		,
+		235
+		'fused with first trunk segment'
+		'articulated'
+		,
+		236
+		'not integrated into the gonad'
+		'integrated into, or flow into, the gonad'
+		,
+		237
+		'absent'
+		'present'
+		,
+		238
+		,
+		239
+		'circumciliary microvilli absent'
+		'circumciliary microvilli present'
+		,
+		240
+		'no'
+		'yes'
+		,
+		241
+		'spermatozoa lack flagellum'
+		'spermatozoa with flagellum'
+		,
+		242
+		'absent'
+		'present (whether or not reduced)'
+		,
+		243
+		'alpha-chitin'
+		'collagen'
+		,
+		244
+		'exocuticle (middle cuticle layer)'
+		'endocuticle (lowermost cuticle layer)'
+		,
+		245
+		'composition not distinct'
+		'distinct composition'
+		,
+		246
+		'absent'
+		'present'
+		,
+		247
+		'absent'
+		'present'
+		,
+		248
+		'absent'
+		'present'
+		,
+		249
+		'absent'
+		'present'
+		,
+		250
+		'platymyariant'
+		'coelomyarian'
+		,
+		251
+		'membrane without nuclei or simply with ameobocytes in association with the surface'
+		'membrane containing scattered nuclei'
+		
+	;
+	MATRIX
+	'Gastrotricha'		                           0?0--?0-----0-0000-01000?0001?1??000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---0?-?-?--1????--000?--------00??000-0--0?00-----00000-0?--0--?--??00--0--???????0??-0-000??0??000000-0---0-0?????10011000000?0?0?????010???0100-0000???
+	'Lineus'		                                 0?0--?0-----0-0000-0100??000?????000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---???????????????????????----00??000-0????00-??????????????????????00--0--00----?????????0????????000-0---???????????????????????????????????10?????????
+	'Solenogastres'		                          0?0--?0-----0-0000-000-?1000?????000000---0-00-0000111010----0?---000-0------0-0-000--000--00-0-00---???????????????????????----00??000-0????00-??????????????????????00--0--00----?????????0????????000-0---???????????????????????????????????10?????????
+	'Nereis annelida'		                        100--?020---0-0000-010021110??0??000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---??-?-????????--000?--------00??000-0--0?00-----00000-0?--0--?--??00--0--00----?0-0-0-0?0??0??000000-0---000?1--01000-0?-?10?0?0??????10???010??????0??
+	'Eokinorhynchus rara'		                    000--0?-----0-0000-000-01010??100000000---0-00-0000101010----10000000-1101110010-000--000--00-0-00---1??1(0,1)00??????00?01110111?00000000110400?11??-2-00000000010--001-000--0--00----0????0-00011?21?00000-0---00????????????????????????????????????????????
+	'K antygomonas paulae'		                   000--00-----0-0000-000-011-01?1000110101100100-0111???????????????????0------0-0-000--000--00-0-00---1111200001000000011100-10100?????110??0011?1-????0????110??-0113000--0--111401?100-0-0000----000000-0---0-1??????1011110?0000-0000-0010???0100010000?0
+	'K cateria gerlachi'		                     000--00-----0-0000-000-011-01?1000110001010100-0111???????????????????0------0-0-000--000--00-0-00---??11200001000000011100-10101???????0??00????-?????????1?????0113000--0--00----?100-0-0000----000000-0---0-1??????1011110?0000-0000-0010???0100010000?0
+	'K campyloderes cf vanhoeffeni'		          000--00-----0-0000-000-011-01?1000110001100000-0111???????????????????0------0-0-000--000--00-0-00---1111200001000000011100-1010021000110??0011?1-????0????110??-0113100--0--1103010100-0-0000----000000-0---0-1??????1011110?0000-0000-0010???0100010000?0
+	'K centroderes spinosus'		                 000--00-----0-0000-000-011-01?1000110011100000-0111???????????????????0------0-0-000--000--00-0-00---??11200001000000011100-10100???????0??00????-?????????1?????0113000--0--110401?100-0-0000----000000-0---0-1??????1011110?0000-0000-0010???0100010000?0
+	'K dracoderes abei'		                      000--00-----0-0000-000-011-01?1000110001100000-0100???????????????????0------0-0-000--000--00-0-00---11112000?1000000011100-1010001000111??0011?1-???10????110??-0112000--0--1112010100-0-0000----000000-0---0-1??????1011110?0000-0000-0010???0100010000?0
+	'K echinoderes dujardinii'		               000--00-----0-0000-000-011-01?1000110000100000-0110???????????????????0------0-0-000--000--00-0-00---1111200001000000011100-10100010000-0--001111-0110011011100--0110100--0--1104010100-0-0000----000000-0---0-1?0--?01011110?0000-0000-0010???0100010000?0
+	'K zelinkaderes klepali'		                 000--00-----0-0000-000-011-01?1000110000000100-0111???????????????????0------0-0-000--000--00-0-00---??112000?1000000011100-10100?????110??0011?1-????0????1????-0113000--0--110410?100-0-0000----000000-0---0-1??????1011110?0000-0000-0010???0100010000?0
+	'K paracentrophyes anurus'		               000--00-----0-0000-000-011-011100011100110101001101???????????????????0------0-0-000--000--00-0-00---11112000?1000000011100-10100000000-0--00111?-0111011011????00113000--0--1111010100-0-0000----000000-0---0-1??????1011110?0000-0000-00?????0100010000?0
+	'K pycnophyes zelinkaei'		                 000--00-----0-0000-000-011-01?100011100110001011100???????????????????0------0-0-000--000--00-0-00---??11200011000000011100-1010000000??0??00111?-?????????0????00113000--0--1110010100-0-0000----000000-0---0-1??????101111010000-0000-00101?00100010000?0
+	'K franciscideres kalenesos'		             000--00-----0-0000-000-011-01?1000110000001100-0111???????????????????0------0-0-000--000--00-0-00---??112000?1000000011100-1010?00000??0??00111?-?????????1????0111?000--0--10----0100-0-0000----000000-0---0-1??????1011110?0000-0000-0010???0100010000?0
+	'Nanaloricus mysticus'		                   000--00-----0-0000-000-0000010100000000---0-00-0000???????????????????0------0-0-000--000--00-0-00---011101?0100100000111010101000110011020011100-1-00010000--0--01041110000100----0100-0-0000----000000-0---0-1?0--?10011110110101111111011???110011000-?0
+	'Pliciloricus'		                           000--00-----0-0000-000-0000010100000000---0-00-0000???????????????????0------0-0-000--000--00-0-00---011101?010010000011101010100011001102001(0,1)100-1-00010000--0--0104111?000000----0100-0-0000----000000-0---0-1?0--?100?????1101111111??011???110011000-?0
+	'Eolorica deadwoodensis'		                 000--??-----0-0000-000-00000??100000000---0-00-0000???????????????????0------0-0-000--000--00-0-00---0????????????????111???1010001100110000???????????????0?????01???113000000----0????????00----?00000-0---0-????????????????????????????????????????????
+	'Sirilorica carlsbergi'		                  000--??-----0-0000-000-00000??100000000---0-00-0000???????????????????0------0-0-000--000--00-0-00---?????????0010?000????????????????110001??0-----00000-00--0--00--0111100100----0????0-0?00----?00000-0---0-???????????????100????00????????????????????
+	'Orstenoloricus shergoldii'		              000--??-----0-0000-000-?0000????0000000---0-00-0000???????????????????0------?-0-000--000--00-0-00---?????????????????0???????????????????????????????????????????????1?3000000----0?????????????-??00?????????????????????????010?1?10????????????????????
+	'Acosmia'		                                000--00-----0-0000-000-00010??10?000000-?-0-00-00001?0010----?0???????0------0-0-000--000--00-0-00---0-?0-1-???0?0--100---------??????100?0000???????????????????00--??0--0--00----00-0-0-0000----?0?0???0---0-?????10--???????????????????????????????????
+	'Shergoldana australiensis'		              000--??-----0-0000-000-?0000????0000000---0-00-0000???????????????????0------?-0-000--000--00-0-00---?????????0010????101?????01000000????????????????????????????????00--0--00----0????????????????00?????????????????????????010?1?01????????????????????
+	'Gordioid nmorpha Chordodes'		             000--00-----0-0000-000-2000000100000000---0-00-0000100010----00---10000------0-0-000--000--00-0-00---0-00-0-0-00(0,1)1--0011100-11010000000-0--0010????????????0?????00--000--0--00----0?-0-0-0000----001000-0---0-110--000110110?100001101?11000?-0001101100??
+	'Nematomorpha nectonema'		                 000--00-----0-0000-000-2000000100000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---0-00-0-00????--001?1???11000000000-0--0??0????????????0?????00--000--0--00----00-0-0-0000----001000-0---0-110--000110110?1?????1??111000?-0001101100??
+	'Nematoda kinonchulus'		                   000--00-----0-0000-000-2001000100000000---0-00-0000101010----00---00--0------0-0-000--000--00-0-00---1-?0---11001000111110101?01000000110000011?0-1-??0?10000-0--0100000--0--00----00-0-0-0000----001000-0---0-1?0--0001101100???????????1000?-00011???00??
+	'Nematoda anatonchus'		                    000--00-----0-0000-000-2001000100000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---0-00-0-010010-0111000--11010000001000000110?-????000-001111000--000--0--00----00-0-0-0000----000000-0---0-1?0--0001101100100000?00??1000?-000111(0,1)1001?
+	'Acanthopriapulus horridus'		              000--00-----0-0000-000-0001010100?00000---0-00-0000100010----00---00000------0-0-000--000--00-0-00---11112011011001?001110101000000000??????0111?????????????????00--0?0?????00----?0-0-0-000?????101010010110-1?0--000-11111????????????011???11?0???010?1
+	'Halicryptus spinulosus'		                 000--00-----0-0000-000-0001010100000000---0-00-0000100010----00---00000------0-0-000--000--00-0-00---111120(0,1)101100100011101010010100001004000111530000110-00120-100--0102011000----00-0-0-0001100-101000-0---101?0--000-11111?11001100100011???1110110010?1
+	'Maccabeus'		                              000--00-----0-0000-000-0001010100000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---111120(0,1)101100100010101010010100001102?10111520000110-001211000--010?011000----110100-001110?2010000-0---0-1?0--000-11111?11001100000011???1110???010?0
+	'Meiopriapulus fijiensis'		                000--01-----0-0000-000-0000010110000000---0-00-0000100110----00---1?000------0-0-000--000--00-0-00---111110(0,1)1011000000111010100102000111020001115-2-00000-00130-000--000--0--00----010110-000110?2000000-0---0-1?0--000-1110110000-0000-0011???1110??1010?0
+	'Priapulopsis bicaudatus'		                000--00-----0-0000-000-0001010100000000---0-00-0000100010----00---11000------0-0-000--000--00-0-00---1111201101100110010111010000000101102000111500000011010120-100--010??11-00----?0-0-0-0000----101010001-10-1?0--000-11111?110011?01??011???1110????10?1
+	'Priapulus caudatus'		                     000--00-----0-0000-000-0001010100000000---0-00-0000100010----00---00000------0-0-000--000--00-0-00---1111201101100110011111010000000001102000111520000000-00120-100--0102011000----10-0-0-0000----10101001011111?0--000-11111?11001100100011???1110010010?1
+	'Tubiluchus lemburgi'		                    000--01-----0-0000-000-0001010110000000---0-00-0000100110----20---11000------0-0-000--000--00-0-00---111110(0,1)1011001000111010100102000011020001115-0000010-001313000--0103000000----01011101100----001010100000-1?0--000-11101110001110100011???1110???010?0
+	'Tubiluchus vanuatensis'		                 000--01-----0-0000-000-00010101?0000000---0-00-0000???1???????0???11??0------0-0-000--000--00-0-00---111100(0,1)1011001000111010100102000010040001115-????0????01313000--0103000000----010101???00----001010000000-1?0--000-11101110001110100011???1110???010?0
+	'Markuelia lauriei'		                      000--?0-----0-0000-000-10?10??100???????????????????????0----00---00--0------0-0-000--000--00-0-00---11???0???1100-??01110--10000000001104?00??1???????????0?????01??000--0--00----00-0-0-0??1113??00000-0---0-???????????????0000-0000-0??????????????????
+	'Ancalagon minor'		                        000--00-----0-0000-000-10010??1?0000000---0-00-00001000??????00---00000------0-0-000--000--00-0-00---1??120????????0001110111?010000000-0--0011?0-????0011000-0-000--0?0?????00----0????0-0?00----?00000-0---0-????????????????????????????????????????????
+	'Eopriapulites sphinx'		                   000--??-----0-0000-000-10010??1?0000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---???1?????00100???11101??0010000001104?00111??????0????011???00--0?0?????00----0?????-0000----?00000-0---0-????????????????????????????????????????????
+	'Eximipriapulus globocaudata'		            000--00-----0-0000-000-00010??110100000---0-00-0000100010----00---00??0------0-0-000--000--00-0-00---???120????????0001110101?01000?00???????11?5????????????????00--0?0?????00----0????0-0?00----?00000-0---0-????????????????????????????????????????????
+	'Fieldia lanceolata'		                     000--00-----0-0000-000-10010??1?0000000---0-00-000010001?????00---00000------0-0-000--000--00-0-00---1??1?0????????0001110111?01000000???????11?02????00100?0-0-000--0?0?????00----0????0-0?00----??00???????0-????????????????????????????????????????????
+	'Laojieella thecata'		                     000--00-----0-0000-000-1001???1?0100000---0-00-00000-00-0-----0---00--0------?-0-000--000--00-0-00---11?100????????0001110111?000000000-0--0011?5-?????????01???000--0???????00----0????0-0?00----?00010001-00-????????????????????????????????????????????
+	'Ottoia prolifica'		                       000--00-----0-0000-000-00010?0100000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---11?100(0,1)???????110111011100101000011040001115-????0110101213000--0?0?????00----0????0-0001104-?00011000000-??0--10--?????????????????????????0?????????
+	'Ottoia tricuspida'		                      000--00-----0-0000-000-00010?0100000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---11?100(0,1)???????110111011100101000011040001115-????0110101213000--0?0?????00----0????0-0001104-?00011000000-??????0?-?????????????????????????0?????????
+	'Palaeopriapulites parvus'		               000--00-----0-0000-000-000?0??1?0100000---0-00-00000-00-0-----0---00--0------?-0-000--000--00-0-00---1??1?01???0??1??01110101?010?0?00???????111?????????????????00--0?1?0??000----0????0-0000----?00000-0---0-????????????????????????????????????????????
+	'Paratubiluchus bicaudatus'		              000--0?-----0-0000-000-00000??11?000000---0-00-00000-00-0-----0---??--0------?-0-000--000--00-0-00---???1?01??????10?0111010??????????0-0--0011????????????01????00--0?0?????00----0?????-0?00----?0001?001-00-????????????????????????????????????????????
+	'Priapulites konecniorum'		                000--00-----0-0000-000-00010??1?0000000---0-00-00000-00-0-----0---00--0------0-0-000--000--00-0-00---1??1?0(0,1)??????1?001?11101?00?00000???????11??????????????????00--0?0?????00----0????0-0?00----?01010000100-????????????????????????????????????????????
+	'Scolecofurca rara'		                      000--00-----0-0000-000-??010??1?0000000---0-00-00000-00-0-----0---00--0------?-0-000--000--00-0-00---??????1???????1101110??1?000?0??0110--0011?5-?????????01???000--0?0?????00----0????0-0?0??????00000-0---0-????????????????????????????????????????????
+	'Selkirkia columbia'		                     000--00-----0-0000-000-(0,1)00???01??000000---0-00-0000100?10----101??????0------0-0-000--000--00-0-00---11?100(0,1)???????000111011100001000011040001115-????010-10120-000--0?0?????00----0????0-0?20----?000?0-0---0-????????????????????????????????????????????
+	'Paraselkirkia sinica'		                   000--00-----0-0000-000-(0,1)00???011?000000---0-00-00001??????????????????0------0-0-000--000--00-0-00---???100????????00011101110000?0000110?0001115-????0????0????000--0?0?????00----0????0-0?20----?000?0-0---0-????????????????????????????????????????????
+	'Sicyophorus rarus'		                      000--00-----0-0000-000-000?0??1?0100000---0-00-00000-00-0-----0---00--0------?-0-000--000--00-0-00---1??1?01???0??1?101110101?010?0?00???????111???????00-0?1?0-00?????1300?0??????0????0-0?00----?00000-0---0-????????????????????????????????????????????
+	'Xiaoheiqingella peculiaris'		             000--00-----0-0000-000-10010??100100000---0-00-0000100????????????????0------?-0-000--000--00-0-00---???1?0???110010?01110101?000000001102000111???????????01????00--0?0?????00----0????0-0?00----?0001?001-00-????????????????????????????????????????????
+	'CHALAZOSCOLEX pharkus'		                  000--??-----0-0000-000-1101010100000000---0-00-00001?00??????10?0000??110??1??(1,2)0-000--000--00-0-00---1???(0,1)??????????10111???1?00000000???????11??????????????????00--0?0?????00----0????0-0?0??????00?1?0000?0-????????????????????????????????????????????
+	'CORYNETIS brevis'		                       000--00-----0-0000-000-(0,1)0010?0100000000---0-00-0000100010----1010000??0------0-0-000--000--00-0-00---11?100(0,1)0??????0000---------000000110410011???00000????01(1,2,3)0-000--0?0?????00----0????0-0000----?0001?000000-????????????????????????????????????????????
+	'CRICOCOSMIA jinningensis'		               100--0000000010000-000-21010?0101000000---0-00-00000-00-0-----0---00--1100-11010-000--0100-00-0-00--0???1?0????????0?0110---1?01000000110400011????????????01???000--0?0?????00----0????0-0001110-?00000-0---0-????????????????????????????????????????????
+	'GUANDUSCOLEX minor'		                     000--00-----0-0000-000-10010?010?000000---0-00-0000110011100-101??00??0------0-0-000--000--00-0-00---???100????????0001?1011??????00?????????11??-????000-001???000--0?0?????00----0????0-0?011?0-?00000-0---0-????????????????????????????????????????????
+	'LOUISELLA pedunculata'		                  000--?0-----0-0000-000-11010?0110000000---0-00-0000100010----11???00??0------0-0-000--000--00-0-00---11?100(0,1)???????1101110110?000?0???110410011?5-????000-001(1,2,3)??000--0?0?????00----0????0-0000----?00011000000-??????????????????????????????????0?????????
+	'MAFANGSCOLEX'		                           000--00-----0-0000-000-20010?0111000000---0-00-0000110020----00---10010------0-0-000--000--00-0-00---1??1?????001010101110111?010?0?00110400011?5???????????1(1,2,3)??000--0?0?????00----0????0-0001110-?00000-0---0-????????????????????????????????????????????
+	'MAOTIANSHANIA cylindrica'		               000--00-----0-0000-000-20010?010?000000---0-00-0000110001001100---00??0------0-0-000--000--00-0-00---???100????????0001?1011?????????????????11???????000-0??????00--0?0?????00----0????0-0001110-?00000-0---0-????????????????????????????????????????????
+	'PALAEOSCOLEX piscatorum'		                000--?0-----0-0000-000-20010?0???000000---0-00-0000111001010-1021010110------0-0-000--000--00-0-00---??????????????????????????????????????????????????????????????????0???????????0????0-000??????00100-0---0-???????????????????????????????????1??11????
+	'SCHISTOSCOLEX umbilicatus'		              0??????-----0-0000-0????0010?0???000000---0-00-0000110021000-10?1000110------0-0-000--000--00-0-00---??????????????????????????????????????????????????????????????????????????????00-0-0-00010122?00100-0---0-???????????????????????????????????1????????
+	'SCATHASCOLEX minor'		                     000--??-----0-0000-000-2?010?010?000000---0-00-000011000100??10011000-0------0-0-000--000--00-0-00---???1??(0,1)??????-0?01100--1?01000000110400011??-????000-0012???00--0?0?????00----0????0-00011(0,1)21000000-0---0-????????????????????????????????????????????
+	'TABELLISCOLEX hexagonus'		                100--?0?????0?0000-000-21010?0?0?000000---0-00-00000-00-0-----0---00--1100-1??10-000--0100-00-0-00--0??????????????????????????????????????????????????????????????????0???????????0????0-0001110-?00000-0---0-????????????????????????????????????????????
+	'TYLOTITES petiolaris'		                   100--0000000010000-000-11010?011?000000---0-00-00001?0?10----1020000??0------?-0-000--0100-00-0-00--01??100????????0101?10111?01000000???????11?????????????????000--0?0?????00----0????0-0?01110-?00000-0---0-????????????????????????????????????????????
+	'WRONASCOLEX antiquus'		                   000--??-----0-0000-000-20010?010?000000---0-00-0000110001000-1020000110------0-0-000--000--00-0-00---0-?1??(0,1)??????-???1?00--1?0?????00???????????????????????????00--0?0?????00----0????0-00011121?00000-0---0-????????????????????????????????????????????
+	'WRONASCOLEX iacoborum'		                  0??????-----0-0000-0???20010?0???000000---0-00-0000110001001210210101?0------0-0-000--000--00-0-00---????????????????????????????????????????????????????????????0?????0?????00----0????0-000??????????????????????????????????????????????????????????????
+	'XYSTOSCOLEX boreogyrus'		                 000--??-----0-0000-000-(0,1)00101010?000000---0-00-00001?00???????????00??0------??0-000--000--00-0-00---???100???????????1110111?00000000110????11??????????????????00--0?0?????00----0????0-0?0??????0??00-0---0-????????????????????????????????????????????
+	'YUNNANOSCOLEX magnus'		                   0??????-----0-0000-0???(0,1)0010?0???000000---0-00-0000110001100-1010200110------?-0-000--000--00-0-00---??????????????????????????????????????????????????????????????????0?????00----0????0-0001110-?00000-0---0-????????????????????????????????????????????
+	'Aysheaia'		                               100--0000-00000010-100-11010?0100000000---0-00-0000100010----10?0000000------010-001010104-00-0-011-110?1-0-0?0010--000---------0000001000000???----00000-00--0--0---0?0?????00----0????0-0000----?00100-0---0-????????????????????????????????????????????
+	'Siberion'		                               100--??00-000010????00-(0,1)1010???00000000---0-00-000010?????????0????0??0------?-0-00??0????-00-0-0?????-???????????????0---------00000010???????????????????????????????0?????00----?????????0?????????00-0---??????????????????????????????????????????????
+	'Onychodictyon ferox'		                    100--0000-0000001110100(0,1)1011??100000000---0-00-0000100?10----11?0000001101011010-001100101-00-0-011-11??0-0-0?------000---------0000000-0--00??????????????0?????00--0?0?????00----0????0-0000----?00100-0---??????????????????????????????????????????????
+	'Onychodictyon gracilis'		                 10???0?0??000???????????101?????0000000---0-00-000010??????????????0??110?-1??10-00??00101-00-0-011-1?????????????????0---------000000?-0??????????????????????????????0?????00----?????????0????????000-0---??????????????????????????????????????????????
+	'Diania'		                                 100--0?00-00000000-000-?1011??000000000---0-00-00001000?0----10?00????1??0-0??00-001000?0--00-0-00--?0?????????????????????????????????-0??????????????????????????????0?????00----?????????0????????0?????????????????????????????????????????????????????
+	'Xenusion'		                               1?0--??00-000000????00-?1011???00000000---0-00-000010??????????????0??1100-0-?10-001??????-00-0-00--???????????????????????????????????-0??????????????????????????????0?????00----?????????0????????0?????????????????????????????????????????????????????
+	'Paucipodia'		                             100--0?00-00000000-000-?1010??000000000---0-00-00000-00-0-----0---?0--1???????10-000-00101-00-0-00--?0?????????????????????????????????-0??????????????????????????????0?????00----?????????0????????0?????????????????????????????????????????????????????
+	'Microdictyon'		                           100--0000-00000000-000-11011??001000000---0-00-00000-00-0-----0---00--1100-11010-000-00101-00-0-00--00-?0-0--?------000------?--000000?-0--0????----00000-0?--0--?---0?0?????00----0????0-0?00----?00000-0---0-????????????????????????????????????????????
+	'Cardiodictyon'		                          100--0?00-00100000-010??1011??001000000---0-00-00000-00-0-----0---?0--1100-11?10-000-00101-00-0-00--00-????????????????????????????????-0??????????????????????????????0?????00----?????????0????????0?????????????????????????????????????????????????????
+	'Hallucigenia sparsa'		                    100--?000-00100000-0???21000??010000000---0-00-00000-00-0-----0---00--1111012110-000-00101-00-0-00--?0-?0-0--?-----0000---------000000110410011???????000-0011??00---0?0?????00----00-0-0???00----?00?00-0---0-????????????????????????????????????????????
+	'Hallucigenia fortis'		                    100--0?00-00100000-0101?1011??011000000---0-00-00000-00-0-----0---?0--111111??10-000-00101-00-0-00--00?????????????????????????????????-0??????????????????????????????0?????00----?????????0????????0?????????????????????????????????????????????????????
+	'Hallucigenia hongmeia'		                  1??????0??0?????????????1011?????000000---0-00-00000-00-0-----0---?0--1111111?10-000-00100-00-0-00--???????????????????????????????????????????????????????????????????0?????00----?????????0????????0?????????????????????????????????????????????????????
+	'Luolishania'		                            10??-0?00-00000000-010??1011???11000000---0-00-000010??????????????0??111111??20-001010103-00-1-00--0??????????????????????????????????-0??????????????????????????????0?????00----?????????0????????0?????????????????????????????????????????????????????
+	'Collins monster Emu Bay'		                1??????0??0?????????????1011???1?000000---0-00-0000???????????????????111111??20-001000100-00-1-0??????????????????????????????????????????????????????????????????????0?????00----?????????0??????????????????????????????????????????????????????????????
+	'Orstenotubulus'		                         1??????0??00????????????1011?0???000000---0-00-0000???????????????????1111?1??10-000-1????-00-0-0??????????????????????????????????????????????????????????????????????0?????00----?????????0??????????????????????????????????????????????????????????????
+	'Antennacanthopodia'		                     100--??00-00100000-0100?101???00?000000---0-00-0000???????????????????0------?-0-000-1000--00-0-00---0?????????????????????????????????-0??????????????????????????????0?????00----?????????0????????0?????????????????????????????????????????????????????
+	'Ilyodes'		                                1??????0??0?????????????1010?????000000---0-00-000010??????????????0??0------?-0-000-10101-00-0-0??????????????????????????????????????????????????????????????????????0?????00----?????????0??????????????????????????????????????????????????????????????
+	'Euperipatoides onychophora'		             110--0000-01100000-0100110101000?000000---0-00-0000100010----1020000000------1-0-000-10101-00-0-00--00-00-0--1------000---------0000000-0--0000-----00000-00--0--0---0?0--0--00----000000-0000----000000-0---0-1?11211000?0-0?000000000-00000?-0100110001??
+	'Actinarctus heterotardigrada'		           1110-0001000010000-01000100001100000000---0-00-0000???????????????????1100-110?0-000-01103-00-0-011-11??0-0-010010--0?0---------0000001100000110??--00000-00--0--00--0?0--0--00----000000-0000----000100-0---0-1?10001100?0-0?000000000-0(0,1)000?-010011000-??
+	'Halobiotus eutardigrada'		                100--0001000020000-01000100001100000000---0-00-0000???????????????????10-----010-000-01111-00-0-011-11??0-0-010010--0?0---------0000001100000110??--00000-00--0--00--0?0--0--00----000000-0000----000100-0---0-1?10001100?0-0?000000000-0(0,1)000?-010011000-??
+	'Siberian orsten tardigrade'		             100--??0??000???????????1000???00000000---0-00-0000??????????????????????--???-0-000-00111-00-0-01(1,2)-??????????????????????????????????1????????????????????????????????0?????00----?????????0????????1?????????????????????????????????????????????????????
+	'Megadictyon'		                            1?0--1?00-0000??10-100-?1011???0?000000---0-00-00000-00-0-----0---?0--?------?-0-001100???-00-0-0?????????????????????????????????????1????????????????????????????????0?????00----?????????0??????????????????????????????????????????????????????????????
+	'Jianshanopodia'		                         100--1?00-0000??10-?00-?1011???0?000000---0-00-00000-00-0-----0---?0--0------?-0-001100???-00-0-0101-???0-????-----00?0?-----?--0000001104100?1???????000-0?13????--???0?????00----?????????0????????1?????????????????????????????????????????????????????
+	'Hadranax'		                               1??????0??00????????????1011???0?000000---0-00-000010??????????????0??110??0-?30-000-1????-00-0-0??????????????????????????????????????????????????????????????????????0?????00----?????????0??????????????????????????????????????????????????????????????
+	'Kerygmachela'		                           100--1000-00001010-1???1101110000000000---0-00-00000-00-0-----0---00--1100-0-?310000-0000-11000-0100-0??0-0--?------0?0------?--0000001??--00???-?--00000-00--0--?-????0?????00----0????0-0?00----00?100-0--?0-????????????????????????????????????????????
+	'Pambdelurion'		                           110--1?00-00011010-?00-?101??100?000000---0-00-0000???????????????????????????-10000-0000-11000-?????0??0?0--?????????????????????????110?????0????????????????????????0?????00----?????????0??????????????????????????????????????????????????????????????
+	'Opabinia'		                               110--1?00-00011010-1111?1100??000000000---0-01-0000???????????????????0------0-10000-0000-10000-1101-0??0?0--?????????????????????????100????--????????????????????????0?????00----?????????0??????????????????????????????????????????????????????????????
+	'Anomalocaris'		                           111011?0111001101101111?1000?1000000000---0-01-0000???????????????????0------0-10000-0000-10110-1101-0??0?0--?????????????????????????1114100?0????????????????????????0?????00----?????????0????????1?????????????????????????????????????????????????????
+	'Peytoia'		                                111011?011?001101101111?1000??000000000---0-01-0000???????????????????0------0-10?0???????10110-00---0??0?0--?????????????????????????1114100?0????????????????????????0?????00----?????????0????????1?????????????????????????????????????????????????????
+	'Hurdia'		                                 11101??011?001101101111?1?00??000000000---0-01-0000???????????????????0------0-10?0???????10100-0101?0??0?0--?????????????????????????1114100?1????????????????????????0?????00----?????????0????????1?????????????????????????????????????????????????????
+	'Fuxianhuia'		                             121010?110-2111100-0111?11-0??0-0010?????????0????????????????????????0------0-11100--000-000-010101-0??0?0--?????????????????????????0-0????--????????????????????????0?????00----?????0-000????????-???????????121????????????????????????????????????1??
+	'Chengjiangocaris'		                       121010?110-2111100-0111?11-0??0-0010?????????0????????????????????????0------0-11100--000-000-010101-0??0?0--?????????????????????????0-0????--????????????????????????0?????00----?????0-000????????-??????????????011????????????????????????????????????
+	'Leanchoilia'		                            121101?110-3111100-0111?11-0??0-001??????????0????????????????????????0------0-11110--010(0,2)000-0000---0??0?0--?????????????????????????0-0????--????????????????????????0?????00----?????0-000????????-?????????????????????????????????????????????????????
+	'Alalcomenaeus'		                          121101?1??-31111????111?11-0??0-001??????????0????????????????????????0------0-11110--0100000-0000---0??0?0--?????????????????????????0-0????--????????????????????????0?????00----?????0-000????????-???????????121011????????????????????????????????????
+	'Misszhouia longicaudata'		                121111?110-2111100-0111?11-0?10-0011?????????0????????????????????????0------0-12110--0100000-0000---0??0?0--?????????????????????????0-0????--????????????????????????0?????00----?????0-000????????-?????????????????????????????????????????????????????
+	'Kuamaia lata'		                           121111?110-2111100-0111?11-0?10-0011?????????0????????????????????????0------0-12110--0102000-0000---0??0?0--?????????????????????????0-0????--????????????????????????0?????00----?????0-000????????-?????????????????????????????????????????????????????
+    ;
+    ENDBLOCK;
+
+          BEGIN NOTES;
+              [Taxon comments]
+        	TEXT TAXON=25 TEXT='Kinonchulus Riemann, 1972^n= Pseudonchulus Altherr, 1972 syn. n.^n^nsee Holovachov et al., 2008';
+
+        [Character comments]
+        	TEXT CHARACTER=1 TEXT='WTS26^nPresent in certain Higgins larvae!? e.g. see Heiner 2004; Kristensen and Gad 2004 – (Sørensen et al. 2008)';
+	TEXT CHARACTER=2 TEXT='Most lobopodian taxa possess an anterior mouth – for example Aysheaia  (Whittington 1978), Onychodictyon ferox (Ou et al. 2012) and Kerygmachela (Budd 1993, 1998a) – as do Eutardigrada (e.g. Halberg et al. 2009; Persson et al. 2012).  We code Hallucigenia sparsa as having a ventral-facing mouth because the putative head region is consistently preserved facing ventrally (Ramsköld 1992; Caron et al. 2013), indicative of an authentic life habit rather than post-mortem alteration. We score this transformation series as uncertain in Megadictyon as it is difficult to determine whether the mouth was originally ventral (cf. Liu et al. 2007) or whether this appearance results from compaction. The mouth opening is ventrally oriented in Pambdelurion (Budd 1998b), Opabinia (Budd 1996), anomalocaridids (Daley et al. 2009; Daley and Edgecombe 2014), Onychophora and Heterotardigrada (Eriksson and Budd 2000; Ou et al. 2012; de Sena Oliveira and Mayer 2013; Mayer et al. 2013b; Persson et al. 2014); it faces posteriad in euarthropods (Edgecombe and Ramsköld 1999; Haug et al. 2012b; Yang et al. 2013).^n?Subterminal in adult nematomorphs (Ehlers et al. 1996, cited in Schmidt Rhaesa 1997)^n';
+	TEXT CHARACTER=3 TEXT='Numerous lobopodians have been considered to have cephalic sclerites (Ma et al. 2014a), but in some cases this interpretation requires revision or confirmation through new material. Following recent data presented by Liu and Dunlop (2014), we score this transformation series as absent in Hallucigenia fortis (contra Hou and Bergström 1995), Onychodictyon ferox (contra Ou et al. 2012) and Cardiodictyon (see Hou and Bergström 1995).  We code it as uncertain where the anterior region is ambiguously preserved, as in Onychodictyon gracilis (Liu et al. 2008) and Hallucigenia hongmeia (Steiner et al. 2012).  An uncertain coding is also applied to Luolishania, as their apparent presence is only documented by a single specimen (Ma et al. 2009) whose ‘sclerites’ worryingly resemble features in other lobopodians whose original interpretation as sclerites has since been overthrown.  Taxa with an incomplete anterior region are coded as uncertain.';
+	TEXT CHARACTER=4 TEXT='(–) inapplicable: head sclerites (transformation series 2) absent^nWe score this transformation series as absent for fuxianhuiids, because the cephalic shield is not derived from fused segments (Chen et al. 1995b; Waloszek et al. 2005; Bergström et al. 2008; Yang et al. 2013), and in anomalocaridids, because the carapace-like structure on the head seems not to cover multiple cephalic segments (e.g. Daley et al. 2009; Daley and Edgecombe 2014)';
+	TEXT CHARACTER=5 TEXT='We score this transformation series as present in anomalocaridids because the dorsal carapace-like structure covering their heads is associated with eye-stalks (e.g. Daley et al. 2009; Daley and Edgecombe 2014). Anterior sclerites are widespread among Palaeozoic euarthropods including fuxianhuiids (Budd 2008; Yang et al. 2013), and artiopodans (e.g. Edgecombe and Ramsköld 1999; Ortega-Hernández et al. 2013).  Only the leanchoiliids are coded as absent.';
+	TEXT CHARACTER=6 TEXT='Transformation series 42 in Ma et al. (Ma et al. 2014a); transformation series 16 in Daley et al. (2009).  Coded as uncertain in Antennacanthopodia (Ou et al. 2011) because the dark infilling of the type material may represent decayed internal organs.  The nature of the mid-gut glands of Megadictyon, Jianshanopodia, Pambdelurion and Opabinia is elucidated by Vannier et al. (2014). ';
+	TEXT CHARACTER=7 TEXT='WTS51.^nThe polythyridium is a component of the gut surrounding the entrance to the intestine.  Present in Tubiluchus.  Coded as ambiguous in Paratubiluchus (Han et al. 2004)';
+	TEXT CHARACTER=8 TEXT='(–) inapplicable: paired appendages (trans. ser. 1) absent';
+	TEXT CHARACTER=9 TEXT='We code this transformation series as present in any taxon with sclerotized pre-ocular (protocerebral) limbs, including the podomeres in anomalocaridid ‘great appendages’ (Daley and Edgecombe 2014) and the hypostome that covers the euarthropod labrum (e.g. Edgecombe and Ramsköld 1999; Yang et al. 2013). We score this transformation series as uncertain in taxa where the presence of a hypostome is suggested, but not verified (e.g. Alalcomenaeus), and in the Siberian ‘Orsten’ tardigrade (Maas and Waloszek 2001), where (assuming its modification to a stylet, as in modern tardigrades) it cannot be directly observed.';
+	TEXT CHARACTER=10 TEXT='(–) inapplicable: protocerebral limbs (trans. ser. 6) not sclerotized^nThis transformation series distinguishes the arthropodized ‘great appendages’ of anomalocaridids (Daley and Edgecombe 2014) from the hypostome of Euarthropoda (e.g. Edgecombe and Ramsköld 1999; Yang et al. 2013) and the stylet of Tardigrada (e.g. Halberg et al. 2009), both of which are sclerotized but lack soft arthrodial membranes.';
+	TEXT CHARACTER=11 TEXT='(–) inapplicable: post-ocular limbs, if present, are arthropodized (trans. ser. 5 = 1)^nThe cylindrical ambulacral lobopodous leg characteristic of lobopodians is also found in Opabinia (Budd 1996; Budd and Daley 2012), Kerygmachela (Budd 1993, 1998a) and Pambdelurion (Budd 1998b).  Van Roy et al. (2013) recently reported that anomalocaridids possess two sets of lateral flaps that are likely homologous to the outer and inner branches of the appendages in euarthropods, and thus represent a derived state relative to the presence of cylindrical ambulatory legs.';
+	TEXT CHARACTER=12 TEXT='This character is coded as a single transformation series with four states because each state is seemingly independent.';
+	TEXT CHARACTER=13 TEXT='(~) inapplicable: paired appendages (trans. ser. 1) absent.^nThere are various taxa in which the deutocerebral appendage pair is morphologically differentiated from the rest of the trunk appendages (see references in Liu and Dunlop 2014). For example, Antennacanthopodia has a second set of antenna-like limbs that are morphologically distinct from the walking legs (Ou et al. 2011). Daley and Edgecombe (2014) recently redescribed Anomalocaris canadensis and reported the presence of a smaller set of flaps in proximity with the putative head region; given that this differentiation is expressed in size, rather than structural identity, we score the deutocerebral limbs as undifferentiated in Anomalocaris. The first pair of legs in Tardigrada is serially homologous with the deutocerebral segment of Euarthropoda (Mayer et al. 2013b), and thus is not structurally different from the rest of the trunk appendages. The deutocerebral jaws of Onychophora are significantly modified relative to the rest of the appendages in the body (Eriksson et al. 2010; de Sena Oliveira and Mayer 2013).  In Euarthropoda, this morphological differentiation is generally expressed in the presence of an antenniform (e.g. Edgecombe and Ramsköld 1999; Ma et al. 2012; Yang et al. 2013) or raptorial (Chen et al. 2004; Haug et al. 2012b; Tanaka et al. 2013) deutocerebral appendage.^n';
+	TEXT CHARACTER=14 TEXT='(–) inapplicable: paired appendages (trans. ser. 1) absent^nWe score this transformation series as ventral in Euarthropoda given that the reduced protocerebral appendage pair, transformed into the labrum, occupies a ventral position in association with the mouth (e.g. Scholtz and Edgecombe 2006). The forward-facing stylet apparatus of Eutardigrada is internalized into the mouth cone (Halberg et al. 2009), and is thus considered as having a terminal position relative to the body; in Heterotardigrada, however, the mouth is oriented ventrally and the stylet apparatus is thus scored as having a ventral position.';
+	TEXT CHARACTER=15 TEXT='(~) inapplicable: paired appendages (trans. ser. 1) absent^nModified from transformation series 16 in Ma et al. (Ma et al. 2014a) to reflect the posited homology between the anterior appendages of lobopodians and the euarthropod labrum (cf. Eriksson and Budd 2000; Budd 2002): specifically, the euarthropod labrum is coded as a fused pair of appendages (Scholtz and Edgecombe 2006; Liu et al. 2009, 2010; Posnien et al. 2009). The stylet apparatus of Tardigrada is not coded as fused, as each stylet within the buccal tube remains independent despite significant modification (Dewel and Eibye-Jacobsen 2006; Halberg et al. 2009; Guidetti et al. 2012).  Jianshanopodia is coded uncertain due to unclear preservation (Liu et al. 2006).^n';
+	TEXT CHARACTER=16 TEXT='(~) inapplicable: protocerebral appendages not fused (trans. ser. 12 = 0)^nIn lobopodians, appendage fusion is restricted to the proximal component (cf. Budd 1993, 1998a; Daley et al. 2009; Dzik 2011; Daley and Edgecombe 2014).  Per transformation series 12 above, the euarthropod labrum is coded as a set of fully fused appendages.^n';
+	TEXT CHARACTER=17 TEXT='(~) inapplicable: paired appendages (trans. ser. 1) absent^nThis transformation series refers to the spines/spinules present in the most anterior appendage pair of anomalocaridids (Daley et al. 2009; Daley and Edgecombe 2014), gilled lobopodians (Kerygmachela, see Budd 1993, 1998; Pambdelurion, see Budd 1997; Opabinia, see Budd 1996) and certain lobopodians (e.g. Aysheaia, see Whittington 1978; Jianshanopodia, see Liu et al. 2006; Megadictyon, see Liu et al. 2007; Onychodictyon ferox, see Ou et al. 2012).';
+	TEXT CHARACTER=18 TEXT='(0) one series (e.g. Aysheaia, Kerygmachela, Opabinia) (Whittington 1978; Budd 1993, 1996, 1998a)^n(1) two series (e.g. anomalocaridids, Onychodictyon ferox) (Daley and Budd 2010; Ou et al. 2012; Daley and Edgecombe 2014)^n(–) inapplicable: spines/spinules on the protocerebral appendage (trans. ser. 14) absent';
+	TEXT CHARACTER=19 TEXT='(–) inapplicable: spine/spinules, if present, in single series (trans. ser. 15 = 0)^nThis transformation series distinguishes the coplanar spinules found in Onychodictyon ferox (Ou et al. 2012) from those of anomalocaridids (Daley et al. 2009; Daley and Budd 2010; Daley and Edgecombe 2014), where both spine rows face in the same direction.';
+	TEXT CHARACTER=20 TEXT='(~) inapplicable: spines/spinules not present on the protocerebral appendage (trans. ser. 14 = 0)^nThis transformation series describes the multifurcate termination observed in the protocerebral appendages of dinocaridids (Budd 1996; Daley et al. 2009; Daley and Budd 2010; Budd and Daley 2012; Daley and Edgecombe 2014) and certain lobopodians – such as Aysheaia  (Whittington 1978), Megadictyon (Liu et al. 2007) and Kerygmachela (Budd 1993, 1998a) – but absent in Onychodictyon ferox (Ou et al. 2012).';
+	TEXT CHARACTER=21 TEXT='Transformation series 10 in Daley et al. (2009) and 25 in Ma et al. (Ma et al. 2014a). Eyes as treated as present in Onychodictyon ferox (cf. Ou et al. 2012) and Hallucigenia fortis (cf. Liu and Dunlop 2014).';
+	TEXT CHARACTER=22 TEXT='Transformation series 26 in Ma et al. (Ma et al. 2014a).';
+	TEXT CHARACTER=23 TEXT='(–) inapplicable: eyes (trans. ser. 23) absent^nTransformation series 27 in Ma et al. (Ma et al. 2014a).  This transformation series is scored as uncertain in Luolishania because the fragmentary preservation of its visual units does not allow full resolution of the level of structural organization (see Ma et al. 2009)^n';
+	TEXT CHARACTER=24 TEXT='WTS25.  Taxa within 25% of the borderline between tokens are coded ambiguous for either token.^nDimensions for palaeoscolecids from (García-Bellido et al. 2013a). Eopriapulites follows (Shao et al. 2016).  Xystoscolex measured from photographs (Conway Morris and Peel 2010) at close to 10; scored ambiguous (0, 1).  Selkirkia around 7–10, depending on how much of tube the body occupies; scored as ambiguous (0, 1).  Paraselkirkia , measured from photographs (Hou et al. 2017)almost exactly 10';
+	TEXT CHARACTER=25 TEXT='This character distinguishes essentially cylindrical worms such as Palaeoscolex from taxa with clearly defined dorsal and ventral surfaces, whether by the presence of appendages (such as Louisella and lobopodians) or plates (such as Cricocosmia and Tabelliscolex) or by the differential expression of spinose armature (such as Tylotites).  Differentiation that is restricted to the proboscis or the posterior trunk, such as the location of the anus or presence of tail hooks or caudal appendages, is not included in this character.^nCoded as ambiguous in Mafangscolex as there are unpublished reports of trunk papillae in two rows (Han et al. 2007b)^nAbsent in Shergoldana (Maas et al. 2007a)as not clear that plate distribution follows dorsal-ventral axis.^nCoded as present in Halicryptus, as both species bear a ventral grove (Shirley and Storch 1999) ^nCoded as present in Chalazoscolex to reflect the three lateral zones (Conway Morris and Peel 2010)';
+	TEXT CHARACTER=26 TEXT='Transformation series 25 in Daley et al. (2009).  Epidermal segmentation is a distinguishing feature of Euarthropoda (e.g. Budd 2001a; Edgecombe 2009). Although the body of Onychophora and Tardigrada is metamerically organized, both at the level of segment polarity gene expression (Gabriel and Goldstein 2007; Eriksson et al. 2009) and musculature (e.g. Halberg et al. 2009; Marchioro et al. 2013), this pattern is not expressed on the epidermis: we thus score it as absent in these phyla.  We code Opabinia as present since has discrete body segments separated by furrows (Budd 1996; Zhang and Briggs 2007; Budd and Daley 2012). Epidermal segmentation is not evident in anomalocaridids (e.g. Daley and Edgecombe 2014), which we score absent.  Hurdia is the exception: because the only complete specimen is partly disarticulated (Daley et al. 2009), we consider the presence of epidermal segmentation to be ambiguous. Kinorhynchs and annelids also exhibit a segmented epidermis; though this presumably has an independent derivation from the segmentation of arthropods, the lack of a clear morphological basis for discrimination means separate character states cannot be assigned to these phyla.  It is not clear that the repeated elements of Eokinorhynchus reflect segmentation rather than annulations or serial iteration; this taxon is not coded as segmented.';
+	TEXT CHARACTER=27 TEXT='(–) inapplicable: sclerotized dorsal integument with arthrodial membranes (trans. ser. 27) present^nTransformation series 26 in Daley et al. (2009); WTS27. Annulations are repeated superficial integument rings. Coded as present in Eokinorhynchus, reflecting ring-like nature of epidermal ‘segments’ (Zhang et al. 2015).  Present in Fieldia, reflected by transverse arrangement in spines in certain specimens (e.g. USNM57715, see (Caron 2011))  The cuticle of Anatonchus bears hints of fine annulations on its tip (Peneva et al. 1999; Choudhary et al. 2009); the cuticle of Kinonchulus is ‘delicately annulated’ (Riemann 1972)1.  Coded ambiguous in Selkirkia and Paraselkirkia as the trunk is concealed by the tube, and ambiguous in Palaeopriapulites and Sicyophorus as the ‘trunk’ is putatively concealed by a lorica (Hou et al. 2017).';
+	TEXT CHARACTER=28 TEXT='(~) inapplicable: annulations (trans. ser. 29) not present^nTransformation series 29 in Liu et al. (2011); trans. ser. 27 in Daley et al. 2009; WTS27.  This transformation series distinguishes between annulation patterns that are uniform along the length of the trunk (homonomous) from those which display serially-repeated differentiated fields (heteronomous), usually associated with the location of limbs. We code Pambdelurion as uncertain, reflecting the poor preservation of the trunk (Budd 1998b).';
+	TEXT CHARACTER=29 TEXT='WTS87.^nNanaloricus bears circular muscles around the neck (Neves et al. 2013)^nCircular muscles are reduced in adult Nematoids (Sørensen et al. 2008)';
+	TEXT CHARACTER=30 TEXT='Budd (2001a) proposes the distribution of musculature as a key phylogenetic character.  The musculature of tardigrades, Pambdelurion, Anomalocaris and more derived euarthropods is metamerically arranged and runs through the body cavity, whereas muscles in cycloneuralians, onychophorans and Kerygmachela are seemingly dominated by longitudinal and circular structures (Budd 1998c, 2001a; (Neves et al. 2013).  A longitudinal arrangement of musculature is suggested by the longitudinal wrinkling present in Carbotubulus (Haug et al. 2012c). The metameric distribution of musculature in artiopodans is inferred by comparison with Campanamuta (Budd 2011).';
+	TEXT CHARACTER=31 TEXT='(–) inapplicable: WHY@^nThe anterior trunk of Aysheaia and Onychodictyon ferox is differentiated into a stout ‘proboscis’, distinct from the trunk by virtue of its shape and its lack of annulations (Ou et al. 2012).  This ‘proboscis’ is considered homologous to the cycloneuralian worm introvert (=armature Zone I).  This region is reduced in taxa such as Hallucigenia (where it has become part of the buccal cavity) and Anomalocaris (where it has been reduced and is no longer evident).  It remains present in tardigrades, in certain species bearing oral papillae.^n';
+	TEXT CHARACTER=32 TEXT='After transformation series 54 in Smith & Caron (2015). The differentiation observed in lobopodians (see below) is also reflected in the organisation of Louisella and Tylotites (Conway Morris 1977a; Han et al. 2007c; Zhang et al. 2015), where the anterior trunk has a different annulation pattern to the posterior portion, with an abrupt change separating the two regions. The “neck” of Eokinorhynchus is not consistently distinguishable from the introvert, and is considered to represent part of that structure.  The same is arguably true in Halicryptus higginsi, though not in H. spinulosus.  The anterior annulations of H. higginsi are much more closely spaced and bear denser setae than the posterior annulations (Shirley and Storch 1999), but in the absence of a sharp distinction between the regions this character is scored as ambiguous.  Coded absent in Cricocosmia (Hou et al. 2017); the diminution of annulations anteriad is reflected in a separate transformation series, and there is no clear morphological division of an anterior portion of the trunk.^nThis transformation series reflects the pronounced differentiation of the posterior and anterior trunk – not just the trunk appendages – in certain lobopodians.  In  Hallucigenia sparsa, the region of the trunk anterior of the third appendage pair is narrower, lacks dorsal armature, and expresses differentiated appendages (this study).  The short constricted region anterior of the first spine pair in H. fortis is associated with two differentiated appendage pairs (Ramsköld and Chen 1998) and apparently corresponds with the ‘neck’ of H. sparsa.  In luolishaniids, the anterior body bears elongate limbs with accentuated armature (Ma et al. 2009; García-Bellido et al. 2013).  The portion of the trunk in Carbotubulus corresponding to the first two or three leg pairs is substantially narrower than the posterior trunk and its associated appendages are narrower and less prominent than the posterior appendages, indicating trunk differentiation (Haug et al. 2012c).  Although the width of the trunk narrows gradually towards the front of Paucipodia, this tapering is gradual and does not correspond to the differentiation of the anterior trunk (Chen et al. 1995a; Hou et al. 2004).  Coded ambiguous in Orstenotubulus, Hallucigenia hongmeia, and Ilyodes due to incomplete preservation (Thompson and Jones 1980; Maas et al. 2007; Steiner et al. 2012).^nCoded as absent in loriciferans (Neves et al. 2016), Sirilorica (Peel et al. 2013).^nThe anterior 5–8% of the trunk of Meiopriapulus bears trunk scalids and lacks the wrinkles, tubercles and other structures of the posterior trunk (Sørensen et al. 2012a)^nTubiluchus lemburgi has a distinctive anterior trunk marked by a change in diameter and surface ornament (Schmidt-Rhaesa et al. 2013)^nCoded as present in Paratubiluchus (Han et al. 2004).^nPresent in Paraselkirkia, where armature becomes enhanced (Hou et al. 2017); not evident in Selkirkia, even USNM 57624 in which the trunk is well extended; but coded ambiguous as posterior trunk unknown.^nCoded as present in Eximipriapulus (Ma et al. 2014b), though with the caveat that the differential appearance of the neck might conceivably be attributed to preservational factors^nCoded absent in Markuelia; the unannulated region in e.g. Dong et al. fig. 10D seems to correspond to the introvert, as suggested by the presence of a single row of spines (cf. trichoscalids, anterior head setae of nematodes); it is not demarked from the rest of the trunk by a change of thickness etc.';
+	TEXT CHARACTER=33 TEXT='The  bulbous heads of Hallucigenia fortis, Microdictyon, Cardiodictyon and Luolishania also lack annulations (Chen et al. 1995b; Ma et al. 2009, 2012a; Liu and Dunlop 2014). In contrast, annulations continue to the tip of the head in Paucipodia, Onychodictyon gracilis, and Diania (whichever end of Diania is interpreted as anterior) (Chen et al. 1995a; Hou et al. 2004; Liu et al. 2008b; Ma et al. 2014).  ^nAnnulations are not clearly preserved in the anterior region of Jianshanopodia and Megadictyon (Liu et al. 2006, 2007), making this transformation series difficult to score with confidence.  Annulations in the pharynx of Kerygmachela continue to the terminal mouth (Budd 1998a); given the position of the prominent annulated appendages, it seems likely that the head also expressed external annulations.  ^nCoded ambiguous in Guanduscolex (Hu et al. 2008) as the apparent absence of anterior annulations may be preservational.^nCoded absent in Eokinorhynchus as the ‘neck’ region is considered part of the introvert (Zhang et al. 2015).^nCoded ambiguous in Paratubiluchus (Han et al. 2004) as annulations are not clearly enough preserved to evaluate their distribution in the neck area.^nCoded as continuing to front in Halicryptus.  A deep groove separates the region that is adorned with Zone I armature, but this area seems to bear faint annulations (that are not in associated with the armature) (Shirley and Storch 1999). Continuing to the front in Priapulus (Hammond 1970).';
+	TEXT CHARACTER=34 TEXT='Observed in Laojieella, Eximipriapulus, Xiaoheiqingella^nIncludes the lorical region of Palaeopriapulites and Sicyophorus. (Hou et al. 2017)';
+	TEXT CHARACTER=35 TEXT='The development of sclerotized tergal plates connected by arthrodial membranes is distinctive of body arthrodization, and thus exclusive to Euarthropoda (e.g. Edgecombe and Ramsköld 1999; Haug et al. 2012b; Yang et al. 2013). Given the morphological similarity between arthropod tergites and the articulated tergal plates of kinorhynchs (e.g. Sørensen 2008), the latter are also scored as present.  The small plates of Eokinorhynchus do not appear to have fused into discrete terga or sterna, so are not scored as such; their regular arrangement is instead considered as annulation. Although some heterotardigrades possess dorsal plates (e.g. Nelson 2002; Marchioro et al. 2013; Persson et al. 2014), these are not connected by arthrodial membranes and thus score the heterotardigrade terminal Actinarctus as absent for this transformation series.  ';
+	TEXT CHARACTER=36 TEXT='Sternites – ventral sclerotized plates – are a key feature of most Euarthropoda, and are well documented in Artiopoda (e.g. Whittington 1993; Edgecombe and Ramsköld 1999; Ortega-Hernández and Brena 2012).  Sternites are notably absent in Fuxianhuiida (Chen et al. 1995b; Waloszek et al. 2005; Bergström et al. 2008; Yang et al. 2013), even though these taxa have a sclerotized dorsal exoskeleton. We code sternites as uncertain in leanchoiliids.  Given the morphological similarity between arthropod sternites and the articulated sternal plates of kinorhynchs (e.g. Sørensen 2008), the latter are also scored as present.';
+	TEXT CHARACTER=37 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nPresent in Pycnophyidae and Neocentrophyidae (Kinorhyncha); see character 14 in (Sørensen et al. 2015)^n^nPresent in Pycnophyidae and Neocentrophyidae (Kinorhyncha); see character 14 in (Sørensen et al. 2015)';
+	TEXT CHARACTER=38 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nSee character 17 in (Sørensen et al. 2015)^n';
+	TEXT CHARACTER=39 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nSee character 23 in (Sørensen et al. 2015)^n';
+	TEXT CHARACTER=40 TEXT='(–) inapplicable: sternites absent^nSee character 19 in (Sørensen et al. 2015)^n';
+	TEXT CHARACTER=41 TEXT='See character 21 in (Sørensen et al. 2015)';
+	TEXT CHARACTER=42 TEXT='(–) inapplicable: sternites absent (trans. ser. ##)^nModified from character 20 in (Sørensen et al. 2015); comparison with other plates avoids over-weighting the presence/absence of two sternal plates';
+	TEXT CHARACTER=43 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nModified from character 22 in (Sørensen et al. 2015); comparison with other plates avoids over-weighting the presence/absence of two sternal plates^n';
+	TEXT CHARACTER=44 TEXT='(–) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nSee character 24 in (Sørensen et al. 2015)';
+	TEXT CHARACTER=45 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nSee character 25 in (Sørensen et al. 2015)^n';
+	TEXT CHARACTER=46 TEXT='(~) inapplicable: ^nSee character 26 in (Sørensen et al. 2015)^n';
+	TEXT CHARACTER=47 TEXT='Transformation series 41 in Daley et al. (2009).  A series of parallel-oriented lanceolate blades that are attached at one end and free-hanging towards the posterior of each trunk segment.';
+	TEXT CHARACTER=48 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nSee character 27 in (Sørensen et al. 2015)^n';
+	TEXT CHARACTER=49 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nSee character 40 in (Sørensen et al. 2015)^nMost kinorhynchs (though not, for example, Kinorhynchus, Neocentrophyes) exhibit prominent lateroterminal spines (Sørensen and Pardos 2008), clearly distinguished from palaeoscolecid/priapulid posterior hooks by their position and morphology.';
+	TEXT CHARACTER=50 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nCertain kinorhynchs (Antygomonas, Franciscideres, Cateria, Campyloderes, Centroderes, Echinoderes, Zelnkaderes) exhibit an secondary spine alongside their lateroterminal spine (Higgins 1968; Sørensen and Pardos 2008; Dal Zotto et al. 2013; Neuhaus and Sørensen 2013; Neuhaus et al. 2014; Altenburger et al. 2015; Landers and Sørensen 2016).  Others (Pyconophyes, Dracoderes, Paracentrophyes) do not (Sørensen et al. 2010, 2012b; Herranz et al. 2014; Sánchez et al. 2016). See character 38 in (Sørensen et al. 2015).';
+	TEXT CHARACTER=51 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^nSee character 41 in (Sørensen et al. 2015); modified to present in Franciscideres (Dal Zotto et al. 2013) and Paracentrophyes (Sørensen et al. 2010)^nFollowing the coding of Sorensen where this contradicts the data from (Sørensen and Pardos 2008; Dal Zotto et al. 2013)^n';
+	TEXT CHARACTER=52 TEXT='(?) inapplicable: covered with sternites or lorica^nTransformation series 41 in Ma et al. (Ma et al. 2014a) and 30 (and  cf. 29) in Wills (2012).  We code Orstenotubulus as uncertain as its papillae are not clearly observed throughout the trunk region (Maas et al. 2007b).  The epidermal plates of palaeoscolecids conceivably represent an end-member of a continuum taking in the spine-like ornament of Tylotites (Han et al. 2007c), papilla-like spines of Louisella (Conway Morris 1977a), and the rings of papillae in certain lobopodians (e.g. Aysheaia, onychophoran); plate-like structures are coded as representing toughened components associated with papillae.^nPresent in Eokinorhynchus (Zhang et al. 2015).^nOccur, seemingly in rings, in Markuelia (Haug and Maas 2009; Dong et al. 2010)^nAbsent in Cricocosmia and Tabelliscolex (Han et al. 2007b).^nDetails of Mafangscolex given by (Liu et al. 2016)^nDetail of Maotianshania mentioned in (Hu et al. 2012)^nAmbiguous in Shergoldana as adult state unknown.^nAmbiguous in Antennacanthopoda (Ou et al. 2011) as preservational quality insufficient to discern,^nAreoles in Chordodes (Bolek et al. 2010) are treated as epidermal plates.^nRound non-mineralized plates adorn the posterior trunk of Ancalagon (pers. obs.)^nSpines adorn the surface of Fieldia (ROM 93-1678; Conway Morris 1977a) ^nSmall spines (setae) occur on Halicryptus and Priapulopsis (van der Land 1970). Somatic setae occur irregularly on Kinonchulus (Riemann 1972) and in other onchulids (Olovachov et al. 2008)^nAbsent in Maccabeus (Por and Bromley 1974)^nRobustly-topped spines in Aysheaia (Whittington 1978)^nSpines are present at least in the anterior trunk of Selkirkia and Paraselkirkia (termed ‘Zone C of the proboscis’ by Conway Morris 1977); this was variably emergent from the tube (see Caron 2011)^nThe ambiguous token is selected for inapplicable tokens as the presence of a trunk covering may obscure XYZ.^nNot reported in Kerygmachema (Budd 1998a)^n';
+	TEXT CHARACTER=53 TEXT='(–) inapplicable: trunk is not armoured (trans. ser. ###)^nPlates in Louisella have the same properties as non-mineralized cuticular structures.^nNematomorph areoles are cuticular, not mineralized (Bolek et al. 2010)^nSpines are heavily chitinised in Acanthopriapulus (van der Land 1970)^nSpines of Corynetis are not obviously mineralized (Huang et al. 2004a)^n';
+	TEXT CHARACTER=54 TEXT='(~) inapplicable: trunk is not armoured (trans. ser. ###)^nCircular in Scathascolex, Wronascolex spp., ^nElongated parallel to body axis in Palaeoscolex piscatorum,^nEssentially circular in Chordodes (Bolek et al. 2010)^ncf. WTS30';
+	TEXT CHARACTER=55 TEXT='(~) inapplicable: dorsal sclerotized integument (trans. ser. 36) absent^n^nWTS34^nTubuli are short tube-like projections arising from the trunk in certain priapulids (e.g. Janssen et al. 2009).  In Tubilucus, these are adhesive organs with a bulbous base and a stiff tapering tube (Todaro and Shirley 2003)^n';
+	TEXT CHARACTER=56 TEXT='(–) inapplicable: plates absent (trans. ser. ##)^nSetae (conical spines) in Chordodes (Bolek et al. 2010)^n';
+	TEXT CHARACTER=57 TEXT='(~) inapplicable: plates absent (trans. ser. ##)^nNodes are raised lumps, arranged in a series parallel to the plate margin^nBlackberry areoles in Chordodes have a similar construction, even if the nodes are irregularly distributed (Bolek et al. 2010) – but these areoles are perhaps better considered as equivalent to platelets, by comparison with priapulid tumuli.^nSchistoscolex has four nodes in an irregular ring (Müller and Hinz-Schallreuter 1993)^n';
+	TEXT CHARACTER=58 TEXT='(–) inapplicable: nodes absent (trans. ser. ##)';
+	TEXT CHARACTER=59 TEXT='(–) inapplicable: number of nodes in central ring is constant (trans. ser. XX)';
+	TEXT CHARACTER=60 TEXT='(–) inapplicable: no nodes in central ring (trans. ser. ###)^nPalaeoscolex piscatorum has eight to ten nodes on its plates (Conway Morris 1997)^nScathascolex sometimes has five, perhaps sometimes has four as well?^nWronascolex antiquus has four to six ^nWronascolex iacoborum has five, always^n';
+	TEXT CHARACTER=61 TEXT='(–) inapplicable: number of nodes in central ring is not constant (trans. ser. 150)';
+	TEXT CHARACTER=62 TEXT='(–) inapplicable: plates absent (trans. ser. ##)^nPlates of Corynetis form clear transverse rows (Huang et al. 2004a)^nThose of Tubiluchus lemburgi form longitudinal rows that occasionally arise or pinch out (Schmidt-Rhaesa et al. 2013)^nTaxa with a differentiated fore-trunk (e.g. Eximipriapulus, Meiopriapulus) often show a more regular arrangement in their ‘neck’; the arrangement in the trunk (which is typically irregular) is what is coded here.^nSome ordering is apparent in Selkirkia, where the rows are clearly diagonal/quincuncial^n';
+	TEXT CHARACTER=63 TEXT='(~) inapplicable^nLouisella and Onychodictyon ferox bear transverse rows of ventral papillae (Conway Morris 1977a; Ou et al. 2012)^n';
+	TEXT CHARACTER=64 TEXT='(–) inapplicable; ^nThe plates of Corynetis form a quincuncial arrangement, a consequence of each subsequent transverse row being offset relative to the previous (Huang et al. 2004a).  IN Palaeoscolex piscatorum, plates do not correspond exactly to their neighbours on the next annulation (Conway Morris 1997)^n';
+	TEXT CHARACTER=65 TEXT=' (–) inapplicable: plates disordered (trans. ser. ###)^nWronascolex antiquus has a single row of plates on each annulation.  Scathascolex minor has a row of plates on each margin of each annulation; within each row, sclerites are  longitudinally paired.  I have interpreted this as two primary fields per annulation, each comprising two rows of sclerites.   cf. WTS30^nAmbiguous (at best) in Louisella (Conway Morris 1977a, 1997; Smith 2015)^nProminently single in Tylotites (Han et al. 2007c)^nSeemingly single in Chalazoscolex  (Conway Morris and Peel 2010)^n';
+	TEXT CHARACTER=66 TEXT='(–) inapplicable; plates disordered (trans. ser. ###)';
+	TEXT CHARACTER=67 TEXT='(~) inapplicable: plates absent (trans. ser. ##)^nPlatelets are smaller than plates but have an equivalent distribution and ornamentation^nIn taxa with non-mineralized papillae, the distinction of microplates is less clear; tumuli (as in Tubiluchus) are included here.^nWTS33^nTumuli are small papillae.  In Tubiluchus they are supported at their periphery by cuticular ridges, giving them a star-shaped aspect (Todaro and Shirley 2003).^nVariation in plate size in Chordodes is neither systematic nor substantive (Bolek et al. 2010); this taxon is coded as having plates of a single size.^n';
+	TEXT CHARACTER=68 TEXT='(~) inapplicable: epidermal platelets absent^nPriapulid tumuli have a distinctively star-shaped appearance (Schmidt-Rhaesa et al. 2013)^n';
+	TEXT CHARACTER=69 TEXT='(~) inapplicable: plates absent (trans. ser. ##)^nMicroplates are smaller than plates and platelets and are expressed as a patterning of the cuticle. [tbc]^nAmbiguous in Louisella and Tylotites as plates are not strongly preserved; preservational quality is inadequate to assess the presence of microplates^n';
+	TEXT CHARACTER=70 TEXT='(–) inapplicable: platelets absent (trans. ser. ##)';
+	TEXT CHARACTER=71 TEXT='(?) inapplicable: sclerotized exoskeleton (trans. ser. ##) present^nGiven the possibility that lobopodian sclerites derived from the plates of palaeoscolecid worms (Dzik and Krumbiegel 1989), we have reformulated this transformation series from (Smith and Ortega-Hernández 2014) to encapsulate the ‘two longitudinal rows’ of sclerites envisioned by trans. ser. 31 in Wills et al. (2012).  We still code these as present in tardigrades to represent the possible homology of their epidermal depressions with the epidermal evaginations of other lobopodians (Smith and Ortega-Hernández 2014).  Aysheaia is coded as absent as its ‘plates’ (reported by Liu and Dunlop 2014) seem to represent the impressions of the opposite pair of legs (see Whittington 1978). Eokinorhynchus is coded as present as its spines are regularly paired; the seemingly ventral position of the first pair may represent relocation late in development, or deformation of the specimen during preservation. Shergoldana is coded absent as the specializations belong to a tessellating series of plates rather than occurring in transverse pairs (Maas et al. 2007a). Chalazoscolex  is coded present, with the “two to three” individual sclerites occupying the width of each segment (Conway Morris and Peel 2010) assumed to reflect sclerites of the dorsal zone';
+	TEXT CHARACTER=72 TEXT='(–) inapplicable: epidermal specializations (trans. ser. 32) absent^nThe nodes, plates and spines of lobopodian taxa (TS32) represent epidermal evaginations; the paired sclerotized dorsal plates of Actinarctus (Heterotardigrada) are also interpreted as epidermal evaginations (e.g. Nelson 2002; Marchioro et al. 2013; Persson et al. 2014). Halobiotus (Eutardigrada) has epidermal depressions, represented by the paired pits that serve as muscle attachment sites (Halberg et al. 2009; Marchioro et al. 2013). We code Paucipodia, Diania and Aysheaia as uncertain; their preservation is insufficient to establish whether the paired specializations are node-like evaginations or pit-like depressions (Chen et al. 1995a; Liu and Dunlop 2014; Ma et al. 2014a).^nShergoldana bears three rings of four epidermal evaginations (Maas et al. 2007a); we follow the model of Dzik and Krumbiegel (Dzik and Krumbiegel 1989) and code these in the same fashion as the trunk developments of certain palaeoscolecids (e.g. Cricocosmia) and lobopodians (e.g. Microdictyon).^n';
+	TEXT CHARACTER=73 TEXT='(–) inapplicable: epidermal evaginations (trans. ser. 33) absent^nLobopodians’ epidermal evaginations fall into two geometric categories: flat nodes or plates (token 0) and tall spines (token 1). Although the distal portions of the evaginations of Orstenotubulus are not preserved (Maas et al. 2007b), we infer a spine-like habit from the proportions of the spine stubs. ^n';
+	TEXT CHARACTER=74 TEXT='(–) inapplicable: epidermal evaginations (trans. ser. 33) absent^nThis transformation series refers solely to the shape of the trunk evaginations’ apices. It is independent from the evaginations’ proportions (trans. ser. 34), as demonstrated by Onychodictyon ferox, where sclerites are wider than tall (i.e. plates) but display an acute distal termination (Zhang and Aldridge 2007; Ou et al. 2012; Topper et al. 2013).  O. gracilis is coded as uncertain due to its ambiguous preservation (Liu et al. 2008).';
+	TEXT CHARACTER=75 TEXT='(–) inapplicable: epidermal evaginations, if present, lack an acute distal terminus (trans. ser. 35)^nThe spines of Hallucigenia fortis (Hou and Bergström 1995), H. hongmeia (Steiner et al. 2012), Luolishania (Ma et al. 2009) and the Emu Bay ‘Collins Monster’ (García-Bellido et al. 2013b) are distinctively curved, whereas those of H. sparsa (Conway Morris 1977b) and Onychodictyon ferox (Topper et al. 2013) are essentially straight.^n';
+	TEXT CHARACTER=76 TEXT='(–) inapplicable: epidermal evaginations (trans. ser. 33) absent^nThe epidermal evaginations of ‘armoured’ lobopodians are substantially sclerotized (Hou and Bergström 1995; Steiner et al. 2012; Caron et al. 2013), in contrast to those of Xenusion (Dzik and Krumbiegel 1989), Hadranax (Budd and Peel 1998) and Kerygmachela (Budd 1993, 1998a).^nThe robust preservation and narrow spinose projections of the evaginations of Shergoldana (Maas et al. 2007a) suggest primary sclerotization.';
+	TEXT CHARACTER=77 TEXT='(–) inapplicable: sclerotized epidermal evaginations (trans. ser. 37) absent^nWe code this transformation series as uncertain in taxa that are not well enough preserved for the ornament to be apparent. Hallucigenia sparsa has a scaly ornament (Caron et al. 2013) whereas H. hongmeia bears a net-like pattern (Steiner et al. 2012) shared with Onychodictyon and Microdictyon (e.g. Topper et al. 2013); Cardiodictyon specimens show a comparable ornament (Liu and Dunlop 2014 fig. 4f).  Actinarctus sclerites also exhibit a net-like ornament (Marchioro et al. 2013).^n';
+	TEXT CHARACTER=78 TEXT='(~) inapplicable: sclerites absent^nThis transformation series is coded as present in any taxon where exoskeletal elements (claws or epidermal evaginations) comprise stacked constituent elements at all stages of growth (as in Hallucigenia sparsa and Euperipatoides, see main text), not just during ecdysis (as in Onychodictyon, see Topper et al. 2013).  Aysheaia does not have stacked elements (Extended Data Fig. 1p¬–q); stacked elements .  Where sclerites are not preserved in sufficient detail to assess their construction, this transformation series is coded as ambiguous.^n';
+	TEXT CHARACTER=79 TEXT='(–) inapplicable: epidermal specializations (trans. ser. 32) absent^nWe score Cardiodictyon as having two epidermal specializations (token 1), following suggestions that the apparently single dorsal sclerite is formed by the fusion of a pair of elements (Liu and Dunlop 2014).  Following the hypothesis of Dzik and Krumbiegel (Dzik and Krumbiegel 1989), we score Shergoldana as having two specialisations in each band, assuming that only the dorsal sclerites are homologous with the specializations of lobopodian taxa.^nCf. WTS32.^n';
+	TEXT CHARACTER=80 TEXT='(~) inapplicable: paired appendages (trans. ser. 1) absent^nTransformation series 31 in Daley et al. (2009).^n';
+	TEXT CHARACTER=81 TEXT='(–) inapplicable: trunk exites (trans. ser. 44) absent';
+	TEXT CHARACTER=82 TEXT='(~) inapplicable: exites (trans. ser. 44) absent^nWe follow Daley et al. (2009, trans. ser. 34) in considering the lanceolate blades and lateral lobes of lobopodians and anomalocaridids as exites, and trunk walking legs as endopods. Anomalocaris is coded as unfused (token 0) based on the recently reported presence of a second set of lateral flaps (Van Roy et al. 2013). Peytoia and Hurdia (Daley et al. 2009) are coded as uncertain as the possible presence of a second pair of lateral flaps has not been explicitly discounted.';
+	TEXT CHARACTER=83 TEXT='(~) inapplicable: limbs (trans. ser. 5) not arthropodized^nTransformation series 8 of Ma et al. (Ma et al. 2014a), 35 in Daley et al. (2009).  Gnathobasic appendages are absent in fuxianhuiids (Chen et al. 1995b; Waloszek et al. 2005; Bergström et al. 2008; Yang et al. 2013) but present in Artiopoda (Edgecombe and Ramsköld 1999; Ortega-Hernández et al. 2013) and megacheirans (Chen et al. 2004; Haug et al. 2012a, b).^n';
+	TEXT CHARACTER=84 TEXT='(~) inapplicable: limbs (trans. ser. 5) not lobopodous^nThis transformation series is modified from transformation series 9 in Ma et al. (Ma et al. 2014a).  We code as O. gracilis as uncertain as its longitudinal series of dot-like structures (Liu et al. 2008, fig. 2A6). 2A6) could indicate an organization of appendicules similar to those of O. ferox (see Ou et al. 2012, fig. 2a). Siberion is coded as uncertain because its limbs are poorly preserved (Dzik 2011). Hurdia and Peytoia as scored as uncertain pending new data on the structure of the second set of flaps and their morphology (see Van Roy et al. 2013).^n';
+	TEXT CHARACTER=85 TEXT='(–) inapplicable: no secondary structures on the lobopodous limbs (trans. ser. 48)^nSpines and setae taper to sharp point, whereas appendicules have a uniform length and a flattened terminus.^n';
+	TEXT CHARACTER=86 TEXT='(–) inapplicable: limbs (trans. ser. 5) not lobopodous^nTransformation series 10 in Ma et al. (Ma et al. 2014a).  In contrast to appendicules and spines, papillae are short projections associated with the annulations.^n';
+	TEXT CHARACTER=87 TEXT='(~) inapplicable: paired appendages (trans. ser. 1) absent^nThe finger-like projections in the legs of tardigrades can bear sets of terminal claws or sucking discs (Schuster et al. 1980; Nelson 2002).^n';
+	TEXT CHARACTER=88 TEXT='(~) inapplicable: paired appendages (trans. ser. 1) absent^nWe score terminal claws as absent in Opabinia following Budd and Daley (2012). Hurdia and Peytoia are coded as ambiguous as there is no definitive information on the presence of lobopodous limbs or a second set of flaps (Van Roy et al. 2013). Jianshanopodia (Liu et al. 2006) and Megadictyon (Liu et al. 2007) are also coded as uncertain as the preservation of the type material does not allow the presence or absence of terminal claws to be confirmed. Diania too is scored as uncertain, as it is difficult to distinguish possible terminal claws from its myriad accessory spines (Liu et al. 2011; Ma et al. 2014a).^n';
+	TEXT CHARACTER=89 TEXT='(~) inapplicable: terminal claws (trans. ser. 52) absent^nComplex claws are present in Eutardigrada (Schuster et al. 1980; Nelson 2002; Halberg et al. 2009) and the Siberian Orsten-type tardigrade (Maas and Waloszek 2001), but not in heterotardigrades or any Palaeozoic lobopodian.';
+	TEXT CHARACTER=90 TEXT='(–) inapplicable: terminal claws (trans. ser. 52) absent^nModified from transformation series 18 in Ma et al. (Ma et al. 2014a) to better reflect the diversity of claw number in Cambrian lobopodians. Cardiodictyon unambiguously has two claws (Ramsköld and Chen 1998).  Leanchoilia is coded as ambiguous for tokens 0 and 2 (one or three claws) to reflect the conflicting interpretations of García-Bellido and Collins (2007) and Haug et al. (2012a).^n';
+	TEXT CHARACTER=91 TEXT='(–) inapplicable: exites (trans. ser. 44) absent^nTransformation series 31 in Ma et al. (Ma et al. 2014a); trans. ser. 36 in Daley et al. (2009). The definition has been slightly modified reflect the presence of two pairs of lateral flaps in Anomalocaridida (Van Roy et al. 2013).^n';
+	TEXT CHARACTER=92 TEXT='(~) inapplicable: lateral flaps (trans. ser. 55) not present^nTransformation series 38 in Daley et al. (2009). ^n';
+	TEXT CHARACTER=93 TEXT='(~) inapplicable: lateral flaps (trans. ser. 55) not present^nTransformation series 37 in Daley et al. (2009)^n';
+	TEXT CHARACTER=94 TEXT='(–) inapplicable: lateral flaps (trans. ser. 55) not present^nTransformation series 40 in Daley et al. (2009)^n';
+	TEXT CHARACTER=95 TEXT='(~) inapplicable: limbs (trans. ser. 5) not lobopodous^nTransformation series 38 in Ma et al. (Ma et al. 2014a).^n';
+	TEXT CHARACTER=96 TEXT='(–) inapplicable: limbs (trans. ser. 5) not arthropodized^nThe endopods of certain taxa in the euarthropod stem-group, such as fuxianhuiids, bear 15 or more podomeres and are considered ‘multipodomerous’ (Chen et al. 1995b; Waloszek et al. 2005; Bergström et al. 2008; Yang et al. 2013).^n';
+	TEXT CHARACTER=97 TEXT='(~) inapplicable: lateral flaps (trans. ser. 55) absent^nTransformation series 42 in Daley et al. (2009)^n';
+	TEXT CHARACTER=98 TEXT='(~) inapplicable: paired appendages (trans. ser. 1) absent^nWe score Jianshanopodia (Liu et al. 2006) as present because the lateral extensions of the tail fan likely correspond to a modified pair of appendages.  Onychophora are scored as undifferentiated: their posteriormost region does not express appendages (Mayer and Koch 2005), but the appendages are lost (not structurally differentiated); the  posteriormost appendage pair that are expressed are not structurally differentiated.  See also transformation series 35 in Ma et al. (Ma et al. 2014a).^n';
+	TEXT CHARACTER=99 TEXT='(–) inapplicable: posterior appendages unmodified (trans. ser. 63 = 0)^nIn fuxianhuiids, the posteriormost appendage pair is modified into a tail fan or tail flukes (e.g. Chen et al. 1995b; Yang et al. 2013); a similar condition is also observed in Opabinia (Whittington 1975; Budd 1996; Budd and Daley 2012), Anomalocaris (Daley and Edgecombe 2014) and Hurdia (Daley et al. 2009). The paired tail rami of Kerygmachela (Budd 1993, 1998a) likely represent modified appendages. The last appendage pair of Jianshanopodia is modified into a set of lateral flaps, which form a tail fan together with the flattened terminal portion of the body (Liu et al. 2006).  Partial fusion of the last pair of legs occurs in Aysheaia (Whittington 1978), Onychodictyon gracilis (Liu et al. 2008), O. ferox (Ou et al. 2012) and Tardigrada (e.g. Halberg et al. 2009; Marchioro et al. 2013); in these taxa, this characteristic is expressed as an incipient fusion of the medioproximal bases of the posteriormost appendage pair.  The Siberian Orsten tardigrade is scored as having a reduced posteriormost appendage pair based on the vestigial rudiment present on its posteroventral body region (Maas and Waloszek 2001).  We score Pambdelurion as uncertain because its posterior trunk is poorly known (Budd 1998b).^n';
+	TEXT CHARACTER=100 TEXT='(–) inapplicable: appendicular tail not present (trans. ser. 64 ≠ 0)^nThis transformation series distinguishes the long tail rami of Kerygmachela (Budd 1993, 1998a) from the flaps observed in Jianshanopodia (Liu et al. 2006), Opabinia (Budd 1996; Budd and Daley 2012), anomalocaridids (Daley et al. 2009; Daley and Edgecombe 2014), and fuxianhuiids (e.g. Yang et al. 2013).^n';
+	TEXT CHARACTER=101 TEXT='(–) inapplicable: posterior appendages lack claws (trans. ser.  52 = 0)^nThe last pair of legs are rotated anteriad in tardigrades (e.g. Marchioro et al. 2013), Aysheaia (Whittington 1978), Onychodictyon gracilis (Liu et al. 2008) and O. ferox (Ou et al. 2012), but not in Cardiodictyon, Hallucigenia fortis or Microdictyon (Hou and Bergström 1995).  Hallucigenia sparsa is coded as ambiguous owing to the poor preservation of its posterior end.  We score Siberian Orsten tardigrade (Maas et al. 2007b) as uncertain.^n';
+	TEXT CHARACTER=102 TEXT='(~) inapplicable: mouth not terminal (trans. ser. ##)^nAfter transformation series 1 in Wills et al.  (2012).  The introvert is the region of the trunk that corresponds to the Zone I armature zone in the scheme of Conway Morris (1977). (Zones II and III are on the pharynx, which is often termed the ‘mouth cone’ in the priapulid and kinorhynch literature.)^nTaxa without such a region, or where the region is extremely short (as in Scathascolex and Wronascolex), do not have an invaginable introvert.  This character cannot readily be applied to taxa with a non-terminal mouth.^nThe introvert of Eokinorhynchus is partly inverted in some specimens, fully everted in others; the maximum extent of its invagination is unknown (Zhang et al. 2015).^nCoded as ambiguous in Sirilorica (Peel et al. 2013); introvert never seen invaginated but sample size insufficient to determine whether this was not biologically possible.^nAn introvert is not present in adult Chordodidae (Poinar Jr. and Doelman 1974).^nAmbiguous in Xiaoheiqingella as the introvert is not retracted in any specimen (Han et al. 2004; Huang et al. 2004b; Han and Hu 2006; HU et al. 2017) ^nSeemingly invaginable to some extent in Chalazoscolex; unclear in Xystoscolex (Conway Morris and Peel 2010)?^nInvaginable in tardigrades (Guidetti et al. 2013b)^nThe loriciferan introvert can be telescopically retracted inside the lorica, but not inverted (Kristensen 1983), so these are coded as not invaginable.^nPartially inversible in Aysheaia (Whittington 1978)^n';
+	TEXT CHARACTER=103 TEXT='(–) inapplicable: proboscis (trans. ser. 73) not eversible^nAfter transformation series 1 in Wills et al. (2012).  It is not clear how Wills established that the introverts of Louisella and Selkirkia/Paraselkirkia could not be fully retracted; as such these taxa are left ambiguous.^nAmbiguous in Scathascolex (Smith 2015)^n';
+	TEXT CHARACTER=104 TEXT='Proposed by Nielsen (2001, 2012)as a synapomorphy of kinorhynchs, loriciferans and extant priapulids.';
+	TEXT CHARACTER=105 TEXT='After transformation series 4 in Wills et al. (2012).^nScathascolex and Wronascolex are coded as ambiguous as available material is insufficient to determine the invagibility of the pharynx.^nA pharynx, permanently inverted, is present in Chordodes; it is degenerate in adults and there is pharyngeal armature is not recorded (though it exists in larval stages) (Bolek et al. 2010).^nEversible in Xystoscolex; and seemingly Chalazoscolex  (Conway Morris and Peel 2010)^nAn everted pharynx can be observed in some specimens of Aysheaia (e.g. USNM 58655; Whittington 1978)^n';
+	TEXT CHARACTER=106 TEXT='(–) inapplicable: pharynx not eversible^nWTS22^nCoded ambiguous in Scathascolex as there are insufficient specimens to determine whether the pharynx is preserved in its fully everted position.  Coded as complete or incomplete in Eokinorhynchus as a specimen is preserved with eversion beyond proximal teeth (Zhang et al. 2015)^n';
+	TEXT CHARACTER=107 TEXT='(~) inapplicable: pharynx not eversible^nAfter transformation series 4 in Wills et al. (2012).^nScathascolex and Wronascolex are coded as ambiguous as available material is insufficient to determine the invagibility of the pharynx.  Scolecofurca is viewed as having its narrow pharynx in a minimally everted position.^nLoriciferans are coded as permanently everted as the mouth cone remains everted even when the introvert is retracted (Neves et al. 2013)^n';
+	TEXT CHARACTER=108 TEXT='(–) inapplicable: pharynx not eversible (trans. ser. ##)^nCf. WTS83. This formulation reflects the proposed homology between megaintroverts [Lemburg 1999] without attaching undue significance to subtle variations in introvert length.  It is phrased as ‘foregut’ rather than ‘introvert’ to recognize the proposed homology between the panarthropod foregut and the cycloneuralian introvert.';
+	TEXT CHARACTER=109 TEXT='(–) inapplicable: pharynx not eversible (trans. ser. ##)^nCf. WTS85.^nCoded as absent in Corynetis following the interpretation of (Huang et al. 2004a). Movement of pharynx is interpreted as having a role in locomotion in Kinonchulus (Riemann 1972), but it is not clear whether this employs peristalsis.. Both Kinorhyncha (Neuhaus and Higgins 2002) and Loricifera employ their introvert in locomotion (Sørensen et al. 2008), though seemingly through the use movement of individual scalids rather than peristaltic contraction of the entire introvert.';
+	TEXT CHARACTER=110 TEXT='WTS86.  A triradiate introvert is a putative synapomorphy of Loricifera, Priapulida + Kinorhyncha (Yamasaki et al. 2015). The pharynx is also triradiate in most nematodes (Altun and Hall 2017), including Kinonchulus (Riemann 1972) and in some larval onychophorans (Schmidt-Rhaesa et al. 1998)^nTriradiate in Pycnophyes and Kinorhynchus, but round in Cyclorhagida (Neuhaus and Higgins 2002)^n';
+	TEXT CHARACTER=111 TEXT='Modified from transformation series 9 in Wills et al. (2012).  In order to capture homology due to a radial arrangement, the armature number is formulated a number of transformation series, each corresponding to a common factor and thus a potential homology of symmetry.  Priapulids, with 25 rows, also exhibit pentaradial symmetry.  (A taxon could conceivably exhibit 30-fold symmetry, which would have both pentaradial and hexaradial symmetry.) In priapulids, the symmetry of the pharynx is defined by the number of elements that comprise the first three circlets and, hence, defining the number of longitudinal rows of elements on the introvert.^nTaxa with 25 scalid rows: Recent Priapulidae, Halicryptidae,  Tubiluchidae and Maccabeus (Adrianov and Malakhov 2001), Xiaoheiqingella, Yunnanpriapulus (Huang et al. 2004b), Markuelia (Dong et al. 2010)^nThe first three rows contain 8 + 9 + 8 = 25 scalids in Meiopriapulus even if they do not define the symmetry (Adrianov and Malakhov 2001)^nEximipriapulus: “More than 30” (Ma et al. 2014b)^nfewer than 25 – c. 10 on each side – in Sicyophorus and Palaeopriapulites (Maas et al. 2007c)^n6+6+7=19 in nematomorphs (Conway Morris 1977a) – but does this reflect an underlying 6-fold symmetry (see below)?^nShergoldana’s armature comprises a ring of cushion-like folds, each bearing a single tooth.  Each fold is associated with two round humps, and a further round hump occurs between each pair of folds (Maas et al. 2007a).  This arrangement suggests a six-fold symmetry.^nThe armature of kinorhynchs is arranged in a pentaradial fashion (Sørensen et al. 2008)^nA six-fold symmetry is observed in Chordodes, Shergoldana (Maas et al. 2007a), larval nematodes (despite lack of Zone I armature), and loriciferans (Sørensen et al. 2008).  In Halicryptus, the hatching larva has seven-fold symmetry, becoming eightfold in the Higgins larva (Storch and Higgins 1991; Janssen et al. 2009)^nThe six oral papillae of Aysheaia (Whittington 1978) and Tardigrada (Urban 2013) are taken to indicate a 6-fold pharyngeal symmetry, reflected by the six oral plates of Actinarctus (Boesgaard and Kristensen 2001) and Halobiotus (Biserova and Kuznetsova 2012).  The six denticles of Sirilorica (Peel 2010; Peel et al. 2013)are interpreted in the same way^n';
+	TEXT CHARACTER=112 TEXT='(–) inapplicable: not a multiple of five';
+	TEXT CHARACTER=115 TEXT='Although the first three circlets of Meiopriapulus contain 25 sclerites, these do not define longitudinal rows of sclerites or a 25-fold symmetry of the introvert (Adrianov and Malakhov 2001)^nThe circlets of Maccabeus contain 25 elements apiece; the first circlet is interpreted as representing an amalgamation of the first three circlets (Adrianov and Malakhov 2001)^nNot so in Kinorhynchs (Herranz et al. 2013), or either Kinonchulus or Eopriapulites sphinx (where it is the first one row that defines the symmetry) (Liu et al. 2014)^n';
+	TEXT CHARACTER=116 TEXT='WTS20^nSlightly narrower in Corynetis (Huang et al. 2004a; Hu et al. 2012)^nNot substantially wider in Cricocosmia (Hou and Bergström 1994)^nNot wider in Halicryptus (Merriman 1981; Shirley and Storch 1999; Adrianov and Malakhov 2001)^n';
+	TEXT CHARACTER=117 TEXT='(~) inapplicable: pharynx not eversible^nWTS21.^nThe fully everted pharynx of Ottoia, Sirilorica and Louisella expresses a  marked increase in width; this bulb-like feature is armed in Louisella  (Peel et al. 2013)(Conway Morris 1977a).^nCoded ambiguous in Scathascolex as there are insufficient specimens to determine whether the pharynx is preserved in its fully everted position.^nCoded ambiguous in Cricocosmia (Hou and Bergström 1994); the material on which the reconstruction of (Han et al. 2007b) is based is not figured.^nCoded present in nematodes as pharynx (though not eversible) bears bulbs (Altun and Hall 2017).^nCoded ambiguous in Paratubiluchus as the ‘bulb’ may represent gut contents (Han et al. 2004)^n';
+	TEXT CHARACTER=118 TEXT='The dorsal stylet (large dorsal tooth of Kinonchulus) arises outside the pharynx, as revealed during moulting and by the possession of its own set of musculature (p 191 Bird and Bird 1991); it is not considered part of the pharyngeal armature.  Its dorsal position indicates that it is not homologous with the (ventral) tardigrade stylet.';
+	TEXT CHARACTER=119 TEXT='(~) inapplicable; introvert absent or armature not comparable to priapulid proboscis zones^nAfter transformation series 5 in Wills et al. (2012).^nAmbiguous in Tabelliscolex due to low preservational fidelity (Han et al. 2003b).^nAbsent in Corynetis (Hu et al. 2012).^nAmbiguous in Shergoldana and Orstenoloricus because these taxa are presumed to represent larvae, meaning that the adult situation is unknown.^nCoded as ambiguous in Palaeoscolex piscatorum (Whittard 1953; Conway Morris 1997); not clear on what basis Wills et al. (2012) coded introvert features.^nThe specimens of Cricocosmia figured in (Hou et al. 2017) clearly shows that there is a single circlet of Zone I armature.^nMultiple circlets are evident in Tylotites (Han et al. 2007c)^nDetailed references: Nanaloricus (Kristensen et al. 2007); Pliciloricus, (Heiner and Kristensen 2005); Echinoderes (Sørensen and Pardos 2008; Herranz et al. 2014); Paracentrophyes, (Sørensen et al. 2010); Campyloderes, (Neuhaus and Sørensen 2013); CEntroderes, (Neuhaus et al. 2014); Zelinkaderes (Sørensen et al. 2007; Altenburger et al. 2015)^n';
+	TEXT CHARACTER=120 TEXT='(–) inapplicable: introvert unarmoured or not eversible^nScalids and pharyngeal teeth have been distinguished based on their orientation on the pharynx (Nielsen 2001 p. 332)^nCoded ambiguous in Tylotites as descriptions are ambiguous on this point (Han et al. 2003a, 2007c)^nDirected anteriad in Maccabeus (Por and Bromley 1974)^n';
+	TEXT CHARACTER=121 TEXT='Nematomorphs have two (Nectonema?) or three (Gordiida) circlets (Schmidt-Rhaesa 1996).  Kinonchulus has around seven. Shergoldana possibly has more than one.';
+	TEXT CHARACTER=122 TEXT='After transformation series 10 in Wills et al. (2012).';
+	TEXT CHARACTER=123 TEXT='Zone I sclerites arranged ‘raidally’, in longitudinal or diagonal lines; see transformation series 6 in Wills et al. (2012). The nature of the radial arrangement – pentaradial or hexaradial – is not independent of the number of longitudinal armature rows (trans. ser. 84) and is thus not coded separately here. A radial arrangement is not apparent in Eokinorhynchus (Zhang et al. 2015); this does not seem to represent preservation and is taken as authentic.^nNot in rows in Nematomorphs: they have a 6-6-7 arrangement (Schmidt-Rhaesa 1996)^nThe symmetric arrangement of kinorhynchs (Herranz et al. 2013) and loriciferans (Kristensen et al. 2007) does not qualify as neat rows; the character aims to capture the regimented organization of priapulids.  The armature of Ottoia and Selkirkia is in prominent diagonal rows, producing a quincunx arrangement (Smith et al. 2015). Inapplicable in Markuelia as the three rings preserved seem to correspond to those that define the prominent rows in priapulids (Dong et al. 2010).  ^n';
+	TEXT CHARACTER=124 TEXT='(–) inapplicable; Zone I without rows of armature (trans. ser. 82)^nAfter transformation series 6 in Wills et al. (2012).  Diagonal in Eokinorhynchus (Zhang et al. 2015).  Parallel in Nanaloricus, Pliciloricus (Neves et al. 2016).  The regular arrangement of scalids in Eolorica (Harvey and Butterfield 2017) is suggestive of a row-wise arrangement, though the orientation of such rows cannot be determined.^nDiagonal in Laojieella (Han et al. 2006)^nAmbiguous in Eopiapulites; although sclerites occur in more-or-less transverse rows, helical ridges suggest that the underlying organization may be spiral (Liu et al. 2014)^n';
+	TEXT CHARACTER=125 TEXT='This and the following transformation series attempt to extract the full phylogenetic information implicit in transformation series 8 of Wills et al. (2012).^nThe spines of Scolecofurca appear to have originally been cuticularized, based on images taken by Jean-Bernard Caron (Caron 2011). These depict simple posterior-directed spines, though finer subsidiary morphology is possible.^n';
+	TEXT CHARACTER=126 TEXT='The solid sclerites of nematomorphs differ from the structures borne by scalidophorans (Schmidt-Rhaesa 1996).  The construction of Zone II and Zone III armature elements is typically the same as that of Zone I elements, so this character statement stands for elements of all three zones.';
+	TEXT CHARACTER=127 TEXT='Maccabeus has long and short sclerites in Zone I (Por and Bromley 1974) so is coded as ambiguous.';
+	TEXT CHARACTER=128 TEXT='Coded as spinose in loriciferans (Neves et al. 2016)^nLimited information is available from Nectonema (Schmidt-Rhaesa 1996)^n## Todo might be worth reviewing?^n';
+	TEXT CHARACTER=129 TEXT='(~) inapplicable^nIn certain kinorhynch genera (here, Cateria), primary spinoscalids bifurcate at their base, giving the appearance that their number is twice its true figure (Sørensen et al. 2015).';
+	TEXT CHARACTER=130 TEXT='(~) inapplicable';
+	TEXT CHARACTER=131 TEXT='(~) inapplicable^nSpinoscalids and clavoscalids of many loriciferans, including Eolorica, bear articulated joints (Neves et al. 2016; Harvey and Butterfield 2017)^nSclerites of Dracoderes are also articulated (Sørensen et al. 2012b)';
+	TEXT CHARACTER=132 TEXT='(~) inapplicable^nSpinoscalids of many loriciferans, including Eolorica, bear small subsidiary setules (Neves et al. 2016; Harvey and Butterfield 2017)^n';
+	TEXT CHARACTER=133 TEXT='(~) inapplicable^nThe sclerites of Priapulopsis are telescopic (Storch et al. 1995).^n';
+	TEXT CHARACTER=134 TEXT='(~) inapplicable^nThe Zone I sclerites of Meiopriapulus bear a pectinate hood (Morse 1981)^n';
+	TEXT CHARACTER=135 TEXT='Zone II is considered to represent the base of the pharynx, and as such the proximal circlet of Zone II sclerites represent circumpharyngeal structures, which are coded as homologous with the radial mouthparts of Hallucigenia, Jianshanopodia et al. (see Smith and Caron 2015).^nSee transformation series 12 in Wills et al. (2012).^nThe grasping denticles of Sirilorica (Peel 2010; Peel et al. 2013) are interpreted as circumpharyngeal.^nThe ‘wrinkles’ at the base of Zone II in Eokinorhynchus (Zhang et al. 2015, fig. 1f) have a spinose shape and are considered to represent a ring of spines compressed to lie flat against an otherwise unarmed Zone II.^nThe outer oral styles  (Sørensen and Pardos 2008) are considered to mark the base of Zone II in kinorhynchs.^nThe six (?) peri-oral structures of Eolorica (Harvey and Butterfield 2017) are interpreted as robust oral ridges, preserved where the accompanying mouth cone has decayed.^nCoded as ambiguous in Tylotites (Han et al. 2003a, 2007c) as it is possible that the distinct and forward-oriented ring of introvert hooks corresponds to the spines at the base of Zone II.^nA single ring of elongate spines appears to gird the base of Zone II in Cricocosmia (Hou and Bergström 1994; Han et al. 2007b)^nThe buccal papillae of Halicryptus are assumed to correspond to the Zone II elements; these are not sclerotized and are irregularly distributed (Merriman 1981; Storch et al. 1990; Adrianov and Malakhov 2001).  A similar condition occurs in Tubiluchus (Calloway 1975)^nThe ‘double tentacles’ of Maccabeus are described as surrounding the mouth, but the eight trigger spines sit directly on the circumoral nerve ring (Por and Bromley 1974).  On this basis, the latter are homologized with the Zone II elements; the tentacles are considered to represent modified Zone I spines. ^nScolecofurca appears to have elongate Zone II elements visible at its anterior margin (Caron 2011)^nCoded ambiguous for Fieldia; just a hint of some form of structure around the base of the everted Zone II (Pers Obs of ROM 93-1678A)^nNot described in Guanduscolex (Hu et al. 2008), though it is possible that these have been overlooked on account of preservation (cf. the faint preservation in Mafangscolex mannus).^nXystoscolex has prominent ridge-like features at the boundary of the introvert and the pharynx (Conway Morris and Peel 2010); these presumably correspond to Zone II armature, though their detailed morphology remains ambiguous^nTODO Review in Aysheaia and Siberion whether the oral papillae might correspond to Zone I^n';
+	TEXT CHARACTER=136 TEXT='(–) inapplicable: radial circumpharyngeal structures (trans. ser. 19) absent^nPanarthropods express a considerable diversity of circumoral structures, which represent a symplesiomorphic feature of Ecdysozoa as a whole (e.g. Edgecombe 2009). Various lobopodians bear oral papillae/lamellae (e.g. Aysheaia  (Whittington 1978); Kerygmachela (Budd 1993, 1998a); Opabinia (Whittington 1975)); a similar feature occurs in the oral cone of Tardigrada (Dewel and Eibye-Jacobsen 2006; Guidetti et al. 2012).  Pambdelurion (Budd 1998b) and anomalocaridids (e.g. Daley et al. 2009; Daley and Edgecombe 2014) exhibit radially arranged plates that together form a mouth apparatus (Daley and Bergström 2012).  We code the nature of the circumoral structures in Megadictyon and Jianshanopodia (Liu et al. 2006, 2007; Vannier et al. 2014) as uncertain; in the former case, the type material does not unequivocally exhibit a plate-like nature; in the latter, the documentation of the plates is inconclusive.  The transformation series is scored as inapplicable in Onychophora because the bilaterally symmetrical lip papillae are demonstrably not homologous with the radially symmetrical structures of other taxa (Eriksson and Budd 2000; Martin and Mayer 2014)^n';
+	TEXT CHARACTER=137 TEXT='(~) inapplicable: circumoral structures, if present, are neither scalids nor plates (trans. ser. 20)^nThis transformation series distinguishes the somewhat indistinct organization of the mouth apparatus in Pambdelurion (Budd 1998b) from the radially arranged mouthparts of anomalocaridids (Daley et al. 2009; Daley and Bergström 2012; Daley and Edgecombe 2014). We score Megadictyon and Jianshanopodia as uncertain to reflect their mouthparts’ poor preservation (Liu et al. 2006, 2007).^n';
+	TEXT CHARACTER=138 TEXT='(–) inapplicable: Zone II not armoured (trans. ser. ##)^nAfter transformation series 12 in Wills et al. (2012).^nThe single circlet of large denticles in Sirilorica (Peel et al. 2013) is interpreted as the proximal circlet of Zone II.  There are at least six denticles; a seventh may be obscured by incomplete preservation (Peel et al. 2013).  Nanaloricidae, and most species of Pliciloricus, bear eight oral ridges (though ranging from six to twelve in Pliciloricidae) (Neves et al. 2016).  The six peri-oral sclerites preserved in Eolorica (Harvey and Butterfield 2017) are taken to represent the full complement.  Six in Actinarctus (Boesgaard and Kristensen 2001), Halobiotus (Biserova and Kuznetsova 2012), Aysheaia.  Twelve liplets corresponding to six lobes in Anatonchus (Borgonie et al. 1995), so coded as homologous to six as this is the underlying organization.  c. Eighteen in Eopriapulites (Liu et al. 2014)^n';
+	TEXT CHARACTER=139 TEXT='(–) inapplicable: Zone II not armoured (trans. ser. ##)^nAfter transformation series 13 in Wills et al. (2012).^nMaccabeus is coded ambiguous; the spines have a length:width ratio of 4:1 if the width is measured at its maximum in the basal region, but 12:1 if measured at the base of the elongate projection (Por and Bromley 1974).^n';
+	TEXT CHARACTER=140 TEXT='(~) inapplicable: no spines at base of Zone II^nThe spines of Sirilorica seem to have multiple cusps (Peel et al. 2013), as do the trigger spines of Maccabeus (Por and Bromley 1974).^nShergoldana is coded as ambiguous as it is not clear whether the ‘cushion-like folds’ (Maas et al. 2007a) are part of the spine or represent soft tissue.^n';
+	TEXT CHARACTER=141 TEXT='(~) inapplicable; reduced or not differentiated^nWhere present, the oral ridges of loriciferans (Neves et al. 2016) are interpreted as Zone II sclerites fused to the introvert. In other taxa, only the proximal part of the sclerites is attached to the trunk. ^nIn certain kinorhynchs (here, Campyloderes) the outer oral stylets (= Zone III sclerites) lie flat against the introvert, to which they are fused (Sørensen et al. 2015).  ^n';
+	TEXT CHARACTER=142 TEXT='The Zone III armature trans. series has been reformulated from Wills et al. (2012, trans. ser. 15–19) to better capture possible homologies between similar structures, and to avoid treating different character states as homologous.^n(–) inapplicable : WHY?^nAfter transformation series 3 in Wills et al. (2012).  Priapulids’ Zone III sclerites, and the microspines (proventricular acanthae) of the arthropod foregut, are included here.  The presence of comparable features in the foregut of Jianshanopodia (Vannier et al. 2014) demonstrates that comparable features can be observed in Cambrian lobopodians given suitable preservation; lobopodians are thus coded as ambiguous for this transformation series.  The features are absent in Onychophora (Elzinga 1998); electron-dense thickenings in the tardigrade pharynx (Dewel and Clark 1973b) are tentatively considered to represent armature that has been reduced in size due to the miniaturization of the tardigrade body.^nCorresponds to the inner rows of teeth in Hurdia (Transformation series 9 in Daley et al. (2009). ^nOral stylets are occasionally present (three, four or six) in Pliciloricus (Neves et al. 2016); eight are present in Nanaloricus mysticus (Kristensen 1983).^nPresence of armature in Priapulites (Schram 1973) indicated by robust preservation of pharyngeal region.^nThe adult condition is used, except where elements are present in larvae only.^nSimple spinose elements within the oral circlet of Eopriapulites (Liu et al. 2014) are interpreted as elements of Zone III.^n';
+	TEXT CHARACTER=143 TEXT='The situation in Zone III is assumed also to apply to Zone I armature, thus this character statement stands for both.';
+	TEXT CHARACTER=144 TEXT='After transformation series 3 in Wills et al. (2012).';
+	TEXT CHARACTER=145 TEXT='(–) inapplicable: Zone III lacking armature (trans. ser. 22)^nAfter transformation series 14 in Wills et al. (2012).  ^nThe oral stylets of loriciferans, where present, occur in a single circlet (Neves et al. 2016).^nCirclets of tardigrade mucrones are indistinct, and given presence of prominent deeper circlet in certain taxa, this is coded as ambiguous (Guidetti et al. 2013b)^nAnatonchus (Nematoda) has four circlets (Borgonie et al. 1995), in addition to three teeth (codedd as distal elements)^nMaotianshania has around 12 circlets (Hou and Bergström 1994)^nEokinorhynchus has at least two circlets; the full number is unknown as the pharynx may not be fully everted (Zhang et al. 2015).^nKinorhynchs have four circlets within Zone III: one ring of outer oral stylets, two rings of inner oral styles, and the helioscalids (Sørensen and Pardos 2008)^nOttoia has c. 40 (Smith et al. 2015)^nCorynetis has c. 60, if the armature is arranged in circlets rather than irregularly (Hu et al. 2012)^nHalluicgenia is coded as ?; its sclerites are not strictly arranged in circlets, and occur in a large number of rows (Smith and Caron 2015).^nHalycryptus has multiple circlets, with the number increasing during growth (Adrianov and Malakhov 2001)^nMany circlets in Maccabeus (Por and Bromley 1974)^nc. 50 in Priapulus (Adrianov and Malakhov 2001)^nAround 12 clear circlets in Tubiluchus, with further more distally (Kirsteuer 1976)^nAt least thirteen in Priapulopsis (van der Land 1970)^nVariable numbers reported in Meiopriapulus, possible changing with ontogeny (Sørensen et al. 2012a)^nc. 20 in Laojieella (Han et al. 2007a)^nSeemingly a single circlet in Ancalagon and Fieldia (Conway Morris 1977a) (and Pers. Obs)^n';
+	TEXT CHARACTER=146 TEXT='(–) inapplicable: number of elements in proximal circlet of Zone III armature not equal to five (trans. ser. ##), or fewer than ten circlets^nA distinct pentaradial symmetry is evident “only in the [first] eight circlets” in Halicryptus (Adrianov and Malakhov 2001)^nSeven (including the proximal circlet) in Maccabeus (Por and Bromley 1974)^nWTS19^n';
+	TEXT CHARACTER=147 TEXT=' (–) inapplicable: none present (trans. ser. ###)^nWTS18^nEight in Meiopriapulus (Sørensen et al. 2012a)^nFive in Tubiluchus lemburgi (Schmidt-Rhaesa et al. 2013), reflected by the five basal papillae (which represent a distinct circlet from the remainder of the pharyngeal teeth).^nSix in Namnaloricus, Pliciloricus (Neves et al. 2016), Kinochulus ^nMaotianshania has approximately 15 (Hou and Bergström 1994); coded as ?^nCoded ambiguous in Cricocosmia (Hou and Bergström 1994)?^nSixteen in Eokinorhynchus (Zhang et al. 2015)^nOttoia approx.. 24–30; probably not a constant number between specimens (Smith et al. 2015); coded ambiguous^nThe dorsal outer oral stylet in Kinorhyncha is understood to be secondarily reduced; the decaradial arrangement of the elements being clearly evident (Nebelsick 1993); these taxa are thus coded as ten.^nTwelve reported in Kinonchulus, though six drawn; possibly six are the Zone II ‘hooks’.^nAnatonchus > 40 (Borgonie et al. 1995), coded ambiguous ^nFive in Halicryptus (Adrianov and Malakhov 2001) and Priapulopsis (van der Land 1970)^nc. Sixteen in Fieldia? (pers. obs)';
+	TEXT CHARACTER=148 TEXT='The proximal circlet in kinorhynchs has an obvious relationship to the subsequent circlets, each containing vice – this suggests an underlying shared five-fold symmetry, hence linking these two options ';
+	TEXT CHARACTER=149 TEXT='(~) inapplicable';
+	TEXT CHARACTER=150 TEXT='(~) inapplicable: Zone III unarmoured (trans. ser. ##)^nReduction relates to size; this transformation series therefore applies whether or not the morphology of the proximal circlet is differentiated^n';
+	TEXT CHARACTER=151 TEXT='TODO in matrix, switch position with adjacent character – follow column headings^nFollowing Sørensen et al. 2015 character 1 (Sørensen et al. 2015), the outer oral stylets of neocentrophyid and dracoderid kinorhynchs alternate between prominent and less well-developed sizes; see for example Paracentrophyes (Sørensen et al. 2010)';
+	TEXT CHARACTER=152 TEXT='(~) inapplicable: Zone III lacking armature (trans.ser. ##)^nAfter transformation series 18 in Wills et al. (2012).^nDifferentiated circlets are depicted in the drawn reconstruction of Corynetis (Huang et al. 2004a), but not formally described or depicted; this taxon is coded as ambiguous.^nDifferentiated in Halicryptus, Priapulopsis (Conway Morris 1977a).^nScored as inapplicable in loriciferans (Neves et al. 2016), whose single circlet cannot be meaningfully coded as ‘proximal’, ‘medial’ or ‘distal’.^nScored as differentiated in Ancalagon and Fieldia as the medial Zone III armature is massively reduced or absent in these taxa (Conway Morris 1977a)^nThe circlet of five sclerotized trabeculae in Maccabeus (Por and Bromley 1974) are interpreted as a reduced circlet of Zone III teeth.^nIn Priapulopsis bicaudatus, the first ring of teeth feature a reduced central spine (van der Land 1970)^nDifferentiated in Ottoia and Selkirkia (Type A teeth) (Conway Morris 1977a; Smith et al. 2015)';
+	TEXT CHARACTER=153 TEXT='(~) inapplicable: proximal circlet of Zone III absent or reduced (trans. ser. 107)^nThis and the following transformation series have been modified from trans. ser. 15 in Wills et al. 2012 to better capture possible homologies between sclerite morphologies.^n';
+	TEXT CHARACTER=154 TEXT='(–)	inapplicable: proximal circlet of Zone III armature without prominent central spine (trans. ser. ##)';
+	TEXT CHARACTER=155 TEXT='(~)	inapplicable: proximal circlet of Zone III armature without prominent central spine  (trans. ser. ##)^nPectinate projections can occur from the fringe of a central cone (cf. trans. ser. 15, state 4 in Wills et al. 2012) or can occur along the margin of a scalid that lacks a central spine (cf. trans. ser. 15, state 6 in Wills et al. 2012).  There is a gradation from a pectinate fringe (cf. Ottoia) via a multispinose situation (cf. Selkirkia Type A) through multiple spines (cf. Pripaulopsis); as such, all of these are coded in a single character statement.^nA basal fringe is present in the outer oral stylets of certain kinorhynchs – Paracentrophyes (Sørensen et al. 2010), Dracoderes (Sørensen et al. 2012b)^n';
+	TEXT CHARACTER=156 TEXT='(~) inapplicable: not morphologically differentiated, or reduced^nThe outer oral stylets of many kinorhynchs (though not certain Pycnophyidae) consist of two to three rigid articulating units (Sørensen et al. 2015)';
+	TEXT CHARACTER=157 TEXT='(–) inapplicable: Zone III lacks armature (trans. ser. ##)^nFieldia and Ancalagon only possess a single ring of Zone III teeth (Conway Morris 1977a), which I consider to represent a differentiated proximal circlet; the middle circlets are perhaps reduced or indistinct in the fossil material.  The situation in loriciferans is taken to be the same: the Zone III armature comprises a single ring (typically) of oral ridges (i.e. a proximal circlet) and a single ring (where present) of oral stylets (a single distal circlet) (Neves et al. 2016).^nKinorhynchs have three rings of simple spinose styles (Sørensen and Pardos 2008; Herranz et al. 2014)^n';
+	TEXT CHARACTER=158 TEXT='(–) inapplicable: middle circlets in Zone III armature absent or reduced (trans. ser. ##)^nMultiple spines in Ottoia and Selkirkia (Smith et al. 2015). Simple spines in Eokinorhynchus (Zhang et al. 2015)^nSingle spines with pectinate fringe in Antygomonas (Bauer-Nebelsick 1996) and Centroderes (Neuhaus et al. 2014) coded as single spines; not clear that pectinate fringe is always clear enough to be unambiguously observed in other taxa.^n';
+	TEXT CHARACTER=159 TEXT='(~) inapplicable: Zone III unarmoured (trans. ser. ##)^nIn taxa such as Ottoia, the distal teeth in Zone III are morphologically and constitutionally distinct from the more proximal Zone III teeth (Smith et al. 2015). Scored as present if sclerites in the distal region of Zone III are morphologically distinct from those in the medial region, which are typically more robustly cuticularized.  Sclerites that arm the upstanding eversible ‘mouth cone’ of priapulids are not included as part of the Zone III armature.  Ambiguous in Louisella (Conway Morris 1977a).  ^nDifferentiated ‘curved, scimitar-shaped’ teeth at entrance to stomach in Maccabeus (Por and Bromley 1974)^n';
+	TEXT CHARACTER=160 TEXT='(–) inapplicable: distal circlets in Zone III armature not morphologically distinct (trans. ser. ##)^nPectinate in Ottoia (Smith et al. 2015).^nMorphologically distinct, though still pectinate, in Tubiluchus (Kirsteuer and Ruetzler 1973)^n';
+	TEXT CHARACTER=161 TEXT='WTS23.  If the proximal ring of elements is morphologically distinct, they are not included in this consideration.^nThe Zone III elements in Ottoia and Selkirkia do not change in size, just in angle of preservation (Smith et al. 2015).^nNo change in size is evident in Scathascolex.^n';
+	TEXT CHARACTER=162 TEXT='(~) inapplicable^nA feature of certain kinorhynchs, e.g. Franciscideres; see character 7 in (Sørensen et al. 2015)^n';
+	TEXT CHARACTER=163 TEXT='Trichoscalids are scalids that occur posterior to the last spinoscalid ring of the introvert in kinorhynchs, distinguished from other scalids morphologically, by their ‘hairy’ appearance, and positionally, by the gap between them and the Zone I scalids (Neves et al. 2016). They are listed as features of the neck as trichoscalid plates, where present, are connected to the placids (Sørensen et al. 2015).  Wills et al. (2012) considered these as a separate ring of the Zone I armature (see their transformation series 11), but they are here treated separately. ^nThe fringed tips of sclerites in Eolorica (Harvey and Butterfield 2017) are taken to identify the presence of trichoscalids.^nCoded ambiguous in Sicyophorus, as there is a hint of spine-like structures at the base of the introvert of (fig. 3a Maas et al. 2007c) that could conceivably represent tricoscalids.^nCoded as present in Kinonchulus, corresponding to the articulated ‘anterior six head setae’, which occur immediately behind setae that are homologised with the ‘lip setae of other Onchulidae’ (Riemann 1972), which presumably themselves correspond to an additional row of trichoscalids or trichoscalid plates.  The row of backward pointing spines in Markuelia (Haug and Maas 2009) occupy an equivalent position and are coded as homologous.^n';
+	TEXT CHARACTER=164 TEXT='(–) inapplicable: single circlet (trans. ser. ##)^nAfter transformation series 11 in Wills et al. (2012).^n';
+	TEXT CHARACTER=165 TEXT='Following character 5 of (Sørensen et al. 2015). Loriciferans (Neves et al. 2016) have fifteen trichoscalids (seven of which are sometimes ‘double’, interpreted as basally bifurcating as they attach to the same trichoscalid plate).  ';
+	TEXT CHARACTER=166 TEXT='(~) inapplicable: trichoscalids absent^nTrichoscalid plates are large plates to which trichoscalids attach.  They are always present in lorificerans (Neves et al. 2016), and occur in certain kinorhynchs, where they connect at their posterior margin to the placids; see character 6 of (Sørensen et al. 2015)^n';
+	TEXT CHARACTER=167 TEXT='(~) inapplicable^nThe placids of kinorhynchs and the lorical ring of loriciferans and larval priapulids form cuticular plates that surround the neck region of the respective organisms (Wennberg et al. 2009; Peel et al. 2013; Sørensen et al. 2015); whilst placids conceivably represent reduced lorical plates, they are not considered homologous and are treated as two separate transformation series.  Coded absent in Shergoldana as the plates do not form clear rings and do not clearly girdle the neck (Maas et al. 2007a).^nCoded as present in Corynetis as a ring of robust plates seems to occur at the anterior margin of specimens with retracted introverts, though there is no indication that these could form a closing apparatus, their size being too large (Hu et al. 2012).^nCoded as ambiguous in Acanthopriapulus as larval stages are unknown (van der Land 1970; Higgins and Storch 1991)^nCf. WTS61.^n';
+	TEXT CHARACTER=168 TEXT='(~) inapplicable^nCf. WTS24.^nPlates not retained in Tubiluchus; no reference available to support retention in T. vanuatensis (Kirsteuer and Ruetzler 1973; Calloway 1975; Kirsteuer 1976)^nThere is a possibility that the ‘theca’ of Laojieella (Han et al. 2006) is homologous with loriciferan plates (cf. Priapulus Higgins larvae with a prominent dorsal and ventral plate, and Sirilorica with prominent regions of the trunk anterior and posterior of its lorica), but this cannot be substantiated, so Laojieella is coded as ambiguous.^nThe lorica of Sicyophorus is considered to represent the adult form due to the size of the organisms (Hou et al. 2017).  I consider Palaeopriapulites to have a lorical too; a distinct anterior margin is evident in some specimens (Hou et al. 2017).?^n';
+	TEXT CHARACTER=169 TEXT='(–) inapplicable; lorica absent (trans. ser. ##)^nSix in Nanaloricus mysticus, Franciscideres (Kristensen 1983; Sørensen et al. 2015)^nSix to ten in nanaloricidae; six in Nanaloricus mysticus (Kristensen 1983)^nSeven in Sirilorica (Peel et al. 2013), Paracentrophyes (Sørensen et al. 2015)^nTwenty in Eolorica (Harvey and Butterfield 2017), Orstenoloricus (Maas and Waloszek 2009) and Tubiluchus (Higgins and Storch 1989)^nCoded (tentatively) as twenty in Sicyophorus as c. 10 are evident on a single surface (Hou et al. 2017)^nIn Halicryptus and Priapulus caudatus there are 14 plates: a dorsal and a ventral, and on each side three pairs of accordion-like plates (Storch and Higgins 1991; Higgins et al. 1993). ^nNumbers that are unique to a single terminal in the dataset are coded with the ambiguous token as they contain no phylogenetic information.  These include Pliciloricus (typically 22, in some species 21, 30 or 44) (Neves et al. 2016).^nTen places in Maccabeus (Por and Bromley 1974)^n';
+	TEXT CHARACTER=170 TEXT='Shergoldana is coded as ambiguous as its plates with spine-bearing humps (Maas et al. 2007a) equivocally correspond to lorical plates.^nCoded as ambiguous in macrofossils that do not preserve loricae, as the early developmental stages are unknown.^n';
+	TEXT CHARACTER=171 TEXT='(~) inapplicable: plates absent ^nCf. WTS62^nPresent in Halicryptus (Storch and Higgins 1991)^nAbsent in Sicyophorus; may be present in Palaeopriapulites (coded ambiguous) (Maas et al. 2007c; Hou et al. 2017)^n';
+	TEXT CHARACTER=172 TEXT='‘Honeycomb’ ornament is considered equivalent to “rows of subrectangular fields”; the two intergrade in, for example, Halicryptus larvae (Storch and Higgins 1991)';
+	TEXT CHARACTER=173 TEXT='(–) inapplicable; cuticular plates absent (trans. ser. ##)^nSee character 11 in (Sørensen et al. 2015).^nSirilorica and Nanaloricus bear spikes on the anterior margins of their loricae (Peel et al. 2013; Neves et al. 2016); Pliciloricus and Eolorica do not (Neves et al. 2016; Harvey and Butterfield 2017)^n';
+	TEXT CHARACTER=174 TEXT='Placids are a ring of plates in the neck region of most kinorhynchs (though not Cateria), posterior to the introvert. See character 8 in (Sørensen et al. 2015).  Coded ambiguous in Sicyophorus, as there is a hint of spine-like structures at the base of the introvert (fig. 3a Maas et al. 2007c) that could conceivably correspond to placids or lips';
+	TEXT CHARACTER=175 TEXT='(~) inapplicable^n^nIn most cases, placids form a closing mechanism when the head is retracted into the trunk; see character 8 in (Sørensen et al. 2015).  Nematode ‘lips’ also serve to close the front of the trunk (Borgonie et al. 1995; Altun and Hall 2017) ^n';
+	TEXT CHARACTER=176 TEXT='In certain kinorhynch taxa, the arrangement of placids incorporates gaps that give rise to a bilaterally symmetric character; see character 13 in (Sørensen et al. 2015).';
+	TEXT CHARACTER=177 TEXT='(–) inapplicable; cuticular plates absent (trans. ser. ##)^nSee character 9 in (Sørensen et al. 2015).^nSix in Franciscideres; seven in Paracentrophyes; nine in Dracoderes; fourteen in Campyloderes; sixteen in Antygomonas, Centroderes , Echinoderes, Zelinkaderes (Sørensen et al. 2015).^n';
+	TEXT CHARACTER=178 TEXT='(–) inapplicable; cuticular plates absent (trans. ser. ##)^nSee character 11 in (Sørensen et al. 2015).^nSirilorica and Nanaloricus bear spikes on the anterior margins of their loricae (Peel et al. 2013; Neves et al. 2016); Pliciloricus and Eolorica do not (Neves et al. 2016; Harvey and Butterfield 2017)';
+	TEXT CHARACTER=179 TEXT='(–) inapplicable; cuticular plates or trunk segment absent (trans. ser. ##)^nSee character 12 in (Sørensen et al. 2015).^n';
+	TEXT CHARACTER=180 TEXT='A proposed synapomorphy of Scalidophora, though absent in loriciferans, and not really codable as present in priapulids (Sørensen et al. 2008) – thus alternatively proposed as a synapomorphy of kinorhynchs and loriciferans (Neuhaus and Higgins 2002)^nThis said, the spines in kinorhynchs (e.g. Zelinkaderes, Neuhaus and Higgins 2002) are not restricted to the mid-trunk – more occur more posteriorly ^n## For a more careful description see Schmidt-Rhaesa 1997⁄98; Lemburg 1999; Neuhaus and Higgins 2002^nUnambiguously absent in Halicryptus and Tubiluchus Higgins larvae (Higgins and Storch 1989; Storch and Higgins 1991; Higgins et al. 1993), but present in Pripaulus (van der Land 1970) and early larvae of Maccabeus (Por and Bromley 1974)^n';
+	TEXT CHARACTER=181 TEXT='WTS36^nFlosculi have been proposed as a synapomorphy of Scalidophora (Lemburg 1995; Nielsen 2012).^nAmong loricifera, present only in Nanaloricus and Pliciloricus (Neves and Kristensen 2014).^nCoded ambiguous in Chordodes (Bolek et al. 2010) as it is unclear whether any of its areoles might be considered equivalent to flosculi.^nFlosculi are really tiny (Storch and Alberti 1985) and the chances of picking them out from cuticular ridges in Burgess Shale-type fossils are slim – such taxa are coded ambiguous accordingly.  Coded absent in Schistoscolex as the preservation is of sufficient fidelity, and the posterior region of is preserved (Duan et al. 2012)^n';
+	TEXT CHARACTER=182 TEXT='(–) inapplicable: none present (trans. ser. ##)^nFlosculi in Maccabeus (Por and Bromley 1974), Meiopriapulus and Tubiluchus (Sørensen et al. 2012a), kinorhynchs and loriciferans [[Nematomorpha, Priapulida, Kinorhyncha, Loricifera^nedited by Andreas Schmidt-Rhaesa]]^n';
+	TEXT CHARACTER=183 TEXT='(~) inapplicable^nFlosculi in priapulids have petal-like structrues (typically eight) (Wills et al. 2012); in loriciferans they do not bear clear petals (Neves et al. 2016)^n';
+	TEXT CHARACTER=184 TEXT='WTS36';
+	TEXT CHARACTER=185 TEXT='‘Mushroom shaped’ structures present in the genital region of Tubiluchus (Priapulida). WTS37';
+	TEXT CHARACTER=186 TEXT='(–) inapplicable: clavula absent^nThe clavula of Tubiluchus lemburgi has a short stalk and moderately sized distal bulb (Schmidt-Rhaesa et al. 2013).^nT. corallicola, T. australiensis have a short-stalked clavula (Van Der Land 1982; Schmidt-Rhaesa et al. 2013)^nT. remanei has a long-stalked clavula (Van Der Land 1982)^n';
+	TEXT CHARACTER=187 TEXT='The clavula of Tubiluchus lemburgi has a short stalk and moderately sized distal bulb (Schmidt-Rhaesa et al. 2013).^nThe clavulae of T. remanei and T. corallicola are club-shaped with a  distal bulb (Van Der Land 1982)^n^nFrom Schmidt-Rhaesa et al. 2013:^nIn T. remanei (see van der Land, 1982),^nthere is a row of perigenital setae of varying shape and size and^nvery long stalked clavula on each side next to the cloacal opening.^nInT. corallicola(seevan der Land, 1970), the urogenital pore and^nthe anus are very small and almost invisible. Close to each pore is a^nclavula, posterior are two large setae and anterior is a row of small^nperigenital setae. This row leads to a broad ventral region, in which^nnormal setae, large perigenital setae and tubuli are present; most^nprominent is a group of large “normal” setae anterior to the row^nof small perigenital setae. InT. remanei(see van der Land, 1982),^nthere is a row of perigenital setae of varying shape and size and^nvery long stalked clavula on each side next to the cloacal opening.^nA comb-like series of cuticular ridges is described, but not figured.^nTubiluchus australensis (see van der Land, 1985) has a clavula with a^nlarge spherical distal end and a short stalk. Additionally, only a row^nof eight perigenital setae of varying shape and size is present on^neach side of the animal. Whereas the urogenital opening is almost^ninvisible in all previous species, it is quite large and funnel-shaped^ninT. philippinensis (see van der Land, 1985). With a length of about^n25µm the clavulae are very large, and their distal ends are clubshaped. Some setae are present close to each clavula, but the most^nconspicuous structures are a dense group of small perigenital setae^nanterior to each urogenital opening. InT. troglodytes(seeTodaro^nand Shirley, 2003), there are circular cuticular ridges, which in total^nhave the form of an “8”. Eight to 10 setae are present along the ridge^non each side, and a clavula and two setae are present in the anterior^nregion anterolateral of the ridges on each side. Anterior of these^nstructures is a dense group of up to 70 setae. The genital structures^nofT. arcticusandT. vanuatuensiscould not be included here (they^nare, e.g. not mentioned in the English summary of the species in^nAdrianov and Malakhov, 1996).^n';
+	TEXT CHARACTER=188 TEXT='Bullulae are small hemispherical elevations present in the genital region of certain priapulids, including Tubiluchus lemburgi (Schmidt-Rhaesa et al. 2013).^nPresent in T. corallicola (Van Der Land 1982)^n';
+	TEXT CHARACTER=189 TEXT='WTS38. These states are retained in a single transformation series as states 1 and 2 are mutually exclusive but are unlikely to be homologous.';
+	TEXT CHARACTER=190 TEXT='Cf. WTS39.^nLoriciferans bear posterior spines, interpreted as sensory setae (Neves and Kristensen 2014)^nEokinorhynchus has two pairs of caudal spines, distinguishing them from the series of lateral spines on the dorsal trunk (Zhang et al. 2015).  Coded as absent in loriciferans as posterior projections only occur in larval stages (Neves et al. 2016)^nAmbiguous in Shergoldana: larval hooks cannot be assumed to be retained to adulthood (cf. loriciferans, Neves et al. 2016).^nThe posterior bifurcations of adult nematomorphs are not considered as projections.^nTwo present in Halicryptus (Shirley and Storch 1999)^nAcanthopriapulus is covered in a profusion of hooks (van der Land 1970); tail hooks are not distinguished from other trunk hooks, so the character is scored as ambiguous.^nTail hooks are absent in Priapulus; it is possible that the posterior warts correspond to these structures, but I was unable to find any literature that documented their distribution.^nNo posterior structures present in Eopriapulites (Shao et al. 2016)^nAbsent in Fieldia (ROM93-1509)^nI know of no specimens of Palaeoscolex piscatorum that document the posterior end; it’s not clear how Wills et al. (2012) coded hooks as present.^nPosterior projections in kinorhynchs (Sørensen and Pardos 2008)(Herranz et al. 2014) differ fundamentally in position, distribution, morphology, and differentiation of morphology, and are not considered homologous to the caudal spines in palaeoscolecids and certain priapulids.^n';
+	TEXT CHARACTER=191 TEXT='Cf. WTS44.';
+	TEXT CHARACTER=192 TEXT='Cf. WTS49.^nCoded as ambiguous in Scathascolex and Eokinorhynchus as the tail hooks’ basal diameter is close to 20% of the trunk diameter; the preservation of the fossils makes it difficult to determine the exact diameter of the hooks.^n';
+	TEXT CHARACTER=193 TEXT='(–) inapplicable: no posterior projections (trans. ser. ###)^nScathascolex and Eokinorhynchus have four hooks.^nWronascolex antiquus is scored as having four hooks; the hooks are occluded by adpression in the specimens figured in (García-Bellido et al. 2013a)  but seem to occur in two pairs.^nMaccabeus has 40–65 hooks (Por and Bromley 1974)^nMeiopriapulus has 32–38 in a single ring (Sørensen et al. 2012a)^nSix in Markuelia (Dong et al. 2010)^n';
+	TEXT CHARACTER=194 TEXT=' (–) inapplicable; not more than two posterior spines or hooks (trans. ser. ###)^nCf WTS39.^nSchistoscolex has four projections, two bilateral pairs; they encircle the entire posterior surface of the organism and are thus coded as being a radial ring.^nThe pairs in Eokinorhynchus form an open arc (Zhang et al. 2015)^nThe condition in Markuelia is unclear (Dong et al. 2010)^nThe condition in Acanthopriapulus is taken to be irregular (van der Land 1970)^n';
+	TEXT CHARACTER=195 TEXT='WTS40.  Ring papillae are small peg-like structures tipped with a seta; they occur on the annulus/annuli closes to the anus.  They grade into abdominal setae, and are easily missed except with SEM analysis of living priapulids (Merriman 1981) and are thus coded ambiguous in fossil taxa except the exquisitely preserved Schistoscolex, where they are demonstrably absent.  Corynetis and Xiaoheiqingella, coded as present in Wills et al. 2012, do not obviously express a ring of papillae that are distinct from abdominal spines. ';
+	TEXT CHARACTER=196 TEXT='WTS42.';
+	TEXT CHARACTER=197 TEXT='WTS43.^nTerminal in Maccabeus (Por and Bromley 1974)^nTerminal in Onychophora and Tardigrada; not clear why coded as in abdomen in Wills et al. 2012^n';
+	TEXT CHARACTER=198 TEXT='(–) inapplicable: trunk stem not lobopodous^ni.e. terminal limbs of lobopodians; lumps of palaeoscolecids.  Distinguish from caudal appendages.  ^nThis transformation series has been modified by that of previous analyses (Ma et al. 2014a) to reflect the fact that, in extant Onychophorans, the posterior extension of the lobopodous trunk (i.e. anal cone) corresponds to a segment that has lost its appendage pair, as evinced by the prevalence of nephridia in this region (Mayer and Koch 2005).  As it is not possible to determine whether the posterior extension of the trunk in Palaeozoic lobopodians arises through the loss of the last appendage pair (as in Onychophora) or as an elongation of the trunk, we code this transformation series as present in all taxa where the trunk extends posteriad of the last observable pair of limbs.  We code this transformation series as absent in Kerygmachela (Budd 1993, 1998a), Jianshanopodia (Liu et al. 2006) and Anomalocaris (Daley and Edgecombe 2014) as their tails likely represent modified appendages (see transformation series 63 and 64).  There is possible, but inconclusive, evidence for a small posterior extension in Opabinia (Whittington 1975; Budd 1996; Budd and Daley 2012), which is thus coded as uncertain. Siberion is scored as uncertain as it is difficult to distinguish the possible body termination from a posterior leg or pair of legs (Dzik 2011). Hallucigenia sparsa is also coded as uncertain; the posterior part of its body is poorly known (Ramsköld 1992).  It is present in other species of Hallucigenia (e.g. Hou and Bergström 1995).^n';
+	TEXT CHARACTER=199 TEXT='Cf. WTS45.^nBy comparison with Corynetis (Huang et al. 2004a; Hu et al. 2012), the posterior trunk region of Louisella (Conway Morris 1977a) is coded as a caudal appendage.^nThe posterior lobes of nematomorphs are not considered to represent separate appendages or organs, so caudal appendages are coded as absent in this taxon.^nJust a hint of some form of caudal appendage in Fieldia (ROM 93-1509)^nCoded ambiguous in Selkirkia as the posterior trunk is not known; the posterior of the tube was apparently open. ^n';
+	TEXT CHARACTER=200 TEXT='WTS41.^nGiven the difficulty of distinguishing the ‘bursa’ in fossil worms such as Ottoia and Louisella (Conway Morris 1977a) from a caudal appendage, or indeed of clearly defining a distinction, a ‘bursa’ is coded as a caudal appendage; this transformation series refers to the eversibility of this appendage.^nThe identity of the posterior extension in Chalazascolex as a bursa is speculative (Conway Morris and Peel 2010);this taxon is coded ambiguous.^n';
+	TEXT CHARACTER=201 TEXT='(–) inapplicable: caudal appendage absent^nCf. WTS45. The caudal appendage of Tubiluchus lemburgi is distinctly longer than the body ';
+	TEXT CHARACTER=202 TEXT='(~) inapplicable: caudal appendage absent^nWTS46.^n';
+	TEXT CHARACTER=203 TEXT='(–) inapplicable: caudal appendage absent^nCf. WTS47. ^n';
+	TEXT CHARACTER=204 TEXT='(–) inapplicable: caudal appendage absent or bicaudal^nCf WTS47.^n';
+	TEXT CHARACTER=205 TEXT='(–) inapplicable: caudal appendage absent or bicaudal^nWTS48. ^n';
+	TEXT CHARACTER=206 TEXT='Cf. WTS50.';
+	TEXT CHARACTER=207 TEXT='(–) inapplicable: posterior warts absent (trans. ser. ###)^nCf. WTS50.^n';
+	TEXT CHARACTER=208 TEXT='WTS55. Proposed as a synapomorphy of Cycloneuralia (Nielsen 2012), though also present in Panarthropoda; Euperipatoides has been scored as present based on the homology of the supraoesophageal ganglion with the circumpharyngeal brain, as argued by (Eriksson and Budd 2000).  Present in Nematomorpha despite the absence of a pharynx (Henne et al. 2017)';
+	TEXT CHARACTER=209 TEXT='TO ADD See (Schmidt-Rhaesa 1997a) , Schmidt Rhaesa 1996 Monophyly.^nA synapomorphy of Nematomorpha.^n';
+	TEXT CHARACTER=210 TEXT='Whereas typical cycloneuralians have a circumoesophageal nerve ring (e.g. Storch 1991; Telford et al. 2008; Edgecombe 2009; Rothe and Schmidt-Rhaesa 2010), Panarthropoda is characterized by dorsal condensed brain neuromeres (Eriksson et al. 2003; Mittmann and Scholtz 2003; Harzsch et al. 2005; Mayer et al. 2010, 2013b). A dorsal condensed brain has been described in Fuxianhuia (Ma et al. 2012) and Alalcomenaeus (Tanaka et al. 2013).';
+	TEXT CHARACTER=211 TEXT='(–) inapplicable: dorsal condensed brain (trans. ser. 68) absent^nSee the introductory statements above.^n';
+	TEXT CHARACTER=212 TEXT='(–) inapplicable: dorsal condensed brain (trans. ser. 68) absent^nRecent fossil data suggest a likely deutocerebral innervation for the mouth in Fuxianhuia and Alalcomenaeus based on the position of the oesophageal foramen relative to the brain (Ma et al. 2012; Tanaka et al. 2013), which is congruent with the organization found in phylogenetically basal extant euarthropods such as Chelicerata and Myriapoda (e.g. Mittmann and Scholtz 2003; Harzsch et al. 2005; Scholtz and Edgecombe 2005, 2006).  Tritocerebral innervation is observed in Pancrustacea, but not among the taxa included in this study.  Onychophora are coded as state 2 to reflect their complex neurological organization: although the jaws have a deutocerebral segmental affinity and innervation, the lip papillae that delineate the oral opening are formed as epidermal derivatives of the three anteriormost body segments, and thus receive nervous terminals from the protocerebrum, deutocerebrum and part of the ventral nerve cord (Eriksson and Budd 2000; Martin and Mayer 2014). The tardigrade mouth cone is innervated from the protocerebrum (Mayer et al. 2013b).^n';
+	TEXT CHARACTER=213 TEXT='Transformation series 1 in Tanaka et al. (2013).  This transformation series distinguishes the organization of the ventral nerve cord in Onychophora (e.g. Mayer et al. 2013a) from that in other phyla.';
+	TEXT CHARACTER=214 TEXT='WTS52.^n“	Living priapulids possess unpaired ventral nerve cords, whereas gastrotrichs, onychophorans and loriciferans possess ventral nerve cords that are paired throughout their length, and the ventral nerve cords of nematomorphs and nematodes divide at points along their length (Schmidt-Rhaesa Phylogenetic relationships of the nematomorpha 203-216); the situation in kinorhynchs is unresolved (paired according to Kristensen and Higgins, 1991; unpaired according to Neuhaus 1994). The condition in Ottoia is common to extant priapulids (Conway Morris, 1977).”^nSee also (Martín-Durán et al. 2016)^nIn kinorhynchs there are seven to twelve nerve cords; the ventral nerve cord is unpaired in Echinoderes (Neuhaus and Higgins 2002)^n';
+	TEXT CHARACTER=215 TEXT='(–) inapplicable inapplicable in taxa where the ventral nerve cord is not paired!^nTransformation series 2 in Tanaka et al. (2013).  Tardigrada and Euarthropoda have a ganglionated ventral nerve cord (Schulze et al. 2014), in contrast to the ladder-like ventral nerve cord in Onychophora (Mayer et al. 2013a). Priapulida have an unpaired nerve cord associated with a net-like system of neural connectives (Storch 1991; Rothe and Schmidt-Rhaesa 2010). Recent data on the neurological organization of stem-euarthropods indicate that paired ganglia are present in Chengjiangocaris (Yang et al. 2013) and Alalcomenaeus (Tanaka et al. 2013).  Hou et al. (2004, figs 2f, 4f) reported faint paired structures adjacent to the gut of Paucipodia, which were interpreted as potential nerve ganglia.  We nevertheless code Paucipodia as ambiguous: the structures cannot be observed in the figured material, and are described as ‘faintly preserved with a pink colour’ in contrast to the conspicuously dark colouration of unambiguous nervous tissue in Chengjiang-type fossils (see Ma et al. 2012; Tanaka et al. 2013; Yang et al. 2013).^nVentral nerve cord of Kinorhynchs comprises two separate cords that are close together; paired ganglia are present. [[Structure and Evolution of Invertebrate Nervous Systems^nBy Andreas Schmidt-Rhaesa, Steffen Harzsch, Günter Purschke]]^n';
+	TEXT CHARACTER=216 TEXT='(–) inapplicable: ventral nerve cords not paired^nWTS53.^nForm a loop or have free ends in kinorhynchs [[Structure and Evolution of Invertebrate Nervous Systems^nBy Andreas Schmidt-Rhaesa, Steffen Harzsch, Günter Purschke]]^n';
+	TEXT CHARACTER=217 TEXT='Absent in panarthropods (Martin et al. 2017)';
+	TEXT CHARACTER=218 TEXT='(–) inapplicable^nCf. WTS54.^nUnpaired dorsal nerve cords are seen as a synapomorphy of Nematoida (Sørensen et al. 2008)^n';
+	TEXT CHARACTER=219 TEXT='WTS56. The cycloneuralian brain comprises three distinct regions: an anterior aggregation of somata from neurons (perikarya), followed by a central neuropil, followed posteriorly by a further region of perikarya (Rothe and Schmidt-Rhaesa 2010). This has been proposed as a synapomorphy of the cycloneuralians (Lemburg 1999): as the brains of panarthropods are arranged differently (Martin et al. 2017).  However, the perikarya has an equal distribution in nematomorpha (Schmidt-Rhaesa 1997a) ';
+	TEXT CHARACTER=220 TEXT='(–) inapplicable: brain not of cycloneuralian pattern ^nModified from Wills et al. (2012) character statement 57, which is understood to refer to a modification of the cycloneuralian brain in Tubiluchus and Meiopriapulus; the revised character is thus scored inapplicable in taxa without a cycloneuralian brain arrangement.  This avoids the difficulty in deciding which bit of the onychophoran brain, which contains abundant perikarya (Martin et al. 2017), is ‘apical’.^n';
+	TEXT CHARACTER=221 TEXT='WTS58. Lemburg (1999) recognizes the presence of this character as a synapomorphy of (extant) Priapulida';
+	TEXT CHARACTER=222 TEXT='Special types of glial/epidermal cells with characteristic bundles of tonofilaments, interpreted as a scalidophoran synapomorphy (though absent in certain Echinoderes species) (Nebelsick 1993).  Coded, following the references in Nebelsick, as present in Tubiluchus, Meiopriapulus, Pycnophyes and Loricifera, ambiguous in Echinoderes dujardinii, and absent in Nematoda.';
+	TEXT CHARACTER=223 TEXT='WTS60.  Biphasic encompasses the multiple phases of priapulid larvae (e.g. Wennberg et al. 2009), also documented in Sirilorica (Peel et al. 2013)^nThe nematode larva is morphologically similar to the adult, but lacks reproductive functions.^nLarvae of Priapulopsis are poorly known but are understood to be similar to Priapulus (van der Land 1970), and are coded equivalently herein.^n';
+	TEXT CHARACTER=224 TEXT='(~) inapplicable: loricate stage absent^nCf. WTS62^n';
+	TEXT CHARACTER=225 TEXT='(~) inapplicable: direct development, or larva without defined neck. ^nCrenulated in the Higgins larva of loriciferans (Neves et al. 2016)^nNot in Halicryptus (Storch and Higgins 1991; Janssen et al. 2009)^n';
+	TEXT CHARACTER=226 TEXT='(~) inapplicable: direct development^nPliciloricus and Urnaloricus have a collar region in their neck, whereas Nanaloricus and Tenuiloricus do not (Neves and Kristensen 2014).^n';
+	TEXT CHARACTER=227 TEXT='(–) inapplicable^nWTS63. Lemburg (1999) recognised the presence of this character as a synapomorphy of (extant) Priapulida. However, it has since been demonstrated that the larvae of nematomorphs also possess six pharyngeal retractor muscles (Kristensen 2003; Müller et al. 2004). Long pharynx retractor muscles are also present in loriciferans (at least within the Nanaloricidae) (Neves et al. 2013).^n';
+	TEXT CHARACTER=228 TEXT='(~) inapplicable: no larval form (direct development; trans. ser. ###)^nWTS65.^nA proposed synapomorphy of scalidophora, but also present in nematomorphs ^nPresent in Priapulid caudatus, Tubiluchis corallicola; absent in Kinorhyncha, Loricifera ; probably absent in Nectonema larvae yet present in adults (Schmidt-Rhaesa 1997a)^n';
+	TEXT CHARACTER=229 TEXT='(~) inapplicable^nProposed as a synapomorphy between nematomorphs and loriciferans (Kristensen 1983)^nNot reported in Halicryptus, Maccabeus or Priapulus (van der Land 1970; Por and Bromley 1974; Storch and Higgins 1991), but present in Tubiluchus (Higgins and Storch 1989)^n';
+	TEXT CHARACTER=230 TEXT='(~) inapplicable: proboscis and abdomen undivided^nThe larvae of Orstenoloricus (Maas and Waloszek 2009) possess a pair of spines at the anterior of the trunk.  These may correspond to the anteroventral setae of Tenuiloricus (Neves and Kristensen 2014).  Similar spines are present in Nanaloricidae and Pliciloricidae (Neves et al. 2016)^nThe tubuli present in the Halicryptus hatching larva are not paired, and disappear in the Higgins larval stage; paired spines are coded as absent in this taxon (Storch and Higgins 1991; Janssen et al. 2009)  similar structures present in Tubiluchus (Kirsteuer 1976)';
+	TEXT CHARACTER=231 TEXT='(~) inapplicable^nPresent in the Higgins larva of many loriciferans (Neves et al. 2016), Shergoldana (Maas et al. 2007a), ^nCoded as absent in Orstenoloricus (Maas and Waloszek 2009) as most specimens unambiguously lack them; only a single specimen has putative structures that are not unequivocally spines or appendages.^nPosterior protuberances occur at the posterior of the Halicryptus lorica (van der Land 1970); these probably ought to be coded in a separate transformation series but are included here for now.  Similar features (‘tubuli’) are present in Priapulus (Higgins et al. 1993)';
+	TEXT CHARACTER=232 TEXT='(–) inapplicable^nA similarity between the Nectonema and Nanaloricus larvae (Kristensen 1983)^nSac-like guts with single ‘fold’ in larvae of e.g. Tubiluchus (Higgins and Storch 1989)';
+	TEXT CHARACTER=233 TEXT='(~) inapplicable^nA similarity between nematomorpy and loriciferan larvae (Kristensen 1983)large mesenchyme cells^n';
+	TEXT CHARACTER=234 TEXT='WTS66.^nThe presence of a cloaca in both sexes is seen as a synapomorphy of Nematoida (Sørensen et al. 2008)^n';
+	TEXT CHARACTER=235 TEXT='Cf. WTS67.^nThe reduction of protonephridia is seen as a possible nematoid synapomorphy (Sørensen et al. 2008)^n';
+	TEXT CHARACTER=236 TEXT='(~) inapplicable: protonephridia absent (trans. ser. ###)  ^nCf. WTS67.^n';
+	TEXT CHARACTER=237 TEXT='(~) inapplicable^nA possible synapomorphy of Scalidophora (Sørensen et al. 2008)^nPresent in Pycnophyes (Neuhaus 1988)^nCheck Neuhaus 1994, Ultrastructure of alimentary canal and body cavity, ground pattern, and phylogenetic relationships of the Kinorhyncha , Microfauna marina for Zelinkaderes details.^n';
+	TEXT CHARACTER=238 TEXT='Not yet a character.  Homologous to cuticularized tubes of Pycnophyes (and Kinorhyncha) (Neuhaus 1988). In species of Echinoderidae, the protonephridial openings form two fairly conspicuous sieve plates, and due to their distinct appearance in LM as well as SEM, they are often reported in systematic and taxonomic studies. However, in non-echinoderid species there are no sieve plates and the nephridial pores are much more inconspicuous.';
+	TEXT CHARACTER=239 TEXT='(–) inapplicable^nThe absence of such microvilli is a possible synapomorphy of Priapulida + Kinorhyncha (Neuhaus and Higgins 2002)^n';
+	TEXT CHARACTER=240 TEXT='(~) inapplicable^nWTS68.^n';
+	TEXT CHARACTER=241 TEXT='WTS69.^nThe reduction of the flagellum is seen as a possible synapomorphy of Nematoids (Sørensen et al. 2008), though a flagelliform tail is found in Kinonchulus (Riemann 1972). A flagellum has been reported in Gordius, but this is probably a misinterpretation (Schmidt-Rhaesa 1997b) , so Chordodes is coded as lacking a flagellum.^n';
+	TEXT CHARACTER=242 TEXT='Cf. WTS72. ';
+	TEXT CHARACTER=243 TEXT='WTS73.^nSee (Bereiter-Hahn et al. 1984).  Nematodes and Nematomorphs have principally replaced chitin with collagen as the principle component of their cuticle, though vestiges of chitin remain (Nielsen 2012). Coded as present in Palaeoscolex as chambers in the cuticle are believed to correspond to collagen fibres (Kraft and Mergl 1989)^n';
+	TEXT CHARACTER=244 TEXT='(–) inapplicable: chitin not a substantial component of the cuticle^nCf. WTS74.^n';
+	TEXT CHARACTER=245 TEXT='WTS76.';
+	TEXT CHARACTER=246 TEXT='WTS78.';
+	TEXT CHARACTER=247 TEXT='Cf. WTS79.^n^nTo add^nIn the tardigrade Echiniscus viridis, the central cuticle comprises:^n-	An outer portion of alternating dense antd transparent layuers, with a much denser band proximally^n-	Within these, a region made up of hexagons (looking striated in transverse section), with a complex dense outer layer and a less dense inner one^n-	Proximal to that, an electron transparent zone containing dense rods^n-	Within that, and innermost, transversely oriented fibres^n-	The structure of the ventral cuticle is […] virtually identical to that described by Wright and Hope (1968) for the cuticle of the marine nematode, Acanthonchus (duplicatus Wieser, 1959 and quite similar to that described by Inglis (1964) and Watson (1965) for cuticles of certain other nematodes, including Elichromadora sp. Moreover, the striated layer found in the cuticle of E. viridi.s appears to be a nearly universal characteristic of nematode cuticles (cf. I,ee 1966, Wisse and Daems 1968 – (Crowe et al. 1970)^n';
+	TEXT CHARACTER=248 TEXT='WTS84. Not clear how this is to be coded for fossil taxa, so they are coded as ambiguous.';
+	TEXT CHARACTER=249 TEXT='Ma et al. (Ma et al. 2014a) described a dorsal heart in Fuxianhuia; all other fossil taxa are scored as ambiguous.  Budd (2001b) discussed the difficulty of interpreting the absence of a circulatory system in Tardigrada as ancestral or derived, given that a circulatory system is unnecessary in a miniaturized organism; he concluded that the most methodologically sound way to address this issue in a cladistic context is to score the character as inapplicable.';
+	TEXT CHARACTER=250 TEXT='Coelomyarian: myofibrils peripheral to muscle cell, present in larger nematodes; Platymyarian: myofibrils restricted toregion next to hypodermis.^nPresent in some derived nematomorphs; probably absent ancestrally: Schmidt Rhaesa 1997 phylo relationships^nSee for example J Ultrastruct Res. 1971 Mar;34(5):517-43.^nPrimitive muscle cells of nematodes: morphological aspects of platymyarian and shallow coelomyarian muscles in two plant parasitic nematodes, Trichodorus christiei and Longidorus elongatus.^n^nHirumi H, Raski DJ, Jones NO. ';
+	TEXT CHARACTER=251 TEXT='WTS88.';
+
+      [Attribute comments]
+      	TEXT TAXON=1 CHARACTER=2 TEXT='The mouth of Gastrotrich is anterior, in some species terminal, in others is sub-terminal^n-Ask M.S - should the sub-terminal species be coded as ventral?';
+	TEXT TAXON=56 CHARACTER=24 TEXT='30-50 times longer than wide (Yang et al., 2020)';
+	TEXT TAXON=56 CHARACTER=31 TEXT='Following Yang et al., 2020';
+	TEXT TAXON=56 CHARACTER=32 TEXT='Introvert is narrower than the trunk (Yang et al., 2020)';
+	TEXT TAXON=21 CHARACTER=32 TEXT='Anterior trunk not differentiated, the anterior papillae are part of the introvert (see Howard et al., 2020)';
+	TEXT TAXON=21 CHARACTER=102 TEXT='Following Howard et sl., 2020^n';
+	TEXT TAXON=21 CHARACTER=105 TEXT='Following Howard et al., 2020';
+	TEXT TAXON=25 CHARACTER=197 TEXT='Anus not terminal (Riemann 1972)';
+	TEXT TAXON=26 CHARACTER=250 TEXT='NEEDS REVIEWING';
+      ENDBLOCK;
+            BEGIN ASSUMPTIONS;
+      TYPESET * UNTITLED = unord: 1 - 251;
+      ENDBLOCK;
+      

--- a/dev/benchmarks/hamilton_iw_na_array.sh
+++ b/dev/benchmarks/hamilton_iw_na_array.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# NA-IW x4 mission-wall A/B job-array: one task per (dataset x seed) cell, each
+# running BOTH arms (x4 off vs on) so the wall ratio controls for node variance.
+# Consumes the $LIB built by hamilton_iw_na_build.sh (the NA-IW-x4 branch).
+# Submit: sbatch --dependency=afterok:<buildjob> hamilton_iw_na_array.sh
+# Array upper bound = n_datasets * n_seeds - 1 (here 4*5-1=19); %N caps concurrency.
+# Native NA datasets (NOT recoded) + XPIWE (MaximizeParsimony default) = production.
+#SBATCH --job-name=ts-naiw-wall
+#SBATCH -p shared
+#SBATCH -n 1
+#SBATCH --mem=4G
+#SBATCH --time=3:00:00
+#SBATCH --array=0-19%20
+#SBATCH --output=/nobackup/%u/TreeSearch/logs/naiwwall_%A_%a.out
+#SBATCH --error=/nobackup/%u/TreeSearch/logs/naiwwall_%A_%a.err
+
+module load r/4.5.1
+module load gcc/14.2
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+
+DEPLIB=/nobackup/$USER/TreeSearch/lib
+LIB=/nobackup/$USER/TreeSearch/lib-naiw
+REPO=/nobackup/$USER/TreeSearch-t29
+export R_LIBS_USER="$LIB:$DEPLIB"
+export TS_LIB=$LIB
+export PARTIAL_DIR=/nobackup/$USER/TreeSearch/iw_na_wall_partials
+export TS_REPS=8
+export TS_SEEDS="1 2 3 4 5"
+# Native NA, largest trees spanning the NA-fraction range (7-64%).
+export TS_DATASETS="Dikow2009 Giles2015 Zanol2014 Zhu2013"
+
+cd "$REPO" || exit 1
+Rscript dev/benchmarks/bench_iw_na_wall_cell.R "$SLURM_ARRAY_TASK_ID"

--- a/dev/benchmarks/hamilton_iw_na_build.sh
+++ b/dev/benchmarks/hamilton_iw_na_build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Build TreeSearch from the NA-IW-x4 branch (claude/confident-gates-0f627e) ONCE
+# into a dedicated read-only library, so the A/B array never recompiles.
+# Deps (TreeTools/Rcpp/ape/...) are reused from the existing populated $DEPLIB.
+# Submit first; chain the array on afterok of this job.
+#SBATCH --job-name=ts-naiw-build
+#SBATCH -p shared
+#SBATCH -n 4
+#SBATCH --mem=8G
+#SBATCH --time=0:45:00
+#SBATCH --output=/nobackup/%u/TreeSearch/logs/naiw_build_%j.out
+#SBATCH --error=/nobackup/%u/TreeSearch/logs/naiw_build_%j.err
+
+module load r/4.5.1
+module load gcc/14.2
+
+BRANCH=claude/confident-gates-0f627e
+REPO=/nobackup/$USER/TreeSearch-t29
+DEPLIB=/nobackup/$USER/TreeSearch/lib          # has TreeTools/Rcpp/ape/...
+LIB=/nobackup/$USER/TreeSearch/lib-naiw        # fresh target for this build
+mkdir -p "$LIB" /nobackup/$USER/TreeSearch/logs
+export R_LIBS_USER="$LIB:$DEPLIB"
+
+if [ ! -d "$REPO/.git" ]; then
+  git clone https://github.com/ms609/TreeSearch.git "$REPO" || { echo "FATAL: clone failed"; exit 1; }
+fi
+cd "$REPO" || { echo "FATAL: no $REPO"; exit 1; }
+git fetch origin "$BRANCH" && (git checkout "$BRANCH" && git reset --hard "origin/$BRANCH")
+echo "Git HEAD: $(git log --oneline -1)"
+
+rm -f src/*.o src/*.so
+R CMD build --no-build-vignettes --no-manual --no-resave-data .
+R CMD INSTALL --library="$LIB" TreeSearch_*.tar.gz
+rc=$?
+rm -f TreeSearch_*.tar.gz
+echo "INSTALL exit: $rc; version: $(Rscript -e 'cat(as.character(packageVersion("TreeSearch")))' 2>/dev/null)"
+exit $rc

--- a/dev/benchmarks/hamilton_iw_na_element_array.sh
+++ b/dev/benchmarks/hamilton_iw_na_element_array.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# NA-IW x4 ELEMENT-level A/B (dilution-free direct ts_tbr_search climbs).
+# Reuses the lib-naiw built by hamilton_iw_na_build.sh (package src unchanged since
+# b34df50a -- only benchmark scripts were added), so NO rebuild dependency needed;
+# just ensure TreeSearch-t29 is pulled to the commit carrying this runner.
+# Submit: sbatch hamilton_iw_na_element_array.sh
+#SBATCH --job-name=ts-naiw-elem
+#SBATCH -p shared
+#SBATCH -n 1
+#SBATCH --mem=4G
+#SBATCH --time=1:00:00
+#SBATCH --array=0-19%20
+#SBATCH --output=/nobackup/%u/TreeSearch/logs/naiwelem_%A_%a.out
+#SBATCH --error=/nobackup/%u/TreeSearch/logs/naiwelem_%A_%a.err
+
+module load r/4.5.1
+module load gcc/14.2
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+
+DEPLIB=/nobackup/$USER/TreeSearch/lib
+LIB=/nobackup/$USER/TreeSearch/lib-naiw
+REPO=/nobackup/$USER/TreeSearch-t29
+export R_LIBS_USER="$LIB:$DEPLIB"
+export TS_LIB=$LIB
+export PARTIAL_DIR=/nobackup/$USER/TreeSearch/iw_na_elem_partials
+export TS_REPS=5
+export TS_SEEDS="1 2 3 4 5"
+export TS_DATASETS="Dikow2009 Giles2015 Zanol2014 Zhu2013"
+
+cd "$REPO" || exit 1
+Rscript dev/benchmarks/bench_iw_na_element_cell.R "$SLURM_ARRAY_TASK_ID"

--- a/src/ts_fitch.cpp
+++ b/src/ts_fitch.cpp
@@ -137,9 +137,11 @@ int fitch_score(TreeState& tree, const DataSet& ds) {
 // --- Incremental passes for SPR clipping ---
 
 int fitch_incremental_downpass(TreeState& tree, const DataSet& ds,
-                               int start_node) {
+                               int start_node,
+                               std::vector<int>* cs_delta) {
   int length_delta = 0;
   int node = start_node;
+  if (cs_delta) std::fill(cs_delta->begin(), cs_delta->end(), 0);
 
   while (true) {
     int ni = node - tree.n_tip;
@@ -181,6 +183,16 @@ int fitch_incremental_downpass(TreeState& tree, const DataSet& ds,
 
       // Store new local cost
       tree.local_cost[cost_idx] = needs_union;
+
+      // IW dirty-region: accumulate per-pattern char_steps change for this
+      // node (old bits removed, new bits added). Matches extract_char_steps'
+      // raw-local_cost counting (already active-masked).
+      if (cs_delta) {
+        uint64_t oc = old_cost;
+        while (oc) { int c = ctz64(oc); (*cs_delta)[blk.pattern_index[c]]--; oc &= oc - 1; }
+        uint64_t nc = needs_union;
+        while (nc) { int c = ctz64(nc); (*cs_delta)[blk.pattern_index[c]]++; nc &= nc - 1; }
+      }
 
       for (int s = 0; s < blk.n_states; ++s) {
         uint64_t isect = left_state[s] & right_state[s];
@@ -862,6 +874,49 @@ void fitch_na_indirect_cached_flat_x4(
   out[0] = es0; out[1] = es1; out[2] = es2; out[3] = es3;
 }
 
+// 4-wide IW batch (pure-IW TBR rerooting). Mirrors fitch_indirect_cached_flat_x4
+// but accumulates weighted iw_delta via a per-candidate ctz gather instead of a
+// popcount. 4 data-independent any_hit_reduce streams hide vroot_cache L2 latency
+// (the same ILP win T-245 gave EW); each es{k} keeps the scalar add order of
+// indirect_iw_length_cached, so per-candidate results are bit-identical.
+void indirect_iw_cached_flat_x4(
+    const uint64_t* clip_prelim,
+    const uint64_t* vroot0, const uint64_t* vroot1,
+    const uint64_t* vroot2, const uint64_t* vroot3,
+    const DataSet& ds, double base_iw,
+    const std::vector<double>& iw_delta,
+    double cutoff, double out[4]) {
+  double es0 = base_iw, es1 = base_iw, es2 = base_iw, es3 = base_iw;
+
+  for (int b = 0; b < ds.n_blocks; ++b) {
+    const CharBlock& blk = ds.blocks[b];
+    if (blk.active_mask == 0) continue;
+    const int off = ds.block_word_offset[b];
+    const int nst = blk.n_states;
+
+    // 4 independent loads from distinct vroot_cache rows.
+    uint64_t a0 = simd::any_hit_reduce(&clip_prelim[off], &vroot0[off], nst);
+    uint64_t a1 = simd::any_hit_reduce(&clip_prelim[off], &vroot1[off], nst);
+    uint64_t a2 = simd::any_hit_reduce(&clip_prelim[off], &vroot2[off], nst);
+    uint64_t a3 = simd::any_hit_reduce(&clip_prelim[off], &vroot3[off], nst);
+
+    uint64_t ns0 = ~a0 & blk.active_mask;
+    uint64_t ns1 = ~a1 & blk.active_mask;
+    uint64_t ns2 = ~a2 & blk.active_mask;
+    uint64_t ns3 = ~a3 & blk.active_mask;
+
+    while (ns0) { int c = ctz64(ns0); es0 += iw_delta[blk.pattern_index[c]]; ns0 &= ns0 - 1; }
+    while (ns1) { int c = ctz64(ns1); es1 += iw_delta[blk.pattern_index[c]]; ns1 &= ns1 - 1; }
+    while (ns2) { int c = ctz64(ns2); es2 += iw_delta[blk.pattern_index[c]]; ns2 &= ns2 - 1; }
+    while (ns3) { int c = ctz64(ns3); es3 += iw_delta[blk.pattern_index[c]]; ns3 &= ns3 - 1; }
+
+    if ((es0 >= cutoff) & (es1 >= cutoff) & (es2 >= cutoff) & (es3 >= cutoff))
+      break;
+  }
+
+  out[0] = es0; out[1] = es1; out[2] = es2; out[3] = es3;
+}
+
 // --- Per-character step extraction ---
 
 void extract_char_steps(const TreeState& tree, const DataSet& ds,
@@ -1174,7 +1229,14 @@ double fitch_score_ew(TreeState& tree, const DataSet& ds) {
     fitch_score(tree, ds);
   }
 
-  std::vector<int> char_steps(ds.n_patterns, 0);
+  // Reusable scratch: this weighted-path full rescore fires per accept /
+  // convergence check / sector+Wagner rescore (IW/profile only — EW returns
+  // above). A fresh per-call heap alloc here is getenv/L1-class invisible;
+  // a thread_local keeps capacity across calls (one emutls fetch per call is
+  // negligible vs the O(n_node x n_block) extract). extract_char_steps zeroes
+  // it, so resize (not assign) suffices.
+  static thread_local std::vector<int> char_steps;
+  char_steps.resize(ds.n_patterns);
   extract_char_steps(tree, ds, char_steps);
   return compute_weighted_score(ds, char_steps);
 }

--- a/src/ts_fitch.cpp
+++ b/src/ts_fitch.cpp
@@ -917,6 +917,74 @@ void indirect_iw_cached_flat_x4(
   out[0] = es0; out[1] = es1; out[2] = es2; out[3] = es3;
 }
 
+// 4-wide NA-IW batch (inapplicable characters + implied-weights TBR rerooting).
+// Fuses the NA active-mask candidate selection of fitch_na_indirect_cached_flat_x4
+// (standard vs has_inapplicable blocks; from1 reduce; shared clip_has_active;
+// per-candidate below_actives AND) with the per-candidate iw_delta ctz-gather of
+// indirect_iw_cached_flat_x4. Each es{k} keeps the exact scalar add order of
+// indirect_na_iw_length_cached, so per-candidate results are bit-identical; the
+// shared (all-4 >= cutoff) bail only changes early-exit on cutoff-LOSING
+// candidates (their partial sum may then differ from the scalar early-return) --
+// any sub-cutoff candidate the caller actually reads is fully accumulated, so the
+// search outcome (argmin) is byte-identical. 4 data-independent any_hit_reduce
+// streams over distinct vroot_cache rows hide the L2 load latency (the T-245 ILP
+// win, now on the IW-NA path).
+void indirect_na_iw_cached_flat_x4(
+    const uint64_t* clip_prelim,
+    const uint64_t* clip_actives,
+    const uint64_t* vroot0, const uint64_t* vroot1,
+    const uint64_t* vroot2, const uint64_t* vroot3,
+    const uint64_t* ba0, const uint64_t* ba1,
+    const uint64_t* ba2, const uint64_t* ba3,
+    const DataSet& ds, double base_iw,
+    const std::vector<double>& iw_delta,
+    double cutoff, double out[4]) {
+  double es0 = base_iw, es1 = base_iw, es2 = base_iw, es3 = base_iw;
+
+  for (int b = 0; b < ds.n_blocks; ++b) {
+    const CharBlock& blk = ds.blocks[b];
+    if (blk.active_mask == 0) continue;   // mirror scalar indirect_na_iw_length_cached
+    const int off = ds.block_word_offset[b];
+    const int k = blk.n_states;
+
+    uint64_t ns0, ns1, ns2, ns3;
+
+    if (!blk.has_inapplicable) {
+      // Standard block: plain any_hit_reduce (states 0..k-1), invert & mask.
+      uint64_t a0 = simd::any_hit_reduce(&clip_prelim[off], &vroot0[off], k);
+      uint64_t a1 = simd::any_hit_reduce(&clip_prelim[off], &vroot1[off], k);
+      uint64_t a2 = simd::any_hit_reduce(&clip_prelim[off], &vroot2[off], k);
+      uint64_t a3 = simd::any_hit_reduce(&clip_prelim[off], &vroot3[off], k);
+      ns0 = ~a0 & blk.active_mask;
+      ns1 = ~a1 & blk.active_mask;
+      ns2 = ~a2 & blk.active_mask;
+      ns3 = ~a3 & blk.active_mask;
+    } else {
+      // NA block: from1 reduce skips the inapplicable state; clip_has_active is
+      // shared across all 4 candidates; AND with each candidate's below_actives.
+      uint64_t clip_ha = simd::or_reduce(&clip_actives[off], k, 1);
+      uint64_t a0 = simd::any_hit_reduce_from1(&clip_prelim[off], &vroot0[off], k);
+      uint64_t a1 = simd::any_hit_reduce_from1(&clip_prelim[off], &vroot1[off], k);
+      uint64_t a2 = simd::any_hit_reduce_from1(&clip_prelim[off], &vroot2[off], k);
+      uint64_t a3 = simd::any_hit_reduce_from1(&clip_prelim[off], &vroot3[off], k);
+      ns0 = ~a0 & clip_ha & ba0[b] & blk.active_mask;
+      ns1 = ~a1 & clip_ha & ba1[b] & blk.active_mask;
+      ns2 = ~a2 & clip_ha & ba2[b] & blk.active_mask;
+      ns3 = ~a3 & clip_ha & ba3[b] & blk.active_mask;
+    }
+
+    while (ns0) { int c = ctz64(ns0); es0 += iw_delta[blk.pattern_index[c]]; ns0 &= ns0 - 1; }
+    while (ns1) { int c = ctz64(ns1); es1 += iw_delta[blk.pattern_index[c]]; ns1 &= ns1 - 1; }
+    while (ns2) { int c = ctz64(ns2); es2 += iw_delta[blk.pattern_index[c]]; ns2 &= ns2 - 1; }
+    while (ns3) { int c = ctz64(ns3); es3 += iw_delta[blk.pattern_index[c]]; ns3 &= ns3 - 1; }
+
+    if ((es0 >= cutoff) & (es1 >= cutoff) & (es2 >= cutoff) & (es3 >= cutoff))
+      break;
+  }
+
+  out[0] = es0; out[1] = es1; out[2] = es2; out[3] = es3;
+}
+
 // --- Per-character step extraction ---
 
 void extract_char_steps(const TreeState& tree, const DataSet& ds,

--- a/src/ts_fitch.h
+++ b/src/ts_fitch.h
@@ -369,6 +369,25 @@ void indirect_iw_cached_flat_x4(
     const std::vector<double>& iw_delta,
     double cutoff, double out[4]);
 
+// 4-wide NA-IW batch for TBR rerooting (inapplicable characters + implied
+// weights): the NA analog of indirect_iw_cached_flat_x4. Fuses the NA
+// active-mask candidate logic of fitch_na_indirect_cached_flat_x4 with the
+// per-candidate iw_delta ctz-gather of indirect_iw_cached_flat_x4, so each
+// es{k} reproduces indirect_na_iw_length_cached's scalar add order exactly
+// (bit-identical per candidate; the shared all-4-exceed-cutoff bail only
+// affects early-exit, not the final < best comparison). ba0..ba3 are
+// below_actives_cache rows (1 uint64 per block) for each candidate.
+void indirect_na_iw_cached_flat_x4(
+    const uint64_t* clip_prelim,
+    const uint64_t* clip_actives,
+    const uint64_t* vroot0, const uint64_t* vroot1,
+    const uint64_t* vroot2, const uint64_t* vroot3,
+    const uint64_t* ba0, const uint64_t* ba1,
+    const uint64_t* ba2, const uint64_t* ba3,
+    const DataSet& ds, double base_iw,
+    const std::vector<double>& iw_delta,
+    double cutoff, double out[4]);
+
 // Precompute iw_delta[p] = marginal cost of one additional step for pattern p.
 // divided_steps: per-pattern step counts of the divided tree.
 void precompute_iw_delta(const DataSet& ds,

--- a/src/ts_fitch.h
+++ b/src/ts_fitch.h
@@ -42,8 +42,13 @@ int fitch_downpass_node(
 // recomputing prelim and local_cost. Stops when prelim stabilizes.
 // Returns the length delta (new_score - old_score for the main tree).
 // Saves old states to tree.clip_undo_stack for restoration.
+// cs_delta (optional, IW dirty-region): if non-null, accumulates the per-pattern
+// char_steps change over the visited path (new local_cost bits +1, old -1); the
+// function zeroes it first. Lets the IW path derive divided_steps incrementally
+// (full_char_steps + cs_delta - nx) instead of an O(n_node) extract_char_steps.
 int fitch_incremental_downpass(TreeState& tree, const DataSet& ds,
-                               int start_node);
+                               int start_node,
+                               std::vector<int>* cs_delta = nullptr);
 
 // Incremental uppass after clip: recompute final_ for nodes whose
 // ancestor's final states changed. Propagates from root downward,
@@ -349,6 +354,20 @@ double indirect_iw_length_cached(
     double base_iw,
     const std::vector<double>& iw_delta,
     double cutoff);
+
+// 4-wide IW batch for TBR rerooting (pure-IW, no inapplicables): the IW analog
+// of fitch_indirect_cached_flat_x4. 4 independent any_hit_reduce load streams +
+// 4 independent double accumulators (each candidate's weighted sum keeps its own
+// scalar add order => bit-identical to indirect_iw_length_cached per candidate;
+// the batch only shares the batch-start cutoff, which affects early-exit not the
+// final < best comparison => byte-identical search outcome).
+void indirect_iw_cached_flat_x4(
+    const uint64_t* clip_prelim,
+    const uint64_t* vroot0, const uint64_t* vroot1,
+    const uint64_t* vroot2, const uint64_t* vroot3,
+    const DataSet& ds, double base_iw,
+    const std::vector<double>& iw_delta,
+    double cutoff, double out[4]);
 
 // Precompute iw_delta[p] = marginal cost of one additional step for pattern p.
 // divided_steps: per-pattern step counts of the divided tree.

--- a/src/ts_tbr.cpp
+++ b/src/ts_tbr.cpp
@@ -1386,14 +1386,15 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
   const bool iw_timing = std::getenv("TS_IW_TIMING") != nullptr;
   long long t_clip_ns = 0, t_spr_ns = 0, t_rer_ns = 0;
   long long n_clips_t = 0, n_spr_t = 0, n_rer_t = 0;
-  // Pure-IW reroot 4-wide batching (T-245 ILP ported to IW). On by default;
-  // kill-switch TS_IW_NOX4 reverts to the scalar reroot path (for A/B). Read
-  // once (no per-clip getenv, per the getenv-cost lesson).
-  const bool iw_x4 = std::getenv("TS_IW_NOX4") == nullptr;
+  // Pure-IW / NA-IW reroot 4-wide batching (T-245 ILP ported to IW). Default-
+  // OFF on the shared branch: mission-null at morphology scale, kept for the
+  // large-N / recipe-retune reopen. Opt-in via TS_IW_X4. Read once (no per-clip
+  // getenv, per the getenv-cost lesson).
+  const bool iw_x4 = std::getenv("TS_IW_X4") != nullptr;
   // Pure-IW extract_char_steps dirty-region: derive per-clip divided_steps
   // incrementally (full_char_steps + cs_delta - nx) instead of the O(n_node)
-  // walk. On by default; kill-switch TS_IW_NODIRTY reverts to extract+add.
-  const bool iw_dirty = std::getenv("TS_IW_NODIRTY") == nullptr;
+  // walk. Default-OFF; opt-in via TS_IW_DIRTY.
+  const bool iw_dirty = std::getenv("TS_IW_DIRTY") != nullptr;
   // DIAGNOSTIC: per-clip compare dirty divided_steps vs extract+add baseline.
   const bool iw_dirtychk = std::getenv("TS_IW_DIRTYCHK") != nullptr;
 
@@ -2102,7 +2103,7 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
             // indirect_na_iw_length_cached scalar tail), which ANDs in
             // clip_has_active + each candidate's below_actives row; the no-NA
             // path is byte-identical to before this branch handled NA.  When
-            // iw_x4 is disabled (TS_IW_NOX4) this whole branch is skipped and
+            // iw_x4 is disabled (default; opt-in TS_IW_X4) this branch is skipped and
             // both NA and no-NA IW fall through to the scalar `else` below.
             int ei = 0;
             while (ei < n_main) {

--- a/src/ts_tbr.cpp
+++ b/src/ts_tbr.cpp
@@ -20,10 +20,6 @@
 
 namespace ts {
 
-// Exact directional (Regime-C) NA TBR scoring — header-only; nests as ts::nadir.
-// Used by exact_verify_sweep's per-candidate audit (TS_NA_DIR_AUDIT).
-#include "ts_fitch_na_directional.h"
-
 // --- Fast hash for virtual_prelim deduplication (Phase 3A) ---
 // Word-at-a-time multiply-xor hash (faster than byte-by-byte FNV-1a).
 
@@ -871,21 +867,6 @@ static bool exact_verify_sweep(TreeState& tree, const DataSet& ds,
   std::vector<std::pair<int,int>> sub_edges;
   std::vector<char> in_sub;
   std::vector<int> dfs, marked;
-  // M2 audit (dev-only): assert the exact directional NA score == full_rescore on
-  // EVERY candidate, in BOTH EW (concavity non-finite) and IW/profile (the default,
-  // concavity=-1) regimes.  candidate_score/whole_score dispatch on ds.scoring_mode.
-  // Runs on first-time scans (cached-optimal topologies covered by their first scan).
-  const bool na_dir_audit = std::getenv("TS_NA_DIR_AUDIT") != nullptr;
-  const double na_dir_tol = std::isfinite(ds.concavity) ? 1e-6 : 0.5;
-  // M3: the exact directional combine CAN be the per-candidate scorer (audited
-  // byte-identical to full_rescore in EW + IW).  Default OFF (opt-in via
-  // TS_NA_DIRECTIONAL): the first full-table implementation was ~85x SLOWER than
-  // the block-bitwise SIMD full_rescore (per-char scalar + per-candidate Msg
-  // allocation); under optimisation (on-demand single-entry combine) before any
-  // default flip.  Audit mode keeps the legacy path + cross-check, so the
-  // directional scorer is non-audit only.
-  const bool na_dir_scorer = std::getenv("TS_NA_DIRECTIONAL") != nullptr && !na_dir_audit;
-  nadir::ClipFolds na_dir_cf;
 
   // TS_NA_INCR_AUDIT: validate the incremental dirty-rescore of each candidate
   // against full_rescore (the prospective fast path for exact_verify). Decisions
@@ -915,22 +896,6 @@ static bool exact_verify_sweep(TreeState& tree, const DataSet& ds,
 
   tree.build_postorder();
   best_score = full_rescore(tree, ds);   // sync to the current (converged) tree
-
-  if (na_dir_audit) {
-    // Whole-tree cross-check (in whatever regime the search uses, EW or IW).
-    // Per-candidate cross-checks happen in the scan loop below.  The directional
-    // weighting arithmetic (weight*(1+upweight) + inactive-char skip) was
-    // separately validated against full_rescore under an imposed perturbed regime
-    // (upweight_mask set + active_mask sparse); that one-shot scaffolding has been
-    // removed (finding recorded in dev/plans/2026-06-19-na-directional-cpp-port.md
-    // §M2 — exact_verify_sweep itself never runs under perturbed weights, since the
-    // ratchet's TBR passes a non-null collapse cd that disables do_reroot).
-    double s_whole = nadir::whole_score(tree, ds);
-    if (std::fabs(s_whole - best_score) > na_dir_tol) {
-      Rcpp::stop("TS_NA_DIR_AUDIT whole-tree mismatch: directional=%.4f full_rescore=%.4f",
-                 s_whole, best_score);
-    }
-  }
 
   // Topology cache: exact_verify is a pure function of (topology, dataset,
   // weighting regime).  A FALSE result for topology T means every unrooted-TBR
@@ -991,11 +956,6 @@ static bool exact_verify_sweep(TreeState& tree, const DataSet& ds,
     collect_subtree_edges(tree, clip_node, sub_edges);   // fragment rerootings
     const int n_reroot = 1 + static_cast<int>(sub_edges.size());
 
-    // Build directional folds for this clip on the CLEAN tree (folds depend only
-    // on clip_node).  Tree is clean here: clip-loop start, subtree marking does
-    // not change topology, and each candidate restores before the next.
-    if (na_dir_scorer || na_dir_audit) nadir::build_clip_folds(tree, ds, clip_node, na_dir_cf);
-
     bool found = false;
     for (int ri = 0; ri < n_reroot && !found; ++ri) {
       int rp = (ri == 0) ? -1 : sub_edges[ri - 1].first;   // -1 => SPR (no reroot)
@@ -1007,35 +967,6 @@ static bool exact_verify_sweep(TreeState& tree, const DataSet& ds,
         if (above < 0 || above == nx) continue;
         if (ri == 0 && below == ns) continue; // identity (no reroot, original spot)
 
-        // FAST PATH: score the candidate WITHOUT applying it (O(1)/char exact).
-        // Non-improvers (the vast majority) cost only the combine — no
-        // apply_tbr_move / build_postorder / full_rescore / restore.
-        if (na_dir_scorer) {
-          double s = nadir::candidate_score(ds, na_dir_cf, rp, rc, below);
-          if (s >= best_score - eps) continue;   // not an improver: tree untouched
-          // improver: materialize it (apply + exact full_rescore to sync state)
-          if (!apply_tbr_move(tree, clip_node, rp, rc, above, below)) {
-            restore_topology(tree, snap);
-            continue;
-          }
-          tree.build_postorder();
-          double s_act = full_rescore(tree, ds);
-          if (s_act < best_score - eps) {
-            if (cache_hit) {                     // TS_EV_AUDIT: cache lied
-              Rcpp::stop("TS_EV_AUDIT: exact_verify cache returned FALSE (optimum) "
-                         "for a topology with an improving neighbour (%.4f < %.4f) "
-                         "- weighting-regime contamination in the cache key.",
-                         s_act, best_score);
-            }
-            best_score = s_act;
-            found = true;
-            break;
-          }
-          restore_topology(tree, snap);          // directional flagged it but exact
-          continue;                              // disagreed at eps boundary: skip
-        }
-
-        // LEGACY / AUDIT PATH: apply, full_rescore, (optionally) cross-check.
         if (!apply_tbr_move(tree, clip_node, rp, rc, above, below)) {
           restore_topology(tree, snap);
           continue;

--- a/src/ts_tbr.cpp
+++ b/src/ts_tbr.cpp
@@ -2094,10 +2094,16 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
                 }
               }
             }
-          } else if (iw_family && !has_na && iw_x4) {
-            // === IW 4-wide batch (pure-IW/XPIWE; T-245 ILP ported to IW) ===
+          } else if (iw_family && iw_x4) {
+            // === IW/XPIWE 4-wide batch (pure-IW/XPIWE and IW+NA; T-245 ILP) ===
             // Same candidate-selection + bookkeeping as the EW flat-x4 above,
-            // but scores via indirect_iw_cached_flat_x4 (double accumulators).
+            // but scores via the IW double-accumulator kernels.  has_na selects
+            // the NA-aware kernel (indirect_na_iw_cached_flat_x4 full batch /
+            // indirect_na_iw_length_cached scalar tail), which ANDs in
+            // clip_has_active + each candidate's below_actives row; the no-NA
+            // path is byte-identical to before this branch handled NA.  When
+            // iw_x4 is disabled (TS_IW_NOX4) this whole branch is skipped and
+            // both NA and no-NA IW fall through to the scalar `else` below.
             int ei = 0;
             while (ei < n_main) {
               int b_ei[4];
@@ -2116,19 +2122,44 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
               double scores[4] = {best_candidate, best_candidate,
                                   best_candidate, best_candidate};
               if (b_n == 4) {
-                indirect_iw_cached_flat_x4(
-                    virtual_prelim.data(),
-                    &vroot_cache[static_cast<size_t>(b_ei[0]) * tw],
-                    &vroot_cache[static_cast<size_t>(b_ei[1]) * tw],
-                    &vroot_cache[static_cast<size_t>(b_ei[2]) * tw],
-                    &vroot_cache[static_cast<size_t>(b_ei[3]) * tw],
-                    ds, base_iw, iw_delta, best_candidate, scores);
+                if (has_na) {
+                  indirect_na_iw_cached_flat_x4(
+                      virtual_prelim.data(), clip_actives,
+                      &vroot_cache[static_cast<size_t>(b_ei[0]) * tw],
+                      &vroot_cache[static_cast<size_t>(b_ei[1]) * tw],
+                      &vroot_cache[static_cast<size_t>(b_ei[2]) * tw],
+                      &vroot_cache[static_cast<size_t>(b_ei[3]) * tw],
+                      &below_actives_cache[
+                          static_cast<size_t>(b_ei[0]) * ds.n_blocks],
+                      &below_actives_cache[
+                          static_cast<size_t>(b_ei[1]) * ds.n_blocks],
+                      &below_actives_cache[
+                          static_cast<size_t>(b_ei[2]) * ds.n_blocks],
+                      &below_actives_cache[
+                          static_cast<size_t>(b_ei[3]) * ds.n_blocks],
+                      ds, base_iw, iw_delta, best_candidate, scores);
+                } else {
+                  indirect_iw_cached_flat_x4(
+                      virtual_prelim.data(),
+                      &vroot_cache[static_cast<size_t>(b_ei[0]) * tw],
+                      &vroot_cache[static_cast<size_t>(b_ei[1]) * tw],
+                      &vroot_cache[static_cast<size_t>(b_ei[2]) * tw],
+                      &vroot_cache[static_cast<size_t>(b_ei[3]) * tw],
+                      ds, base_iw, iw_delta, best_candidate, scores);
+                }
               } else {
                 for (int k = 0; k < b_n; ++k) {
-                  scores[k] = indirect_iw_length_cached(
-                      virtual_prelim.data(),
-                      &vroot_cache[static_cast<size_t>(b_ei[k]) * tw],
-                      ds, base_iw, iw_delta, best_candidate);
+                  scores[k] = has_na
+                      ? indirect_na_iw_length_cached(
+                            virtual_prelim.data(), clip_actives,
+                            &vroot_cache[static_cast<size_t>(b_ei[k]) * tw],
+                            &below_actives_cache[
+                                static_cast<size_t>(b_ei[k]) * ds.n_blocks],
+                            ds, base_iw, iw_delta, best_candidate)
+                      : indirect_iw_length_cached(
+                            virtual_prelim.data(),
+                            &vroot_cache[static_cast<size_t>(b_ei[k]) * tw],
+                            ds, base_iw, iw_delta, best_candidate);
                 }
               }
 

--- a/src/ts_tbr.cpp
+++ b/src/ts_tbr.cpp
@@ -12,12 +12,17 @@
 #include <climits>
 #include <cmath>
 #include <cstring>
+#include <chrono>
 
 #include <Rcpp.h>
 #include <R.h>
 #include <Rinternals.h>
 
 namespace ts {
+
+// Exact directional (Regime-C) NA TBR scoring — header-only; nests as ts::nadir.
+// Used by exact_verify_sweep's per-candidate audit (TS_NA_DIR_AUDIT).
+#include "ts_fitch_na_directional.h"
 
 // --- Fast hash for virtual_prelim deduplication (Phase 3A) ---
 // Word-at-a-time multiply-xor hash (faster than byte-by-byte FNV-1a).
@@ -866,6 +871,21 @@ static bool exact_verify_sweep(TreeState& tree, const DataSet& ds,
   std::vector<std::pair<int,int>> sub_edges;
   std::vector<char> in_sub;
   std::vector<int> dfs, marked;
+  // M2 audit (dev-only): assert the exact directional NA score == full_rescore on
+  // EVERY candidate, in BOTH EW (concavity non-finite) and IW/profile (the default,
+  // concavity=-1) regimes.  candidate_score/whole_score dispatch on ds.scoring_mode.
+  // Runs on first-time scans (cached-optimal topologies covered by their first scan).
+  const bool na_dir_audit = std::getenv("TS_NA_DIR_AUDIT") != nullptr;
+  const double na_dir_tol = std::isfinite(ds.concavity) ? 1e-6 : 0.5;
+  // M3: the exact directional combine CAN be the per-candidate scorer (audited
+  // byte-identical to full_rescore in EW + IW).  Default OFF (opt-in via
+  // TS_NA_DIRECTIONAL): the first full-table implementation was ~85x SLOWER than
+  // the block-bitwise SIMD full_rescore (per-char scalar + per-candidate Msg
+  // allocation); under optimisation (on-demand single-entry combine) before any
+  // default flip.  Audit mode keeps the legacy path + cross-check, so the
+  // directional scorer is non-audit only.
+  const bool na_dir_scorer = std::getenv("TS_NA_DIRECTIONAL") != nullptr && !na_dir_audit;
+  nadir::ClipFolds na_dir_cf;
 
   // TS_NA_INCR_AUDIT: validate the incremental dirty-rescore of each candidate
   // against full_rescore (the prospective fast path for exact_verify). Decisions
@@ -895,6 +915,22 @@ static bool exact_verify_sweep(TreeState& tree, const DataSet& ds,
 
   tree.build_postorder();
   best_score = full_rescore(tree, ds);   // sync to the current (converged) tree
+
+  if (na_dir_audit) {
+    // Whole-tree cross-check (in whatever regime the search uses, EW or IW).
+    // Per-candidate cross-checks happen in the scan loop below.  The directional
+    // weighting arithmetic (weight*(1+upweight) + inactive-char skip) was
+    // separately validated against full_rescore under an imposed perturbed regime
+    // (upweight_mask set + active_mask sparse); that one-shot scaffolding has been
+    // removed (finding recorded in dev/plans/2026-06-19-na-directional-cpp-port.md
+    // §M2 — exact_verify_sweep itself never runs under perturbed weights, since the
+    // ratchet's TBR passes a non-null collapse cd that disables do_reroot).
+    double s_whole = nadir::whole_score(tree, ds);
+    if (std::fabs(s_whole - best_score) > na_dir_tol) {
+      Rcpp::stop("TS_NA_DIR_AUDIT whole-tree mismatch: directional=%.4f full_rescore=%.4f",
+                 s_whole, best_score);
+    }
+  }
 
   // Topology cache: exact_verify is a pure function of (topology, dataset,
   // weighting regime).  A FALSE result for topology T means every unrooted-TBR
@@ -955,6 +991,11 @@ static bool exact_verify_sweep(TreeState& tree, const DataSet& ds,
     collect_subtree_edges(tree, clip_node, sub_edges);   // fragment rerootings
     const int n_reroot = 1 + static_cast<int>(sub_edges.size());
 
+    // Build directional folds for this clip on the CLEAN tree (folds depend only
+    // on clip_node).  Tree is clean here: clip-loop start, subtree marking does
+    // not change topology, and each candidate restores before the next.
+    if (na_dir_scorer || na_dir_audit) nadir::build_clip_folds(tree, ds, clip_node, na_dir_cf);
+
     bool found = false;
     for (int ri = 0; ri < n_reroot && !found; ++ri) {
       int rp = (ri == 0) ? -1 : sub_edges[ri - 1].first;   // -1 => SPR (no reroot)
@@ -966,6 +1007,35 @@ static bool exact_verify_sweep(TreeState& tree, const DataSet& ds,
         if (above < 0 || above == nx) continue;
         if (ri == 0 && below == ns) continue; // identity (no reroot, original spot)
 
+        // FAST PATH: score the candidate WITHOUT applying it (O(1)/char exact).
+        // Non-improvers (the vast majority) cost only the combine — no
+        // apply_tbr_move / build_postorder / full_rescore / restore.
+        if (na_dir_scorer) {
+          double s = nadir::candidate_score(ds, na_dir_cf, rp, rc, below);
+          if (s >= best_score - eps) continue;   // not an improver: tree untouched
+          // improver: materialize it (apply + exact full_rescore to sync state)
+          if (!apply_tbr_move(tree, clip_node, rp, rc, above, below)) {
+            restore_topology(tree, snap);
+            continue;
+          }
+          tree.build_postorder();
+          double s_act = full_rescore(tree, ds);
+          if (s_act < best_score - eps) {
+            if (cache_hit) {                     // TS_EV_AUDIT: cache lied
+              Rcpp::stop("TS_EV_AUDIT: exact_verify cache returned FALSE (optimum) "
+                         "for a topology with an improving neighbour (%.4f < %.4f) "
+                         "- weighting-regime contamination in the cache key.",
+                         s_act, best_score);
+            }
+            best_score = s_act;
+            found = true;
+            break;
+          }
+          restore_topology(tree, snap);          // directional flagged it but exact
+          continue;                              // disagreed at eps boundary: skip
+        }
+
+        // LEGACY / AUDIT PATH: apply, full_rescore, (optionally) cross-check.
         if (!apply_tbr_move(tree, clip_node, rp, rc, above, below)) {
           restore_topology(tree, snap);
           continue;
@@ -1307,6 +1377,26 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
   // Floating-point tolerance for score equality
   const double eps = use_iw ? 1e-10 : 0.0;
 
+  // DIAGNOSTIC (env TS_IW_TIMING): isolate IW-specific cost under REAL bail
+  // (production cutoffs), EW vs IW on the same data. Read ONCE (no per-clip
+  // getenv). t_clip_ns = the bail-INDEPENDENT per-clip IW precompute
+  // (extract_char_steps + compute_iw base + iw_delta; no EW analog); t_scan_ns
+  // = the bail-DEPENDENT per-candidate scan (EW x4-flat/popcount vs IW
+  // scalar-gather), normalised by n_evaluated. No-op unless the var is set.
+  const bool iw_timing = std::getenv("TS_IW_TIMING") != nullptr;
+  long long t_clip_ns = 0, t_spr_ns = 0, t_rer_ns = 0;
+  long long n_clips_t = 0, n_spr_t = 0, n_rer_t = 0;
+  // Pure-IW reroot 4-wide batching (T-245 ILP ported to IW). On by default;
+  // kill-switch TS_IW_NOX4 reverts to the scalar reroot path (for A/B). Read
+  // once (no per-clip getenv, per the getenv-cost lesson).
+  const bool iw_x4 = std::getenv("TS_IW_NOX4") == nullptr;
+  // Pure-IW extract_char_steps dirty-region: derive per-clip divided_steps
+  // incrementally (full_char_steps + cs_delta - nx) instead of the O(n_node)
+  // walk. On by default; kill-switch TS_IW_NODIRTY reverts to extract+add.
+  const bool iw_dirty = std::getenv("TS_IW_NODIRTY") == nullptr;
+  // DIAGNOSTIC: per-clip compare dirty divided_steps vs extract+add baseline.
+  const bool iw_dirtychk = std::getenv("TS_IW_DIRTYCHK") != nullptr;
+
   // Check if any block has inapplicable characters (for state snapshot)
   bool has_na = false;
   for (int b = 0; b < ds.n_blocks; ++b) {
@@ -1400,6 +1490,21 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
   if (use_iw) {
     divided_steps.resize(ds.n_patterns, 0);
     iw_delta.resize(ds.n_patterns, 0.0);
+  }
+  // IW dirty-region buffers: F = full-tree char_steps (refreshed when the tree
+  // changes, f_dirty), cs_delta = per-clip path delta (filled by the downpass),
+  // nx_cs = clip-parent's per-pattern contribution. Pure-IW only.
+  // Both opts are restricted to implied weights (ScoringMode::IW). `use_iw`
+  // (isfinite concavity) is ALSO true for PROFILE/XPIWE, which share the
+  // weighted indirect scan but NOT the char_steps conventions the dirty-region
+  // assumes (profile diverged in validation); they keep the original path.
+  const bool iw_mode = (ds.scoring_mode == ScoringMode::IW);
+  const bool iw_dirty_active = iw_mode && !has_na && iw_dirty;
+  std::vector<int> full_char_steps, cs_delta, nx_cs;
+  if (iw_dirty_active) {
+    full_char_steps.resize(ds.n_patterns, 0);
+    cs_delta.resize(ds.n_patterns, 0);
+    nx_cs.resize(ds.n_patterns, 0);
   }
 
   // Subtree sizes for smaller-subtree filtering
@@ -1516,6 +1621,13 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
     save_topology(tree, snap);
     state_snap.save(tree);
 
+    // IW dirty-region: refresh the full-tree char_steps cache F at the pass
+    // start. clip-undo restores every clip in this pass to exactly this tree
+    // (verified by TS_REVERT_CHECK), so F is valid for all clips in the pass;
+    // per-clip derivation is F + cs_delta - nx_cs.  Refreshing here (not on
+    // accept) aligns F with the snapshot the clips actually restore to.
+    if (iw_dirty_active) extract_char_steps(tree, ds, full_char_steps);
+
     // Reset per-pass diagnostic counters
     pass_clips_tried = 0;
     pass_candidates_evaluated = 0;
@@ -1592,41 +1704,80 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
         fitch_na_incremental_uppass(tree, ds, nz);
         divided_length = static_cast<double>(fitch_na_pass3_score(tree, ds));
       } else {
-        int delta = fitch_incremental_downpass(tree, ds, nz);
+        int delta = fitch_incremental_downpass(tree, ds, nz,
+            iw_dirty_active ? &cs_delta : nullptr);
         fitch_incremental_uppass(tree, ds, nz);
 
+        if (iw_dirty_active) std::fill(nx_cs.begin(), nx_cs.end(), 0);
         int nx_cost = 0;
         for (int b = 0; b < ds.n_blocks; ++b) {
           uint64_t lc = tree.local_cost[static_cast<size_t>(nx) * tree.n_blocks + b];
           int nu = popcount64(lc);
           if (ds.blocks[b].upweight_mask) nu += popcount64(lc & ds.blocks[b].upweight_mask);
           nx_cost += ds.blocks[b].weight * nu;
+          if (iw_dirty_active) {
+            // nx is spliced out by the divided tree; capture its per-pattern
+            // contribution (raw local_cost bits, matching extract_char_steps).
+            const int* pidx = ds.blocks[b].pattern_index;
+            uint64_t m = lc;
+            while (m) { int c = ctz64(m); nx_cs[pidx[c]]++; m &= m - 1; }
+          }
         }
         divided_length = best_score + delta - nx_cost;
       }
 
       // For weighted scoring (IW or profile): precompute base score and deltas
       double base_iw = 0.0;
+      std::chrono::steady_clock::time_point _t_clip;
+      if (iw_timing) _t_clip = std::chrono::steady_clock::now();
       if (use_iw) {
-        std::fill(divided_steps.begin(), divided_steps.end(), 0);
-        extract_char_steps(tree, ds, divided_steps);
-        // extract_char_steps walks only the clipped (divided) postorder, so the
-        // clipped subtree's internal steps are missing; add them back so base_iw
-        // matches the EW divided_length convention (divided_tree + clip_internal)
-        // and the indirect candidate base_iw + reconnect_delta is exact.
-        // Pure-IW only.  The clipped subtree's internal Fitch length is
-        // root- AND attachment-invariant, so adding it back makes the IW
-        // indirect candidate (base_iw + reconnect_delta) EXACT.  NOT applied
-        // under inapplicables: the NA Pass-3 internal step count is
-        // attachment-DEPENDENT (down2 reads whole-tree uppass context), so it
-        // cannot make the NA scan exact — it would be an unvalidated change to
-        // production rooted-NA scoring.  NA instead reaches true unrooted
-        // optima via the physical-reroot path (see the has_na dispatch below).
-        if (!has_na) {
-          add_clip_internal_steps(tree, ds, clip_node, divided_steps);
+        if (iw_dirty_active) {
+          // Dirty-region: divided_steps = (divided tree + clip internal) char
+          // counts = F + cs_delta - nx_cs.  This is the per-pattern analog of
+          // the EW divided_length = best_score + delta - nx_cost computed above
+          // (which likewise keeps the attachment-invariant clip-internal steps),
+          // so it equals extract_char_steps + add_clip_internal_steps but in
+          // O(path) not O(n_node).  Pure-IW only (NA Pass-3 is attachment-dep).
+          for (int p = 0; p < ds.n_patterns; ++p)
+            divided_steps[p] = full_char_steps[p] + cs_delta[p] - nx_cs[p];
+          if (iw_dirtychk) {
+            // Oracle: per-clip compare against the extract+add baseline.
+            std::vector<int> ref(ds.n_patterns, 0);
+            extract_char_steps(tree, ds, ref);
+            add_clip_internal_steps(tree, ds, clip_node, ref);
+            for (int p = 0; p < ds.n_patterns; ++p)
+              if (ref[p] != divided_steps[p]) {
+                REprintf("DIRTYCHK clip=%d p=%d dirty=%d ref=%d\n",
+                         clip_node, p, divided_steps[p], ref[p]);
+                break;
+              }
+          }
+        } else {
+          std::fill(divided_steps.begin(), divided_steps.end(), 0);
+          extract_char_steps(tree, ds, divided_steps);
+          // extract_char_steps walks only the clipped (divided) postorder, so the
+          // clipped subtree's internal steps are missing; add them back so base_iw
+          // matches the EW divided_length convention (divided_tree + clip_internal)
+          // and the indirect candidate base_iw + reconnect_delta is exact.
+          // Pure-IW only.  The clipped subtree's internal Fitch length is
+          // root- AND attachment-invariant, so adding it back makes the IW
+          // indirect candidate (base_iw + reconnect_delta) EXACT.  NOT applied
+          // under inapplicables: the NA Pass-3 internal step count is
+          // attachment-DEPENDENT (down2 reads whole-tree uppass context), so it
+          // cannot make the NA scan exact — it would be an unvalidated change to
+          // production rooted-NA scoring.  NA instead reaches true unrooted
+          // optima via the physical-reroot path (see the has_na dispatch below).
+          if (!has_na) {
+            add_clip_internal_steps(tree, ds, clip_node, divided_steps);
+          }
         }
         base_iw = compute_weighted_score(ds, divided_steps);
         precompute_weighted_delta(ds, divided_steps, iw_delta);
+      }
+      if (iw_timing) {
+        t_clip_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - _t_clip).count();
+        ++n_clips_t;
       }
 
       // Exact directional insertion edge sets for the pure-EW path; computed
@@ -1676,6 +1827,9 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
       // old ternary's first-candidate branch.
       int cutoff = INT_MAX;
 
+      std::chrono::steady_clock::time_point _t_scan;
+      long long _e_spr = n_evaluated;
+      if (iw_timing) _t_scan = std::chrono::steady_clock::now();
       for (auto& [above, below] : main_edges) {
         if (above == nz && below == ns) continue;
         if (sector_mask && !(*sector_mask)[below]) continue;
@@ -1741,6 +1895,11 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
           best_reroot_child = -1;
           cutoff = static_cast<int>(best_candidate - divided_length + 1);
         }
+      }
+      if (iw_timing) {
+        t_spr_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - _t_scan).count();
+        n_spr_t += n_evaluated - _e_spr;
       }
 
       // TBR candidates (rerooting) — with vroot cache (optimization #4)
@@ -1813,6 +1972,9 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
           if (!skip) kept_ei.push_back(ei);
         }
 
+        std::chrono::steady_clock::time_point _t_scan2;
+        long long _e_rer = n_evaluated;
+        if (iw_timing) _t_scan2 = std::chrono::steady_clock::now();
         for (auto& [sp, sc] : sub_edges) {
           if (sp == clip_node) continue;
 
@@ -1915,6 +2077,56 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
                 }
               }
             }
+          } else if (iw_mode && !has_na && iw_x4) {
+            // === IW 4-wide batch (pure-IW; T-245 ILP ported to IW) ===
+            // Same candidate-selection + bookkeeping as the EW flat-x4 above,
+            // but scores via indirect_iw_cached_flat_x4 (double accumulators).
+            int ei = 0;
+            while (ei < n_main) {
+              int b_ei[4];
+              int b_n = 0;
+              while (ei < n_main && b_n < 4) {
+                auto& [ab, bl] = main_edges[ei];
+                bool skip = ((ab == nz && bl == ns) && !do_reroot)
+                    || (sector_mask && !(*sector_mask)[bl])
+                    || (constrained && regraft_violates_constraint(bl, *cd))
+                    || (!collapsed.empty() && collapsed[bl]);
+                if (!skip) b_ei[b_n++] = ei;
+                ++ei;
+              }
+              if (b_n == 0) break;
+
+              double scores[4] = {best_candidate, best_candidate,
+                                  best_candidate, best_candidate};
+              if (b_n == 4) {
+                indirect_iw_cached_flat_x4(
+                    virtual_prelim.data(),
+                    &vroot_cache[static_cast<size_t>(b_ei[0]) * tw],
+                    &vroot_cache[static_cast<size_t>(b_ei[1]) * tw],
+                    &vroot_cache[static_cast<size_t>(b_ei[2]) * tw],
+                    &vroot_cache[static_cast<size_t>(b_ei[3]) * tw],
+                    ds, base_iw, iw_delta, best_candidate, scores);
+              } else {
+                for (int k = 0; k < b_n; ++k) {
+                  scores[k] = indirect_iw_length_cached(
+                      virtual_prelim.data(),
+                      &vroot_cache[static_cast<size_t>(b_ei[k]) * tw],
+                      ds, base_iw, iw_delta, best_candidate);
+                }
+              }
+
+              n_evaluated += b_n;
+              for (int k = 0; k < b_n; ++k) {
+                double candidate = scores[k];
+                if (candidate < best_candidate) {
+                  best_candidate = candidate;
+                  best_above = main_edges[b_ei[k]].first;
+                  best_below = main_edges[b_ei[k]].second;
+                  best_reroot_parent = sp;
+                  best_reroot_child = sc;
+                }
+              }
+            }
           } else {
             // === Scalar path (IW, or ratchet with upweight_mask) ===
             const int n_kept = static_cast<int>(kept_ei.size());
@@ -1978,6 +2190,11 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
               }
             }
           }
+        }
+        if (iw_timing) {
+          t_rer_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+              std::chrono::steady_clock::now() - _t_scan2).count();
+          n_rer_t += n_evaluated - _e_rer;
         }
       }
 
@@ -2314,6 +2531,15 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
     Rprintf("[B2_CEILING] aggressive-skippable SPR-regraft candidates: "
             "%lld / %lld evaluated = %.3f%% (work-weighted ceiling)\n",
             n_b2_aggr, n_b2_eval, 100.0 * n_b2_aggr / n_b2_eval);
+  }
+  if (iw_timing) {
+    REprintf("IWT regime=%s clips=%.0f clip_us/clip=%.3f | "
+             "SPR n=%.0f %.2fns | REROOT n=%.0f %.2fns | total %.1fms\n",
+             use_iw ? "IW" : "EW", (double)n_clips_t,
+             n_clips_t ? t_clip_ns / 1000.0 / (double)n_clips_t : 0.0,
+             (double)n_spr_t, n_spr_t ? (double)t_spr_ns / (double)n_spr_t : 0.0,
+             (double)n_rer_t, n_rer_t ? (double)t_rer_ns / (double)n_rer_t : 0.0,
+             (t_clip_ns + t_spr_ns + t_rer_ns) / 1e6);
   }
 
   return TBRResult{best_score, n_accepted, n_evaluated, n_zero_skipped,

--- a/src/ts_tbr.cpp
+++ b/src/ts_tbr.cpp
@@ -1494,12 +1494,20 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
   // IW dirty-region buffers: F = full-tree char_steps (refreshed when the tree
   // changes, f_dirty), cs_delta = per-clip path delta (filled by the downpass),
   // nx_cs = clip-parent's per-pattern contribution. Pure-IW only.
-  // Both opts are restricted to implied weights (ScoringMode::IW). `use_iw`
-  // (isfinite concavity) is ALSO true for PROFILE/XPIWE, which share the
-  // weighted indirect scan but NOT the char_steps conventions the dirty-region
-  // assumes (profile diverged in validation); they keep the original path.
-  const bool iw_mode = (ds.scoring_mode == ScoringMode::IW);
-  const bool iw_dirty_active = iw_mode && !has_na && iw_dirty;
+  // The char_steps dirty-region + x4 reroot opts apply to BOTH implied-weights
+  // modes: plain IW and extended XPIWE. Both score via compute_iw /
+  // precompute_iw_delta from the SAME per-pattern char_steps (extract_char_steps
+  // is weighting-agnostic; min_steps identical), differing ONLY in the per-pattern
+  // eff_k[p]/phi[p] arrays — which those downstream functions already consume. So
+  // the dirty-region derivation (divided_steps = F + cs_delta - nx) and the x4
+  // gather are byte-identical across IW and XPIWE. PROFILE is excluded: it scores
+  // via compute_profile (info_amounts table + precomputed_steps offset), a
+  // genuinely different char_steps convention. NOTE: production MaximizeParsimony
+  // defaults to XPIWE (xpiwe=TRUE + obs_count; ts_data.cpp), so gating on plain
+  // IW alone left these opts DEAD on the production path for every dataset.
+  const bool iw_family = (ds.scoring_mode == ScoringMode::IW ||
+                          ds.scoring_mode == ScoringMode::XPIWE);
+  const bool iw_dirty_active = iw_family && !has_na && iw_dirty;
   std::vector<int> full_char_steps, cs_delta, nx_cs;
   if (iw_dirty_active) {
     full_char_steps.resize(ds.n_patterns, 0);
@@ -1715,9 +1723,18 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
           int nu = popcount64(lc);
           if (ds.blocks[b].upweight_mask) nu += popcount64(lc & ds.blocks[b].upweight_mask);
           nx_cost += ds.blocks[b].weight * nu;
-          if (iw_dirty_active) {
-            // nx is spliced out by the divided tree; capture its per-pattern
-            // contribution (raw local_cost bits, matching extract_char_steps).
+          // nx is spliced out by the divided tree; capture its per-pattern
+          // contribution (raw local_cost bits). MUST mirror extract_char_steps,
+          // which skips fully-inactive blocks (active_mask == 0): under a ratchet
+          // perturbation that zeroes a block, F (the pass-top extract_char_steps
+          // cache) omits that block's patterns, so subtracting nx_cs for them
+          // drove divided_steps negative (DIRTYCHK: dirty=-1 ref=0 on
+          // Dikow2009/Vinther2008 at ratchetCycles>=3). The candidate scan masks
+          // needs_step by active_mask so the score was unaffected, but the
+          // intermediate per-pattern step counts must stay consistent with F.
+          // EW nx_cost above is intentionally left counting all blocks (its own
+          // best_score/delta length convention is internally consistent).
+          if (iw_dirty_active && ds.blocks[b].active_mask != 0) {
             const int* pidx = ds.blocks[b].pattern_index;
             uint64_t m = lc;
             while (m) { int c = ctz64(m); nx_cs[pidx[c]]++; m &= m - 1; }
@@ -2077,8 +2094,8 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
                 }
               }
             }
-          } else if (iw_mode && !has_na && iw_x4) {
-            // === IW 4-wide batch (pure-IW; T-245 ILP ported to IW) ===
+          } else if (iw_family && !has_na && iw_x4) {
+            // === IW 4-wide batch (pure-IW/XPIWE; T-245 ILP ported to IW) ===
             // Same candidate-selection + bookkeeping as the EW flat-x4 above,
             // but scores via indirect_iw_cached_flat_x4 (double accumulators).
             int ei = 0;

--- a/tests/testthat/test-ts-tbr-dirty-rescore.R
+++ b/tests/testthat/test-ts-tbr-dirty-rescore.R
@@ -119,3 +119,39 @@ test_that("TBR dirty-set rescore matches full rescore (NA-IW dataset, many accep
     validate_result(result, n_tip)
   }
 })
+
+test_that("XPIWE x4 + dirty-region opts are byte-identical to opts-off (port guard)", {
+  # Regression guard for the IW->XPIWE opt port (src/ts_tbr.cpp `iw_family`
+  # gate): the x4 reroot batch + extract_char_steps dirty-region must produce
+  # byte-identical scores to the opts-off scalar path on the PRODUCTION XPIWE
+  # path (MaximizeParsimony defaults to extended IW => ScoringMode::XPIWE).
+  # Before the port these opts were gated to plain ScoringMode::IW and so never
+  # ran under MaximizeParsimony; this asserts the widening did not perturb
+  # XPIWE scores. Requires:
+  #   - pure-XPIWE: recode "-"->"?" so has_na = FALSE (the opts are !has_na-gated)
+  #   - ratchetCycles >= 3: a perturbation can then fully deactivate a block,
+  #     the regime that surfaced the nx_cs/active_mask consistency bug (the
+  #     dirty-region's per-clip internal invariant is itself guarded by the C++
+  #     TS_IW_DIRTYCHK oracle; this test guards the opts' externally-visible
+  #     byte-identity).
+  skip_if_not_installed("TreeSearch")
+  data("inapplicable.phyData", package = "TreeSearch")
+  m <- PhyDatToMatrix(inapplicable.phyData[["Vinther2008"]], ambigNA = FALSE)
+  m[m == "-"] <- "?"                      # pure-XPIWE: has_na = FALSE
+  d <- MatrixToPhyDat(m)
+  ctrl <- SearchControl(ratchetCycles = 4L, xssRounds = 0L, rssRounds = 0L,
+                        cssRounds = 0L, driftCycles = 0L)
+  run <- function(opts_on) {
+    if (opts_on) { Sys.unsetenv("TS_IW_NOX4");   Sys.unsetenv("TS_IW_NODIRTY") }
+    else         { Sys.setenv(TS_IW_NOX4 = "1"); Sys.setenv(TS_IW_NODIRTY = "1") }
+    set.seed(909)
+    r <- suppressWarnings(MaximizeParsimony(
+      d, concavity = 10, maxReplicates = 1L, nThreads = 1L,
+      verbosity = 0L, control = ctrl))
+    min(attr(r, "score"))
+  }
+  on.exit({ Sys.unsetenv("TS_IW_NOX4"); Sys.unsetenv("TS_IW_NODIRTY") }, add = TRUE)
+  score_on  <- run(TRUE)
+  score_off <- run(FALSE)
+  expect_equal(score_on, score_off, tolerance = 0)
+})

--- a/tests/testthat/test-ts-tbr-dirty-rescore.R
+++ b/tests/testthat/test-ts-tbr-dirty-rescore.R
@@ -155,3 +155,31 @@ test_that("XPIWE x4 + dirty-region opts are byte-identical to opts-off (port gua
   score_off <- run(FALSE)
   expect_equal(score_on, score_off, tolerance = 0)
 })
+
+test_that("NA-IW x4 reroot batch is byte-identical to scalar (NA port guard)", {
+  # Regression guard for indirect_na_iw_cached_flat_x4 (src/ts_fitch.cpp) wired
+  # into the iw_family scan branch (src/ts_tbr.cpp): the 4-wide NA-IW reroot
+  # batch must produce byte-identical scores to the one-at-a-time scalar
+  # indirect_na_iw_length_cached on the IW+NA / XPIWE+NA path.  This is the
+  # complement of the port guard above: that one RECODES "-"->"?" (has_na =
+  # FALSE, exercising the no-NA IW x4); this one KEEPS the inapplicable
+  # characters (has_na = TRUE) so the NA-aware batch kernel actually fires.
+  # TS_IW_NOX4 toggles the batch off (falls through to the scalar `else`).
+  skip_if_not_installed("TreeSearch")
+  data("inapplicable.phyData", package = "TreeSearch")
+  d <- inapplicable.phyData[["Vinther2008"]]   # keep "-"; has_na = TRUE
+  ctrl <- SearchControl(ratchetCycles = 4L, xssRounds = 0L, rssRounds = 0L,
+                        cssRounds = 0L, driftCycles = 0L)
+  run <- function(x4_on) {
+    if (x4_on) Sys.unsetenv("TS_IW_NOX4") else Sys.setenv(TS_IW_NOX4 = "1")
+    set.seed(717)
+    r <- suppressWarnings(MaximizeParsimony(
+      d, concavity = 10, maxReplicates = 1L, nThreads = 1L,
+      verbosity = 0L, control = ctrl))
+    min(attr(r, "score"))
+  }
+  on.exit(Sys.unsetenv("TS_IW_NOX4"), add = TRUE)
+  score_x4  <- run(TRUE)
+  score_scalar <- run(FALSE)
+  expect_equal(score_x4, score_scalar, tolerance = 0)
+})

--- a/tests/testthat/test-ts-tbr-dirty-rescore.R
+++ b/tests/testthat/test-ts-tbr-dirty-rescore.R
@@ -141,16 +141,18 @@ test_that("XPIWE x4 + dirty-region opts are byte-identical to opts-off (port gua
   d <- MatrixToPhyDat(m)
   ctrl <- SearchControl(ratchetCycles = 4L, xssRounds = 0L, rssRounds = 0L,
                         cssRounds = 0L, driftCycles = 0L)
+  # Opts are default-OFF on the shared branch: the "on" arm explicitly enables
+  # them (TS_IW_X4 / TS_IW_DIRTY) so the kernel fires; "off" is the scalar base.
   run <- function(opts_on) {
-    if (opts_on) { Sys.unsetenv("TS_IW_NOX4");   Sys.unsetenv("TS_IW_NODIRTY") }
-    else         { Sys.setenv(TS_IW_NOX4 = "1"); Sys.setenv(TS_IW_NODIRTY = "1") }
+    if (opts_on) { Sys.setenv(TS_IW_X4 = "1"); Sys.setenv(TS_IW_DIRTY = "1") }
+    else         { Sys.unsetenv("TS_IW_X4");   Sys.unsetenv("TS_IW_DIRTY") }
     set.seed(909)
     r <- suppressWarnings(MaximizeParsimony(
       d, concavity = 10, maxReplicates = 1L, nThreads = 1L,
       verbosity = 0L, control = ctrl))
     min(attr(r, "score"))
   }
-  on.exit({ Sys.unsetenv("TS_IW_NOX4"); Sys.unsetenv("TS_IW_NODIRTY") }, add = TRUE)
+  on.exit({ Sys.unsetenv("TS_IW_X4"); Sys.unsetenv("TS_IW_DIRTY") }, add = TRUE)
   score_on  <- run(TRUE)
   score_off <- run(FALSE)
   expect_equal(score_on, score_off, tolerance = 0)
@@ -164,21 +166,21 @@ test_that("NA-IW x4 reroot batch is byte-identical to scalar (NA port guard)", {
   # complement of the port guard above: that one RECODES "-"->"?" (has_na =
   # FALSE, exercising the no-NA IW x4); this one KEEPS the inapplicable
   # characters (has_na = TRUE) so the NA-aware batch kernel actually fires.
-  # TS_IW_NOX4 toggles the batch off (falls through to the scalar `else`).
+  # Default-OFF: TS_IW_X4 toggles the batch on; off falls through to scalar.
   skip_if_not_installed("TreeSearch")
   data("inapplicable.phyData", package = "TreeSearch")
   d <- inapplicable.phyData[["Vinther2008"]]   # keep "-"; has_na = TRUE
   ctrl <- SearchControl(ratchetCycles = 4L, xssRounds = 0L, rssRounds = 0L,
                         cssRounds = 0L, driftCycles = 0L)
   run <- function(x4_on) {
-    if (x4_on) Sys.unsetenv("TS_IW_NOX4") else Sys.setenv(TS_IW_NOX4 = "1")
+    if (x4_on) Sys.setenv(TS_IW_X4 = "1") else Sys.unsetenv("TS_IW_X4")
     set.seed(717)
     r <- suppressWarnings(MaximizeParsimony(
       d, concavity = 10, maxReplicates = 1L, nThreads = 1L,
       verbosity = 0L, control = ctrl))
     min(attr(r, "score"))
   }
-  on.exit(Sys.unsetenv("TS_IW_NOX4"), add = TRUE)
+  on.exit(Sys.unsetenv("TS_IW_X4"), add = TRUE)
   score_x4  <- run(TRUE)
   score_scalar <- run(FALSE)
   expect_equal(score_x4, score_scalar, tolerance = 0)


### PR DESCRIPTION
Preserves the IW/XPIWE/NA-aware **x4 reroot batch** and **extract_char_steps dirty-region** TBR opts on `cpp-search` so they survive the disposable worktree they were built on. Mission-null at morphology scale, but the kernel-level win is real (NA-IW x4 cuts the reroot scan 10–14%; no-NA x4+dirty 1.1–1.2× on a full direct climb) — kept **default-OFF, opt-in** for the large-N / recipe-retune reopen.

## What's here
- **`indirect_iw_cached_flat_x4`** — pure-IW 4-wide reroot batch (T-245 ILP ported to IW).
- **`indirect_na_iw_cached_flat_x4`** — the first x4 kernel that crosses the `!has_na` gate onto the native inapplicable-bearing corpus (serves plain IW-NA and the production XPIWE-NA path).
- **extract_char_steps dirty-region** — per-clip `divided_steps = F + cs_delta − nx` instead of the O(n_node) walk.
- **XPIWE gate widening** (`iw_family = IW || XPIWE`) so the opts reach the production scoring mode, **plus a genuine `nx_cs` active-mask underflow fix** (a real broken invariant reachable today via `MaximizeParsimony(extended_iw = FALSE)` rc≥3, independent of these opts).

## Default-OFF / opt-in
Flipped from the worktree's default-on kill-switches to opt-in env vars **`TS_IW_X4`** and **`TS_IW_DIRTY`** (matches the recorded "do not default-on merge" disposition; byte-identical either way, so nothing is imposed on the shared branch by default).

## Correctness (hard gate)
Rebuilt on `cpp-search` (post-#254) and ran both suites:
- `test-ts-tbr-dirty-rescore.R` — x4/dirty byte-identity guards (pure-IW, XPIWE, **and NA-IW**), updated to the opt-in env vars; the "on" arm explicitly enables the kernel so firing is preserved by construction.
- `test-ts-na-incremental.R` — #254's byte-identity tests, incl. the per-candidate audit (`5658/5658 candidates byte-matched full_rescore`), confirming the x4/dirty interleave did not perturb the incremental rescore.

## Deliberately excluded
- The **dead gather microbench** (`ts_iw_gather_bench`) — settled a dead heat; not added to the shared branch.
- The **directional-audit infra** (`ts_fitch_na_directional.h`, `na_dir_audit`/`na_dir_scorer`) — the worktree's `69febb48` bundled its *usage* into `ts_tbr.cpp`; stripped so `exact_verify_sweep` matches `cpp-search`'s #254 version (the directional path is dead, 24–89× slower).

## Supporting infra (dev/)
NA-IW x4 element + mission A/B harnesses (on `TS_IW_X4`) and the two large real NA matrices (`Sun2018`, `lobo`) the large-N reopen will need.

## Deferred / caveats
- Diagnostic env reads (`TS_IW_TIMING`/`DIRTYCHK`/`SCANCHK`) remain once-per-`tbr_search`-call (sub-1%); getenv consolidation deferred.
- Constrained/MPT not separately exercised (opts are scoring-only; `do_reroot` is off under constraints anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)