### PR TITLE
ci: fix gcc-ASAN workflow — adopt r-hub container on x86

### DIFF
--- a/.github/workflows/ASan.yml
+++ b/.github/workflows/ASan.yml
@@ -1,4 +1,5 @@
 # Address Sanitizer: Replicate CRAN's gcc-ASAN 'Additional Test'
+# Uses the r-hub gcc-asan container (R-devel built with ASAN/UBSAN).
 on:
   workflow_dispatch:
   push:
@@ -26,7 +27,9 @@ name: gcc-ASAN
 
 jobs:
   mem-check:
-    runs-on: ubuntu-24.04 # Update RSPM when increasing
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/r-hub/containers/gcc-asan:latest
 
     name: AddressSanitizer ${{ matrix.config.test }}
 
@@ -39,49 +42,14 @@ jobs:
           - {test: 'vignettes'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      _R_CHECK_FORCE_SUGGESTS_: false
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/noble/latest
-      USING_ASAN: true
-      STRINGI_DISABLE_PKG_CONFIG: true
-      BIOCONDUCTOR_USE_CONTAINER_REPOSITORY: FALSE # For stringi
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      ASAN_OPTIONS: verify_asan_link_order=0
 
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Work around ASAN shadow-memory clash (google/sanitizers#856)
-        run: sudo sysctl vm.mmap_rnd_bits=28
-
-      - name: Initialize ASan configuration
-        run: |
-          export LD_PRELOAD=$(gcc -print-file-name=libasan.so)
-
-          echo "PKG_CFLAGS = -g -O0 -fsanitize=address -fno-omit-frame-pointer" > src/Makevars
-          echo "PKG_CXXFLAGS = -g -O0 -fsanitize=address -fno-omit-frame-pointer" >> src/Makevars
-
-          mkdir ~/.R
-          echo "LDFLAGS = -g -O0 -fsanitize=address -fno-omit-frame-pointer" >> ~/.R/Makevars
-
-      - uses: r-lib/actions/setup-r@v2
+      - uses: ms609/actions/asan@main
         with:
-          r-version: release # CRAN uses devel, but takes ages to load deps.
-
-      - name: Set up R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          dependencies: "'soft'"
-          needs: |
-            memcheck
-
-      - name: Install package
-        run: |
-          cd ..
-          R CMD build --no-build-vignettes --no-manual --no-resave-data TreeSearch
-          R CMD INSTALL TreeSearch*.tar.gz
-          cd TreeSearch
-
-      - name: ASAN - memcheck ${{ matrix.config.test }}
-        run: |
-          setarch "$(uname -m)" -R Rscript memcheck/${{ matrix.config.test }}.R
+          test: ${{ matrix.config.test }}
+          # Rogue hard-imports Rfast, a ~30-min source build under ASAN that
+          # adds no coverage to TreeSearch's own compiled code.  All Rogue use
+          # (two vignettes + the Shiny consensus module) is requireNamespace-
+          # guarded and skips cleanly when absent.
+          exclude-packages: Rogue

--- a/.github/workflows/ASan.yml
+++ b/.github/workflows/ASan.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Work around ASAN shadow-memory clash (google/sanitizers#856)
-        run: sudo sysctl vm.mmap_rnd_bits=8
+        run: sudo sysctl vm.mmap_rnd_bits=28
 
       - name: Initialize ASan configuration
         run: |

--- a/.github/workflows/ASan.yml
+++ b/.github/workflows/ASan.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Work around ASAN shadow-memory clash (google/sanitizers#856)
-        run: sudo sysctl vm.mmap_rnd_bits=28
+        run: sudo sysctl vm.mmap_rnd_bits=8
 
       - name: Initialize ASan configuration
         run: |
@@ -84,4 +84,4 @@ jobs:
 
       - name: ASAN - memcheck ${{ matrix.config.test }}
         run: |
-          Rscript memcheck/${{ matrix.config.test }}.R
+          setarch "$(uname -m)" -R Rscript memcheck/${{ matrix.config.test }}.R

--- a/.github/workflows/ASan.yml
+++ b/.github/workflows/ASan.yml
@@ -51,6 +51,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Work around ASAN shadow-memory clash (google/sanitizers#856)
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       - name: Initialize ASan configuration
         run: |
           export LD_PRELOAD=$(gcc -print-file-name=libasan.so)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,7 +71,7 @@ Config/Needs/check:
   pkgbuild,
   rcmdcheck,
 Config/Needs/coverage: covr, spelling
-Config/Needs/memcheck: devtools
+Config/Needs/memcheck: devtools, remotes
 Config/Needs/metadata: codemeta
 Config/Needs/revdeps: revdepcheck
 Config/Needs/website: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,7 +71,7 @@ Config/Needs/check:
   pkgbuild,
   rcmdcheck,
 Config/Needs/coverage: covr, spelling
-Config/Needs/memcheck: devtools, remotes
+Config/Needs/memcheck: devtools
 Config/Needs/metadata: codemeta
 Config/Needs/revdeps: revdepcheck
 Config/Needs/website: 


### PR DESCRIPTION
## Problem

The `gcc-ASAN` workflow on `main` has been broken and `disabled_manually`.
`main`'s `ASan.yml` was frozen since Sept 2025 on the **bare-runner +
manual-makevars** approach, which hits a kernel ASLR/shadow-memory clash on
current `ubuntu-24.04` runners:

```
==NNNN==Shadow memory range interleaves with an existing memory mapping.
        ASan cannot proceed correctly. ABORTING.
==NNNN==This might be related to ELF_ET_DYN_BASE change in Linux 4.12.
```

This aborts **before any R code runs**. (Note: the arm-runner/r-hub-container
breakage seen on unmerged branches never affected `main` — that was a
separate red herring.)

### Rejected fixes (empirically)

Both standard ASLR workarounds were tried and **verified to still abort**:

| Attempt | Commit | Result |
|---------|--------|--------|
| `sudo sysctl vm.mmap_rnd_bits=28` | `8a5de02` | sysctl applied, shadow-memory abort persisted (run 28644456099) |
| `setarch "$(uname -m)" -R` (disable ASLR outright) | `9a2ef4c` / `f8b1ac0` | still aborted identically (run 28645101973) |

The shadow-memory clash is **x86-bare-runner-specific** and not reliably
fixable this way on today's runner images.

## Fix

Adopt the **r-hub `gcc-asan` container on `ubuntu-latest` (x86)** via
`ms609/actions/asan@main` — the container ships R-devel already built with
ASAN/UBSAN and sidesteps the shadow-memory clash by construction. This is the
exact config **TreeTools** runs green (42 min on 2026-06-16, and a fresh 17-min
green run today). Adds `exclude-packages: Rogue` (skips Rogue's ~30-min `Rfast`
source build) and `remotes` to `Config/Needs/memcheck` (the vignettes leg's
`devtools::build_vignettes()` needs it; devtools 2.5.0+ demoted `remotes` to
Suggests).

## Verification

- Run [28646564439](https://github.com/ms609/TreeSearch/actions/runs/28646564439):
  **tests + examples green** under real ASAN; vignettes failed only on the
  `remotes` dependency.
- Run [28648322374](https://github.com/ms609/TreeSearch/actions/runs/28648322374):
  **all three legs green** (tests/examples/vignettes) after the `remotes` fix.

No memory-safety findings surfaced in TreeSearch's own C++.

## Merge note

Please **squash-merge**: the branch carries 3 abandoned sysctl/setarch commits
(kept for the empirical record) before the working container fix (`562dd70`)
and the `remotes` fix (`8e9c510`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)