### PR TITLE
feat(sector): TNT-style in-sector drifting for large sectors (opt-in)

### DIFF
--- a/R/SearchControl.R
+++ b/R/SearchControl.R
@@ -99,11 +99,11 @@
 #'   `godrift`/`gocomb`.  Small sectors are cheap to optimise exhaustively; large
 #'   sectors have more reach but need drift to escape their own local optima.
 #'   `sectorGoComb` solves the sector with `sectorCombStarts` \acronym{RAS}+drift
-#'   starts, keeping the best (\acronym{TNT}'s combined analysis also *fuses* the
-#'   starts; that recombination sub-step is not yet implemented).  `sectorGoComb`
-#'   takes precedence when both trigger.  `0` (default) disables each, leaving all
-#'   sectors on \acronym{RAS}+\acronym{TBR}.  To exercise these, also raise
-#'   `sectorMaxSize` so large sectors are selected.
+#'   starts and then *fuses* them (recombines shared clades across the starts over
+#'   `sectorFuseRounds` rounds), keeping the fused tree only if it beats the best
+#'   start.  `sectorGoComb` takes precedence when both trigger.  `0` (default)
+#'   disables each, leaving all sectors on \acronym{RAS}+\acronym{TBR}.  To
+#'   exercise these, also raise `sectorMaxSize` so large sectors are selected.
 #' @param sectorDriftCycles Integer; drift cycles used when a sector is solved by
 #'   drift or combined analysis (\acronym{TNT} `drift`).
 #' @param sectorDriftAfd Integer; absolute-fit-difference limit (steps) for
@@ -112,8 +112,8 @@
 #'   drift.
 #' @param sectorCombStarts Integer; \acronym{RAS}+drift starts per combined
 #'   sector (\acronym{TNT} `combstarts`).
-#' @param sectorFuseRounds Integer; reserved for the deferred combined-analysis
-#'   fuse sub-step (\acronym{TNT} `fuse`); currently unused.
+#' @param sectorFuseRounds Integer; max fuse rounds for the combined-analysis
+#'   recombination sub-step (\acronym{TNT} `fuse`).
 #' @param postRatchetSectorial Logical; when `TRUE`, run XSS+RSS+CSS again
 #'   after ratchet perturbation using the same round counts.  Approximates
 #'   TNT's interleaved sectorial pattern.  Default: `FALSE`.

--- a/R/SearchControl.R
+++ b/R/SearchControl.R
@@ -92,6 +92,28 @@
 #'   auto-sizes to `2 * nTip / meanSectorSize` (~5).  Higher values chain more
 #'   sequential sector replacements before the next global cleanup, matching the
 #'   ~20-25 of \insertCite{Goloboff1999;textual}{TreeSearch} / \acronym{TNT}.
+#' @param sectorGoDrift,sectorGoComb Integer; size thresholds (in real sector
+#'   tips) above which a sector is solved by tree-drifting (`sectorGoDrift`) or by
+#'   combined analysis (`sectorGoComb`) instead of plain
+#'   \acronym{RAS}+\acronym{TBR}, following \acronym{TNT}'s `sectsch`
+#'   `godrift`/`gocomb`.  Small sectors are cheap to optimise exhaustively; large
+#'   sectors have more reach but need drift to escape their own local optima.
+#'   `sectorGoComb` solves the sector with `sectorCombStarts` \acronym{RAS}+drift
+#'   starts, keeping the best (\acronym{TNT}'s combined analysis also *fuses* the
+#'   starts; that recombination sub-step is not yet implemented).  `sectorGoComb`
+#'   takes precedence when both trigger.  `0` (default) disables each, leaving all
+#'   sectors on \acronym{RAS}+\acronym{TBR}.  To exercise these, also raise
+#'   `sectorMaxSize` so large sectors are selected.
+#' @param sectorDriftCycles Integer; drift cycles used when a sector is solved by
+#'   drift or combined analysis (\acronym{TNT} `drift`).
+#' @param sectorDriftAfd Integer; absolute-fit-difference limit (steps) for
+#'   in-sector drift.
+#' @param sectorDriftRfd Numeric; relative-fit-difference limit for in-sector
+#'   drift.
+#' @param sectorCombStarts Integer; \acronym{RAS}+drift starts per combined
+#'   sector (\acronym{TNT} `combstarts`).
+#' @param sectorFuseRounds Integer; reserved for the deferred combined-analysis
+#'   fuse sub-step (\acronym{TNT} `fuse`); currently unused.
 #' @param postRatchetSectorial Logical; when `TRUE`, run XSS+RSS+CSS again
 #'   after ratchet perturbation using the same round counts.  Approximates
 #'   TNT's interleaved sectorial pattern.  Default: `FALSE`.
@@ -302,6 +324,13 @@ SearchControl <- function(
     sectorMaxHits = 1L,
     sectorCollapseTarget = 0L,
     rssPicks = 0L,
+    sectorGoDrift = 0L,
+    sectorGoComb = 0L,
+    sectorDriftCycles = 5L,
+    sectorDriftAfd = 3L,
+    sectorDriftRfd = 0.1,
+    sectorCombStarts = 3L,
+    sectorFuseRounds = 3L,
     postRatchetSectorial = FALSE,
     # Fuse / pool
     fuseInterval = 3L,
@@ -396,6 +425,13 @@ SearchControl <- function(
       sectorMaxHits = as.integer(sectorMaxHits),
       sectorCollapseTarget = as.integer(sectorCollapseTarget),
       rssPicks = as.integer(rssPicks),
+      sectorGoDrift = as.integer(sectorGoDrift),
+      sectorGoComb = as.integer(sectorGoComb),
+      sectorDriftCycles = as.integer(sectorDriftCycles),
+      sectorDriftAfd = as.integer(sectorDriftAfd),
+      sectorDriftRfd = as.double(sectorDriftRfd),
+      sectorCombStarts = as.integer(sectorCombStarts),
+      sectorFuseRounds = as.integer(sectorFuseRounds),
       postRatchetSectorial = as.logical(postRatchetSectorial),
       fuseInterval = as.integer(fuseInterval),
       fuseAcceptEqual = as.logical(fuseAcceptEqual),
@@ -445,7 +481,10 @@ print.SearchControl <- function(x, ...) {
                      "cssRounds", "cssPartitions",
                      "sectorMinSize", "sectorMaxSize", "rasStarts",
                      "sectorAcceptEqual", "sectorMaxHits", "sectorCollapseTarget",
-                     "rssPicks", "postRatchetSectorial"),
+                     "rssPicks", "sectorGoDrift", "sectorGoComb",
+                     "sectorDriftCycles", "sectorDriftAfd", "sectorDriftRfd",
+                     "sectorCombStarts", "sectorFuseRounds",
+                     "postRatchetSectorial"),
     "Fuse/Pool" = c("fuseInterval", "fuseAcceptEqual", "intraFuse",
                      "poolMaxSize", "poolSuboptimal"),
     "Stopping" = c("consensusStableReps", "perturbStopFactor",

--- a/dev/benchmarks/sector_drift_ab.R
+++ b/dev/benchmarks/sector_drift_ab.R
@@ -1,0 +1,85 @@
+#!/usr/bin/env Rscript
+# Matched-wall A/B for TNT-style in-sector drifting (godrift, HTU-PINNED variant)
+# on the hard sector-resolve / floor corpus. Isolates the DRIFT contribution: both
+# arms allow large sectors (sectorMaxSize raised) and use rasStarts>=2 so the
+# sector-resolve retention channel is live (see memory sect-slack-ablation /
+# tnt-sectorial-recipe); they differ ONLY in whether large sectors are solved by
+# drift. The drift is HTU-pinned (content sector_mask) so ~88% of solves are kept
+# and TBR-polished (see memory sector-drift-htu-float); this A/B answers the open
+# question that the local revert-rate metric CANNOT: does pinned drift move the
+# anytime curve (time-to-best), not just fire.
+#
+# Mission = wall-clock time-to-optimum, so this reports the ANYTIME curve (score
+# vs elapsed) per cell, not just the final score. Drift is expensive and runs per
+# sector pick, so the likely failure mode is "better per-sector quality, WORSE
+# time-to-optimum" — hence the threshold × cycles SWEEP, not a single on/off point.
+#
+# Hamilton SLURM array: one cell per (dataset × seed × arm). No %throttle.
+# Env: TERM=dumb OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1, dedicated isolated lib.
+#
+# Usage (one array cell): Rscript sector_drift_ab.R <cell_index>
+suppressMessages({ library("TreeTools"); library("TreeSearch", lib.loc = Sys.getenv("TS_LIB")) })
+
+# ---- Grid ----------------------------------------------------------------
+datasets <- c("Zanol2014", "Zhu2013", "Wortley2006", "Giles2015")  # sector-resolve corpus
+seeds    <- 1:5
+# arm 0 = baseline (RAS+TBR only, drift force-OFF); arms 1.. sweep threshold×cycles.
+arms <- rbind(
+  data.frame(name = "base",         goDrift =  0L, cycles = 0L, forceOff = TRUE),
+  data.frame(name = "drift40_c3",   goDrift = 40L, cycles = 3L, forceOff = FALSE),
+  data.frame(name = "drift40_c6",   goDrift = 40L, cycles = 6L, forceOff = FALSE),
+  data.frame(name = "drift25_c3",   goDrift = 25L, cycles = 3L, forceOff = FALSE),
+  data.frame(name = "drift55_c3",   goDrift = 55L, cycles = 3L, forceOff = FALSE)
+)
+grid <- expand.grid(dataset = datasets, seed = seeds, arm = seq_len(nrow(arms)),
+                    KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE)
+
+cell <- as.integer(commandArgs(trailingOnly = TRUE)[[1]])
+stopifnot(cell >= 1L, cell <= nrow(grid))
+g   <- grid[cell, ]
+arm <- arms[g$arm, ]
+
+datPath <- file.path("data-raw", paste0(g$dataset, ".nex"))
+dat <- ReadAsPhyDat(datPath)
+
+# Matched wall: fixed maxSeconds budget, both arms identical except drift.
+# rasStarts=3 (TNT) in BOTH arms so the mechanism is exercised, not inert.
+ctrl <- SearchControl(
+  xssRounds = 3L, rssRounds = 2L, cssRounds = 0L,
+  sectorMinSize = 6L, sectorMaxSize = 80L,     # large sectors allowed in BOTH arms
+  rasStarts = 3L,
+  sectorGoDrift = arm$goDrift,
+  sectorDriftCycles = if (arm$cycles > 0L) arm$cycles else 5L
+)
+
+if (isTRUE(arm$forceOff)) Sys.setenv(TS_SECT_DRIFT = "0") else Sys.unsetenv("TS_SECT_DRIFT")
+set.seed(g$seed)
+
+# Anytime trajectory via progressCallback (best_score, elapsed) — the mission
+# metric. The callback fires per replicate/phase (coarse but matched across arms).
+traj <- list()
+cb <- function(info) {
+  traj[[length(traj) + 1L]] <<- data.frame(t = as.double(info$elapsed),
+                                            score = as.double(info$best_score))
+  invisible(TRUE)
+}
+t0 <- Sys.time()
+tr <- MaximizeParsimony(dat, maxReplicates = 200L, maxSeconds = 90,
+                        nThreads = 1L, verbosity = 0L, strategy = "none",
+                        control = ctrl, progressCallback = cb)
+wall <- as.double(difftime(Sys.time(), t0, units = "secs"))
+
+out <- data.frame(cell = cell, dataset = g$dataset, seed = g$seed,
+                  arm = arm$name, goDrift = arm$goDrift, cycles = arm$cycles,
+                  final_score = attr(tr, "score")[1], wall = wall)
+outDir <- Sys.getenv("AB_OUT", "dev/benchmarks/sector_drift/out")
+dir.create(outDir, showWarnings = FALSE, recursive = TRUE)
+write.csv(out, file.path(outDir, sprintf("cell_%03d_%s_s%d_%s.csv",
+          cell, g$dataset, g$seed, arm$name)), row.names = FALSE)
+if (length(traj)) {
+  tj <- do.call(rbind, traj); tj$cell <- cell; tj$arm <- arm$name
+  write.csv(tj, file.path(outDir, sprintf("traj_%03d_%s_s%d_%s.csv",
+            cell, g$dataset, g$seed, arm$name)), row.names = FALSE)
+}
+cat(sprintf("cell %d %s s%d [%s] final=%.1f wall=%.1fs\n",
+            cell, g$dataset, g$seed, arm$name, out$final_score, wall))

--- a/dev/benchmarks/sector_fuse_ab.R
+++ b/dev/benchmarks/sector_fuse_ab.R
@@ -1,0 +1,81 @@
+#!/usr/bin/env Rscript
+# Matched-wall A/B isolating the MARGINAL value of the gocomb FUSE sub-step over
+# drift-only combined analysis. Pre-committed decision rule (set BEFORE running, to
+# avoid open-ended tuning -- cf. the auto-tuner NO-GO):
+#   * fuse arm moves the anytime curve below its matched drift-only arm (lower score
+#     at equal wall, no dataset regressing) -> KEEP gocomb-fuse opt-in.
+#   * fuse arm ties/does-not-improve its drift-only arm -> mechanism stays IN,
+#     default-OFF, documented "implemented, no measured benefit over drift-only".
+# Given pool>=2 is ~1/20 comb solves locally (RAS+drift starts converge), the tie
+# outcome is the expectation, not a surprise.
+#
+# The comparison is clean regardless of engagement: within a combStarts level the
+# fuse/drift arms are IDENTICAL except TS_SECT_FUSE, so any delta is fuse alone.
+# Two combStarts levels (3, 6): more starts -> more start-diversity -> more chances
+# for fuse to find >=2 distinct donors, at higher per-sector cost (matched wall
+# absorbs the cost -> the anytime curve is the honest judge).
+#
+# Hamilton SLURM array, one cell per (dataset x seed x arm). No %throttle.
+# Env per arm sets TS_SECT_FUSE / TS_SECT_DRIFT; rasStarts=3 in ALL arms.
+# Usage (one array cell): Rscript sector_fuse_ab.R <cell_index>
+suppressMessages({ library("TreeTools"); library("TreeSearch", lib.loc = Sys.getenv("TS_LIB")) })
+
+datasets <- c("Zanol2014", "Zhu2013", "Wortley2006", "Giles2015")  # sector-resolve corpus
+seeds    <- 1:5
+# arm: goComb (0 => base/off), combStarts, fuse (TS_SECT_FUSE), forceOff (TS_SECT_DRIFT=0)
+arms <- rbind(
+  data.frame(name = "base",           goComb =  0L, combStarts = 3L, fuse = FALSE, forceOff = TRUE),
+  data.frame(name = "comb_drift_s3",  goComb = 30L, combStarts = 3L, fuse = FALSE, forceOff = FALSE),
+  data.frame(name = "comb_fuse_s3",   goComb = 30L, combStarts = 3L, fuse = TRUE,  forceOff = FALSE),
+  data.frame(name = "comb_drift_s6",  goComb = 30L, combStarts = 6L, fuse = FALSE, forceOff = FALSE),
+  data.frame(name = "comb_fuse_s6",   goComb = 30L, combStarts = 6L, fuse = TRUE,  forceOff = FALSE)
+)
+grid <- expand.grid(dataset = datasets, seed = seeds, arm = seq_len(nrow(arms)),
+                    KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE)
+
+cell <- as.integer(commandArgs(trailingOnly = TRUE)[[1]])
+stopifnot(cell >= 1L, cell <= nrow(grid))
+g   <- grid[cell, ]
+arm <- arms[g$arm, ]
+
+dat <- ReadAsPhyDat(file.path("data-raw", paste0(g$dataset, ".nex")))
+
+ctrl <- SearchControl(
+  xssRounds = 3L, rssRounds = 2L, cssRounds = 0L,
+  sectorMinSize = 6L, sectorMaxSize = 80L,   # large sectors allowed in all arms
+  rasStarts = 3L,
+  sectorGoComb = arm$goComb, sectorCombStarts = arm$combStarts,
+  sectorDriftCycles = 3L, sectorFuseRounds = 3L
+)
+
+# Env gates: force-off drift in base; disable only the fuse step in the drift arms.
+if (isTRUE(arm$forceOff)) Sys.setenv(TS_SECT_DRIFT = "0") else Sys.unsetenv("TS_SECT_DRIFT")
+if (isTRUE(arm$fuse)) Sys.unsetenv("TS_SECT_FUSE") else Sys.setenv(TS_SECT_FUSE = "0")
+set.seed(g$seed)
+
+traj <- list()
+cb <- function(info) {
+  traj[[length(traj) + 1L]] <<- data.frame(t = as.double(info$elapsed),
+                                            score = as.double(info$best_score))
+  invisible(TRUE)
+}
+t0 <- Sys.time()
+tr <- MaximizeParsimony(dat, maxReplicates = 200L, maxSeconds = 90,
+                        nThreads = 1L, verbosity = 0L, strategy = "none",
+                        control = ctrl, progressCallback = cb)
+wall <- as.double(difftime(Sys.time(), t0, units = "secs"))
+
+out <- data.frame(cell = cell, dataset = g$dataset, seed = g$seed,
+                  arm = arm$name, goComb = arm$goComb, combStarts = arm$combStarts,
+                  fuse = arm$fuse, final_score = attr(tr, "score")[1], wall = wall)
+outDir <- Sys.getenv("AB_OUT", "dev/benchmarks/sector_fuse/out")
+dir.create(outDir, showWarnings = FALSE, recursive = TRUE)
+write.csv(out, file.path(outDir, sprintf("cell_%03d_%s_s%d_%s.csv",
+          cell, g$dataset, g$seed, arm$name)), row.names = FALSE)
+if (length(traj)) {
+  tj <- do.call(rbind, traj); tj$cell <- cell; tj$arm <- arm$name
+  write.csv(tj, file.path(outDir, sprintf("traj_%03d_%s_s%d_%s.csv",
+            cell, g$dataset, g$seed, arm$name)), row.names = FALSE)
+}
+cat(sprintf("cell %d %s s%d [%s] final=%.1f wall=%.1fs\n",
+            cell, g$dataset, g$seed, arm$name, out$final_score, wall))

--- a/src/ts_drift.cpp
+++ b/src/ts_drift.cpp
@@ -319,7 +319,8 @@ static bool drift_apply_tbr_move(
 static int drift_phase(TreeState& tree, const DataSet& ds,
                        int afd_limit, double rfd_limit,
                        int max_changes, std::mt19937& rng,
-                       ConstraintData* cd = nullptr) {
+                       ConstraintData* cd = nullptr,
+                       const std::vector<bool>* sector_mask = nullptr) {
   bool constrained = cd && cd->active;
   if (constrained) update_constraint(tree, *cd);
   double score = drift_full_rescore(tree, ds);
@@ -347,6 +348,9 @@ static int drift_phase(TreeState& tree, const DataSet& ds,
     if (node == tree.n_tip) continue;
     // Skip clips where subtree > n/2 (same optimization as tbr_search)
     if (subtree_sizes[node] > half_n) continue;
+    // Sector-mask: only clip inside the masked clade (pins out-of-mask nodes,
+    // e.g. a sector's HTU pseudo-tip and the synthetic root edge).
+    if (sector_mask && !(*sector_mask)[node]) continue;
     clip_candidates.push_back(node);
   }
 
@@ -473,6 +477,8 @@ static int drift_phase(TreeState& tree, const DataSet& ds,
     for (auto& [above, below] : main_edges) {
       if (above == nz && below == ns) continue;
       if (constrained && regraft_violates_constraint(below, *cd)) continue;
+      // Sector-mask: only regraft onto edges inside the masked clade.
+      if (sector_mask && !(*sector_mask)[below]) continue;
       // Collapsed-region regraft merging: skip interior collapsed edges.
       if (!collapsed.empty() && collapsed[below])
         continue;
@@ -525,6 +531,8 @@ static int drift_phase(TreeState& tree, const DataSet& ds,
           if (above == nz && below == ns) continue;
           if (constrained && regraft_violates_constraint(below, *cd))
             continue;
+          // Sector-mask: only regraft onto edges inside the masked clade.
+          if (sector_mask && !(*sector_mask)[below]) continue;
           // Collapsed-region regraft merging (same as SPR loop).
           if (!collapsed.empty() && collapsed[below])
             continue;
@@ -721,7 +729,8 @@ static int drift_phase(TreeState& tree, const DataSet& ds,
 DriftResult drift_search(TreeState& tree, const DataSet& ds,
                          const DriftParams& params,
                          ConstraintData* cd,
-                         std::function<bool()> check_timeout) {
+                         std::function<bool()> check_timeout,
+                         const std::vector<bool>* sector_mask) {
   double best_score = drift_full_rescore(tree, ds);
 
   // No informative characters: all trees have the same score.
@@ -747,7 +756,7 @@ DriftResult drift_search(TreeState& tree, const DataSet& ds,
       // Suboptimal drift phase
       int drift_moves = drift_phase(tree, ds,
                                      params.afd_limit, params.rfd_limit,
-                                     max_drift_changes, rng, cd);
+                                     max_drift_changes, rng, cd, sector_mask);
       total_drift_moves += drift_moves;
     } else {
       // Equal-score drift phase
@@ -758,7 +767,7 @@ DriftResult drift_search(TreeState& tree, const DataSet& ds,
       eq_params.tabu_size = params.tabu_size;
 
       TBRResult eq_result = tbr_search(tree, ds, eq_params, cd,
-                                        nullptr, nullptr, check_timeout);
+                                        sector_mask, nullptr, check_timeout);
       total_drift_moves += eq_result.n_accepted;
     }
 
@@ -770,7 +779,7 @@ DriftResult drift_search(TreeState& tree, const DataSet& ds,
     search_params.tabu_size = params.tabu_size;
 
     TBRResult search_result = tbr_search(tree, ds, search_params, cd,
-                                          nullptr, nullptr, check_timeout);
+                                          sector_mask, nullptr, check_timeout);
     total_tbr_moves += search_result.n_accepted;
 
     // Update best if improved

--- a/src/ts_drift.h
+++ b/src/ts_drift.h
@@ -12,6 +12,7 @@
 #include "ts_tree.h"
 #include "ts_constraint.h"
 #include <functional>
+#include <vector>
 
 namespace ts {
 
@@ -32,10 +33,18 @@ struct DriftResult {
 
 // Run drift search on `tree` with dataset `ds`.
 // Modifies `tree` in place to the best tree found across all cycles.
+//
+// `sector_mask` (optional): when non-null, restricts every internal TBR clip and
+// regraft to nodes flagged true, exactly as tbr_search's sector_mask does. Used
+// by the sectorial search to PIN an HTU pseudo-tip: masking a sector's content
+// clade keeps drift's suboptimal + search phases from re-rooting the reduced tree
+// against the rest-of-tree summary, so the result stays reinsertable. nullptr
+// (default) = drift the whole tree, prior behaviour.
 DriftResult drift_search(TreeState& tree, const DataSet& ds,
                          const DriftParams& params,
                          ConstraintData* cd = nullptr,
-                         std::function<bool()> check_timeout = nullptr);
+                         std::function<bool()> check_timeout = nullptr,
+                         const std::vector<bool>* sector_mask = nullptr);
 
 } // namespace ts
 

--- a/src/ts_driven.cpp
+++ b/src/ts_driven.cpp
@@ -240,6 +240,13 @@ ReplicateResult run_single_replicate(
       sp.accept_equal = params.sector_accept_equal;  // Goloboff 2014 plateau lever
       sp.collapse_target = params.sector_collapse_target;  // Goloboff 1999 coarse sector
       sp.rss_picks_per_round = params.rss_picks_per_round;  // sequential picks/round (0=auto)
+      sp.sector_go_drift = params.sector_go_drift;      // TNT godrift: drift large sectors
+      sp.sector_go_comb = params.sector_go_comb;        // TNT gocomb: RAS+drift+fuse large sectors
+      sp.sector_drift_cycles = params.sector_drift_cycles;
+      sp.sector_drift_afd = params.sector_drift_afd;
+      sp.sector_drift_rfd = params.sector_drift_rfd;
+      sp.sector_comb_starts = params.sector_comb_starts;
+      sp.sector_fuse_rounds = params.sector_fuse_rounds;
 
       // XSS: systematic partitioning
       sp.n_partitions = params.xss_partitions;
@@ -359,6 +366,13 @@ ReplicateResult run_single_replicate(
       sp.accept_equal = params.sector_accept_equal;  // Goloboff 2014 plateau lever
       sp.collapse_target = params.sector_collapse_target;  // Goloboff 1999 coarse sector
       sp.rss_picks_per_round = params.rss_picks_per_round;  // sequential picks/round (0=auto)
+      sp.sector_go_drift = params.sector_go_drift;      // TNT godrift: drift large sectors
+      sp.sector_go_comb = params.sector_go_comb;        // TNT gocomb: RAS+drift+fuse large sectors
+      sp.sector_drift_cycles = params.sector_drift_cycles;
+      sp.sector_drift_afd = params.sector_drift_afd;
+      sp.sector_drift_rfd = params.sector_drift_rfd;
+      sp.sector_comb_starts = params.sector_comb_starts;
+      sp.sector_fuse_rounds = params.sector_fuse_rounds;
 
       if (params.xss_rounds > 0) {
         sp.n_partitions = params.xss_partitions;

--- a/src/ts_driven.h
+++ b/src/ts_driven.h
@@ -107,6 +107,18 @@ struct DrivenParams {
                                      // TNT ~20-25). Plumbs
                                      // SectorParams::rss_picks_per_round.
 
+  // TNT-style in-sector drift / combined analysis for LARGE sectors.
+  // Solve big sectors (>= threshold real tips) by drift or RAS+drift+fuse,
+  // reaching sector topologies plain RAS+TBR cannot escape (TNT `sectsch`
+  // godrift/gocomb/drift/combstarts/fuse). 0 thresholds = off (default).
+  int sector_go_drift = 0;           // Plumbs SectorParams::sector_go_drift.
+  int sector_go_comb = 0;            // Plumbs SectorParams::sector_go_comb.
+  int sector_drift_cycles = 5;       // Plumbs SectorParams::sector_drift_cycles.
+  int sector_drift_afd = 3;          // Plumbs SectorParams::sector_drift_afd.
+  double sector_drift_rfd = 0.1;     // Plumbs SectorParams::sector_drift_rfd.
+  int sector_comb_starts = 3;        // Plumbs SectorParams::sector_comb_starts.
+  int sector_fuse_rounds = 3;        // Plumbs SectorParams::sector_fuse_rounds.
+
   // Post-ratchet sectorial search (T-257).
   // When true, run XSS+RSS+CSS again after ratchet perturbation using the
   // same round counts and sector parameters.  TNT interleaves sectorial

--- a/src/ts_rcpp.cpp
+++ b/src/ts_rcpp.cpp
@@ -1543,6 +1543,21 @@ static void unpack_search_control(List ctrl, ts::DrivenParams& params) {
     params.sector_collapse_target = as<int>(ctrl["sectorCollapseTarget"]);
   if (ctrl.containsElementNamed("rssPicks"))
     params.rss_picks_per_round = as<int>(ctrl["rssPicks"]);
+  // TNT-style in-sector drift / combined analysis for large sectors.
+  if (ctrl.containsElementNamed("sectorGoDrift"))
+    params.sector_go_drift = as<int>(ctrl["sectorGoDrift"]);
+  if (ctrl.containsElementNamed("sectorGoComb"))
+    params.sector_go_comb = as<int>(ctrl["sectorGoComb"]);
+  if (ctrl.containsElementNamed("sectorDriftCycles"))
+    params.sector_drift_cycles = as<int>(ctrl["sectorDriftCycles"]);
+  if (ctrl.containsElementNamed("sectorDriftAfd"))
+    params.sector_drift_afd = as<int>(ctrl["sectorDriftAfd"]);
+  if (ctrl.containsElementNamed("sectorDriftRfd"))
+    params.sector_drift_rfd = as<double>(ctrl["sectorDriftRfd"]);
+  if (ctrl.containsElementNamed("sectorCombStarts"))
+    params.sector_comb_starts = as<int>(ctrl["sectorCombStarts"]);
+  if (ctrl.containsElementNamed("sectorFuseRounds"))
+    params.sector_fuse_rounds = as<int>(ctrl["sectorFuseRounds"]);
 
   // Fuse / pool
   params.fuse_interval      = as<int>(ctrl["fuseInterval"]);

--- a/src/ts_sector.cpp
+++ b/src/ts_sector.cpp
@@ -7,6 +7,7 @@
 #include "ts_splits.h"
 #include "ts_pool.h"
 #include "ts_drift.h"
+#include "ts_fuse.h"
 
 #include <algorithm>
 #include <random>
@@ -1013,14 +1014,15 @@ static void build_ras_sector(ReducedDataset& rd, std::mt19937& rng) {
 // force-disables regardless of params (baseline arm).
 //
 // godrift: solve the sector with a single drift_search per RAS start.
-// gocomb : run `combstarts` HTU-anchored RAS+drift starts and keep the best
-//          (TNT's combined analysis is RAS+drift+FUSE; the fuse recombination
-//          sub-step is DEFERRED — tree_fuse re-roots the reduced tree at tip 0
-//          every round, which drops it out of the (HTU, sr_mapped) synthetic-root
-//          layout that reinsert_sector requires, so a fused result is not
-//          reinsertable without a root-agnostic reinsertion path. Validate
-//          godrift first, then add the fuse step behind that work). Every
-//          candidate kept here stays HTU-anchored, so reinsert_sector is unchanged.
+// gocomb : run `combstarts` HTU-anchored RAS+drift starts, then FUSE them (TNT's
+//          combined analysis = RAS+drift+fuse). tree_fuse re-roots the reduced
+//          tree at tip 0, dropping the (HTU, sr_mapped) synthetic-root layout
+//          reinsert_sector needs; reanchor_fused_at_htu re-roots the fused tree
+//          at the HTU (rooting-invariance) so it is reinsertable whenever fuse
+//          left the HTU on the sector boundary. The fused tree is accepted only
+//          if it beats the best
+//          start, through the same root_ok gate + reinsert path as the drift
+//          starts. Env TS_SECT_FUSE=0 disables the fuse step (drift-only comb).
 //
 // The env gates are read via FUNCTION-LOCAL statics inside search_sector (like
 // _free_htu_probe), NOT namespace-scope statics: a namespace-scope dynamic
@@ -1055,6 +1057,37 @@ static double drift_solve_reduced(ReducedDataset& rd, const SectorParams& params
   return dr.best_score;
 }
 
+// gocomb-fuse engagement counters (env TS_SECT_DRIFT_STATS): fused sectors
+// tried / fused sectors that improved on the best RAS+drift start.
+static long long g_sect_fuse_tries = 0;
+static long long g_sect_fuse_wins  = 0;
+
+// Re-anchor a FUSED reduced sector tree so reinsert_sector can use it.
+//
+// tree_fuse combines the RAS+drift starts over the full reduced tip set
+// (including the HTU pseudo-tip) and re-roots at tip 0, so the result is NOT in
+// the (HTU, sr_mapped) synthetic-root layout reinsert_sector requires. Parsimony
+// is rooting-invariant, so we simply re-root the fused tree at the HTU pseudo-tip:
+// the HTU represents the rest of the tree at the sector boundary, so it stays
+// structurally adjacent to the content root -- re-rooting at it makes its sibling
+// the whole non-HTU clade (the sector arrangement as seen "hanging from the rest-
+// of-tree direction"), exactly the clade reinsert_sector grafts back.
+//
+// Whenever fuse leaves the HTU on the sector boundary -- the common case, since
+// fuse never exchanges the trivial {HTU} split and its interior TBR does not
+// regraft a lone boundary pseudo-tip -- the content clade stays rooted at node id
+// sr_mapped, so the root's children are {HTU, sr_mapped} and the caller's root_ok
+// check accepts the tree. In the rare case fuse floats the HTU into the interior
+// (the same move the drift path deliberately reverts), the content root would
+// carry a different id, root_ok fails, and the caller keeps the best RAS+drift
+// start. So a fused tree is reinserted only when its id mapping is already valid
+// -- never via a speculative relabel (empirically the float case never occurs; a
+// permutation-remap to force it was implemented, found unreachable, and removed).
+static void reanchor_fused_at_htu(TreeState& t, int htu_idx) {
+  reroot_at_tip(t, htu_idx);   // root's children now {htu_idx, content root}
+  t.build_postorder();
+}
+
 // Search the reduced dataset and return the best score found.
 // Modifies rd.subtree in place, leaving the best sector topology ready for
 // reinsertion.
@@ -1084,6 +1117,13 @@ static double search_sector(ReducedDataset& rd, const SectorParams& params,
   }();
   static const bool kSectDriftStats =
       std::getenv("TS_SECT_DRIFT_STATS") != nullptr;
+  // TS_SECT_FUSE=0 disables ONLY the gocomb fuse recombination sub-step, leaving
+  // the RAS+drift keep-best comb behaviour intact -- isolates fuse's contribution
+  // in the A/B (gocomb-with-fuse vs gocomb-drift-only).
+  static const bool kSectFuseOff = []{
+    const char* e = std::getenv("TS_SECT_FUSE");
+    return e != nullptr && e[0] == '0';
+  }();
 
   // Solve-mode escalation by sector size (real tips, as count_clade_tips
   // measures max_sector_size). Both godrift and gocomb solve the sector with
@@ -1111,6 +1151,12 @@ static double search_sector(ReducedDataset& rd, const SectorParams& params,
   double best_score = 0.0;
   bool have_best = false;
   std::vector<int> best_left, best_right, best_parent;
+
+  // gocomb fuse: collect the valid (HTU-anchored) per-start topologies so they
+  // can be recombined after the loop (TNT combined analysis = RAS+drift+FUSE).
+  // Only populated in comb_mode with fuse enabled; the pool dedups by split hash.
+  const bool do_fuse = comb_mode && !kSectFuseOff;
+  TreePool fuse_pool(ras_starts + 1);
 
   // search_sector runs once per sector pick (1000s of times/search). std::getenv
   // is µs-scale on Windows/ucrt (linear env scan), so the per-pick D1-probe gate
@@ -1249,6 +1295,12 @@ static double search_sector(ReducedDataset& rd, const SectorParams& params,
         have_best = true;
       }
     }
+
+    // Stash this start's (valid, HTU-anchored) topology as a fuse donor. Whatever
+    // rd.subtree holds now is reinsertable -- either the solved tree (root_ok) or
+    // the reverted pre-solve one -- so every donor is a legitimate recombination
+    // input. The pool dedups identical starts by split hash.
+    if (do_fuse) fuse_pool.add(rd.subtree, this_score);
   }
 
   // Restore the best topology found across starts, ready for reinsertion.
@@ -1258,6 +1310,58 @@ static double search_sector(ReducedDataset& rd, const SectorParams& params,
     rd.subtree.right = best_right;
     rd.subtree.parent = best_parent;
     rd.subtree.build_postorder();
+  }
+
+  // gocomb FUSE (TNT combined analysis): recombine the RAS+drift starts. With the
+  // best start as recipient, tree_fuse exchanges shared clades from the other
+  // starts (and runs a cleanup TBR) -- reaching arrangements no single start held,
+  // INCLUDING ones that float the HTU (its interior TBR is unmasked). We re-anchor
+  // the fused tree at the HTU (reanchor_fused_at_htu) so it is reinsertable when
+  // fuse kept the HTU on the boundary, then accept it only if it beats the best
+  // start -- and only via the SAME reduced
+  // score + root_ok gate + reinsert path as the drift starts (no reduced-score
+  // shortcut: the reduced length is an HTU APPROXIMATION, so a lower reduced score
+  // is necessary but the full-tree gain is realised through reinsertion exactly as
+  // for godrift). Requires >= 2 distinct donors; on converged starts fuse is a
+  // no-op and best-of-starts stands.
+  if (do_fuse && fuse_pool.size() >= 2) {
+    if (kSectDriftStats) {
+      ++g_sect_fuse_tries;
+      if (g_sect_fuse_tries == 1 || (g_sect_fuse_tries % 20) == 0)
+        REprintf("SECT_FUSE tries=%lld wins=%lld (pool=%d)\n",
+                 g_sect_fuse_tries, g_sect_fuse_wins, fuse_pool.size());
+    }
+    // Recipient = best-of-starts (rd.subtree holds it). tree_fuse mutates in place,
+    // so work on a copy and only commit if it wins.
+    TreeState fused = rd.subtree;
+    FuseParams fp;
+    fp.max_rounds = params.sector_fuse_rounds > 0 ? params.sector_fuse_rounds : 1;
+    fp.accept_equal = accept_equal;
+    tree_fuse(fused, rd.data, fuse_pool, fp);
+    reanchor_fused_at_htu(fused, htu_idx);
+
+    // Same root_ok post-condition as the drift path: HTU and sr_mapped must be the
+    // synthetic root's two children (canonicalize guarantees this; guard anyway --
+    // a failure means keep best-of-starts, never reinsert a mis-anchored tree).
+    const int flc = fused.left[root_i], frc = fused.right[root_i];
+    const bool fused_ok = (flc == htu_idx && frc == sr_mapped) ||
+                          (flc == sr_mapped && frc == htu_idx);
+    if (fused_ok) {
+      const double fused_score = score_tree(fused, rd.data);
+      if (fused_score < best_score) {
+        rd.subtree.left = fused.left;
+        rd.subtree.right = fused.right;
+        rd.subtree.parent = fused.parent;
+        rd.subtree.build_postorder();
+        best_score = fused_score;
+        if (kSectDriftStats) {
+          ++g_sect_fuse_wins;
+          if (g_sect_fuse_wins == 1 || (g_sect_fuse_wins % 20) == 0)
+            REprintf("SECT_FUSE tries=%lld wins=%lld\n",
+                     g_sect_fuse_tries, g_sect_fuse_wins);
+        }
+      }
+    }
   }
 
   // D1 SCORING-ONLY CONFIRM (env TS_FREE_HTU_PROBE), NO reinsertion: does an

--- a/src/ts_sector.cpp
+++ b/src/ts_sector.cpp
@@ -6,6 +6,7 @@
 #include "ts_rng.h"
 #include "ts_splits.h"
 #include "ts_pool.h"
+#include "ts_drift.h"
 
 #include <algorithm>
 #include <random>
@@ -999,22 +1000,113 @@ static void build_ras_sector(ReducedDataset& rd, std::mt19937& rng) {
   t.build_postorder();
 }
 
+// ---- TNT-style in-sector drift / combined analysis (godrift/gocomb) ----
+//
+// Small sectors are cheap to solve exhaustively with RAS+TBR; large sectors have
+// more reach but need drift to escape their own local optima. This reuses the
+// engine's drift_search() on the reduced sector dataset, PINNING the HTU pseudo-
+// tip via a content-clade sector_mask (drift_solve_reduced) so every reduced result
+// stays reinsertable -- an UNMASKED drift floats the HTU (re-roots the sector
+// against the rest-of-tree summary) ~80% of the time and is then discarded on
+// revert, which also loses the sector's TBR polish (net-negative). Gated behind
+// sectorGoDrift/sectorGoComb size thresholds. Default OFF; env TS_SECT_DRIFT=0
+// force-disables regardless of params (baseline arm).
+//
+// godrift: solve the sector with a single drift_search per RAS start.
+// gocomb : run `combstarts` HTU-anchored RAS+drift starts and keep the best
+//          (TNT's combined analysis is RAS+drift+FUSE; the fuse recombination
+//          sub-step is DEFERRED — tree_fuse re-roots the reduced tree at tip 0
+//          every round, which drops it out of the (HTU, sr_mapped) synthetic-root
+//          layout that reinsert_sector requires, so a fused result is not
+//          reinsertable without a root-agnostic reinsertion path. Validate
+//          godrift first, then add the fuse step behind that work). Every
+//          candidate kept here stays HTU-anchored, so reinsert_sector is unchanged.
+//
+// The env gates are read via FUNCTION-LOCAL statics inside search_sector (like
+// _free_htu_probe), NOT namespace-scope statics: a namespace-scope dynamic
+// initializer runs at DLL load, before R can Sys.setenv() after library(), so the
+// kill switch / stats would silently ignore an env var set from R. Function-local
+// statics initialise on the first search_sector call, after any Sys.setenv.
+// Engagement instrumentation counters (drift solves / HTU-float reverts). A high
+// revert rate means anchored drift is inert -- the signal that motivates pinning
+// the HTU (sector_mask). The ++ is unsynchronised across parallel workers, which
+// is acceptable for the opt-in serial trajectory-diff run.
+static long long g_sect_drift_solves = 0;
+static long long g_sect_drift_reverts = 0;
+
+// Solve the reduced sector tree with drift in place; return its best score.
+// `content_mask` PINS the HTU: it flags every node in the sector's content clade
+// (real tips + content internals) true and the synthetic root, HTU pseudo-tip, and
+// content-root node false, so drift's internal clips/regrafts stay strictly below
+// sr_mapped and never re-root the reduced tree against the rest-of-tree summary.
+// The reduced result is therefore always reinsertable (root_ok holds) -- unlike an
+// unmasked drift, whose best landing tree floats the HTU ~80% of the time and is
+// then discarded on revert (net-negative, since the fallback lost its TBR polish).
+static double drift_solve_reduced(ReducedDataset& rd, const SectorParams& params,
+                                  std::function<bool()>& check_timeout,
+                                  const std::vector<bool>& content_mask) {
+  DriftParams dp;
+  dp.n_cycles  = params.sector_drift_cycles;
+  dp.afd_limit = params.sector_drift_afd;
+  dp.rfd_limit = params.sector_drift_rfd;
+  dp.max_hits  = params.internal_max_hits;
+  DriftResult dr = drift_search(rd.subtree, rd.data, dp, nullptr, check_timeout,
+                                &content_mask);
+  return dr.best_score;
+}
+
 // Search the reduced dataset and return the best score found.
 // Modifies rd.subtree in place, leaving the best sector topology ready for
 // reinsertion.
 //
-// `ras_starts` = total starts to try. Start 0 is TBR on the EXISTING sector
-// subtree (so ras_starts=1 reproduces the prior single-TBR behaviour exactly,
-// and the existing topology is always a candidate floor). Starts 1.. are
-// HTU-anchored random-addition restarts (RAS+TBR) — TNT's per-sector tactic.
-static double search_sector(ReducedDataset& rd, int ras_starts,
-                            int max_hits, int clip_order,
-                            bool accept_equal, std::mt19937& rng) {
+// `params.ras_starts` = total starts to try. Start 0 is TBR (or drift) on the
+// EXISTING sector subtree (so ras_starts=1 reproduces the prior single-TBR
+// behaviour exactly, and the existing topology is always a candidate floor).
+// Starts 1.. are HTU-anchored random-addition restarts (RAS+TBR) — TNT's
+// per-sector tactic. When the sector is large enough (sectorGoComb/sectorGoDrift),
+// the per-start solver escalates to combined analysis or drift respectively.
+static double search_sector(ReducedDataset& rd, const SectorParams& params,
+                            std::mt19937& rng,
+                            std::function<bool()> check_timeout = nullptr) {
+  int ras_starts        = params.ras_starts;
+  const int max_hits    = params.internal_max_hits;
+  const int clip_order  = params.clip_order;
+  const bool accept_equal = params.accept_equal;
   if (ras_starts < 1) ras_starts = 1;
+
+  // Env gates, read once on first call (function-local -> after any Sys.setenv;
+  // µs-scale ucrt getenv, so not per-pick). TS_SECT_DRIFT=0 force-disables godrift/
+  // gocomb regardless of params (baseline arm); TS_SECT_DRIFT_STATS enables the
+  // drift-solve / HTU-float-revert instrumentation.
+  static const bool kSectDriftForceOff = []{
+    const char* e = std::getenv("TS_SECT_DRIFT");
+    return e != nullptr && e[0] == '0';
+  }();
+  static const bool kSectDriftStats =
+      std::getenv("TS_SECT_DRIFT_STATS") != nullptr;
+
+  // Solve-mode escalation by sector size (real tips, as count_clade_tips
+  // measures max_sector_size). Both godrift and gocomb solve the sector with
+  // drift; gocomb additionally raises the number of RAS+drift starts to
+  // combstarts and takes precedence when both thresholds fire. (gocomb's fuse
+  // recombination sub-step is deferred — see the header note above.)
+  const int nrt = rd.n_real_tips;
+  const bool comb_mode  = !kSectDriftForceOff &&
+                          params.sector_go_comb > 0 && nrt >= params.sector_go_comb;
+  const bool drift_mode = !kSectDriftForceOff && !comb_mode &&
+                          params.sector_go_drift > 0 && nrt >= params.sector_go_drift;
+  const bool use_drift = comb_mode || drift_mode;
+  if (comb_mode && params.sector_comb_starts > ras_starts)
+    ras_starts = params.sector_comb_starts;
   const int htu_idx = rd.n_real_tips;
   const int root = rd.subtree.n_tip;
   const int sr_mapped = rd.full_to_sector[rd.sector_root];
   const int root_i = root - rd.subtree.n_tip;
+
+  // HTU-pinning mask for the drift path, rebuilt per start below (build_ras_sector
+  // reassigns content-internal ids each restart, and sr_mapped's direct children
+  // differ each restart).
+  std::vector<bool> content_mask;
 
   double best_score = 0.0;
   bool have_best = false;
@@ -1035,6 +1127,30 @@ static double search_sector(ReducedDataset& rd, int ras_starts,
       rd.subtree.build_postorder();
     }
 
+    // Rebuild the HTU-pinning mask for this start's topology. Flag the content
+    // clade true EXCEPT the synthetic root, the HTU pseudo-tip, the content root
+    // sr_mapped, AND sr_mapped's two direct children: clipping a direct child of
+    // sr_mapped splices sr_mapped out of the backbone (floats the HTU), so those
+    // two nodes are barred from clips/regrafts. Everything deeper still rearranges
+    // freely, including moves between the two halves. This cuts the HTU-float
+    // (root_ok=false -> reverted) rate from ~80% (unmasked) to ~10-15%: the
+    // residual is drift MID-SEARCH splicing a grandchild so that a fresh, still-
+    // masked node becomes sr_mapped's child, which a per-start static mask can't
+    // pre-exclude. Fully closing it needs a dynamic parent-in-mask clip gate in
+    // tbr_search/drift_phase, whose mask is shared with css_search (clade root IN
+    // its mask) -> deferred to avoid changing css semantics. Residual reverts are
+    // safe (fall back to the anchored pre-drift topology; the root_ok check below
+    // still guards reinsertion).
+    if (use_drift) {
+      content_mask.assign(rd.subtree.n_node, true);
+      content_mask[htu_idx] = false;
+      content_mask[root] = false;                     // synthetic root (new_root)
+      content_mask[sr_mapped] = false;                // content root
+      const int sr_i = sr_mapped - rd.subtree.n_tip;
+      content_mask[rd.subtree.left[sr_i]] = false;    // sr_mapped's children:
+      content_mask[rd.subtree.right[sr_i]] = false;   // barred to keep sr_mapped
+    }
+
     // Snapshot the (valid, HTU-anchored) pre-TBR topology for revert.
     auto save_left = rd.subtree.left;
     auto save_right = rd.subtree.right;
@@ -1042,41 +1158,60 @@ static double search_sector(ReducedDataset& rd, int ras_starts,
 
     double original_score = score_tree(rd.subtree, rd.data);
 
-    TBRParams tp;
-    tp.max_hits = max_hits;
-    tp.clip_order = static_cast<ClipOrder>(clip_order);
-    // Let the sector RE-SOLVE itself walk equal-length plateaus (TNT `equals`:
-    // "accept equally good subtrees"), holding up to max_hits (sectorMaxHits)
-    // equal trees.  Without this the only equal-move path was a coincidental
-    // RAS-restart tie, which never fires on large sectors -> accept_equal inert
-    // there.  best_score is unchanged (equal moves never worsen it); only the
-    // returned topology differs, so reinsert can take the lateral step.
-    tp.accept_equal = accept_equal;
-    TBRResult tr = tbr_search(rd.subtree, rd.data, tp);
+    // Solve the sector. Large sectors (>= sectorGoDrift/sectorGoComb) escalate to
+    // drift to escape their own local optima (TNT `godrift`); otherwise RAS+TBR.
+    double solved_score;
+    if (use_drift) {
+      solved_score = drift_solve_reduced(rd, params, check_timeout, content_mask);
+    } else {
+      TBRParams tp;
+      tp.max_hits = max_hits;
+      tp.clip_order = static_cast<ClipOrder>(clip_order);
+      // Let the sector RE-SOLVE itself walk equal-length plateaus (TNT `equals`:
+      // "accept equally good subtrees"), holding up to max_hits (sectorMaxHits)
+      // equal trees.  Without this the only equal-move path was a coincidental
+      // RAS-restart tie, which never fires on large sectors -> accept_equal inert
+      // there.  best_score is unchanged (equal moves never worsen it); only the
+      // returned topology differs, so reinsert can take the lateral step.
+      tp.accept_equal = accept_equal;
+      TBRResult tr = tbr_search(rd.subtree, rd.data, tp);
+      solved_score = tr.best_score;
+    }
 
     // Verify root structure: HTU and sector_root_mapped must remain direct
-    // children of the synthetic root. TBR can regraft onto root edges,
+    // children of the synthetic root. TBR/drift can regraft onto root edges,
     // displacing nodes outside the clade — if so the reduced result is
-    // unusable for reinsertion; revert to the (valid) pre-TBR topology.
+    // unusable for reinsertion; revert to the (valid) pre-solve topology.
     int root_lc = rd.subtree.left[root_i];
     int root_rc = rd.subtree.right[root_i];
     bool root_ok = (root_lc == htu_idx && root_rc == sr_mapped) ||
                    (root_lc == sr_mapped && root_rc == htu_idx);
 
+    // Engagement instrumentation (env TS_SECT_DRIFT_STATS): drift-solve count and
+    // HTU-float revert count. A high revert rate means anchored drift is inert.
+    if (use_drift && kSectDriftStats) {
+      ++g_sect_drift_solves;
+      if (!root_ok) ++g_sect_drift_reverts;
+      if (g_sect_drift_solves == 1 || (g_sect_drift_solves % 20) == 0)
+        REprintf("SECT_DRIFT solves=%lld reverts=%lld (%.1f%%)\n",
+                 g_sect_drift_solves, g_sect_drift_reverts,
+                 100.0 * g_sect_drift_reverts / g_sect_drift_solves);
+    }
+
     // --- D1 warm test (env TS_FREE_HTU_PROBE): isolate the root_ok revert. ---
-    // root_ok=false means TBR's best reduced move FLOATS the HTU (re-roots the
-    // sector against the rest of the tree) -- the move discarded at the revert
+    // root_ok=false means the reduced solve's best move FLOATS the HTU (re-roots
+    // the sector against the rest of the tree) -- the move discarded at the revert
     // below.  By the reduced = full - const invariance (const = rest-of-tree
     // standalone downpass length, independent of how the sector re-roots),
-    // tr.best_score < original_score with root_ok=false PROVES a strictly
+    // solved_score < original_score with root_ok=false PROVES a strictly
     // shorter FULL tree the anchored sectorial throws away.  GUARD: also reports
     // root_ok, so a null can be told apart from "TBR never floats the HTU"
     // (false-negative).  Run rasStarts=1 -> this is the warm T0 sector start.
     if (_free_htu_probe) {
       REprintf("REVERT sect=%d S=%d s=%d orig=%.0f tbr=%.0f root_ok=%d %s\n",
-               rd.sector_root, rd.n_real_tips, s, original_score, tr.best_score,
+               rd.sector_root, rd.n_real_tips, s, original_score, solved_score,
                root_ok ? 1 : 0,
-               (!root_ok && tr.best_score < original_score) ? "<<FLOAT-IMPROVES" : "");
+               (!root_ok && solved_score < original_score) ? "<<FLOAT-IMPROVES" : "");
     }
 
     double this_score;
@@ -1087,7 +1222,7 @@ static double search_sector(ReducedDataset& rd, int ras_starts,
       rd.subtree.build_postorder();
       this_score = original_score;
     } else {
-      this_score = tr.best_score;
+      this_score = solved_score;
     }
 
     // Strictly-better always wins. With accept_equal, an equal-length RAS
@@ -1370,9 +1505,7 @@ SectorResult rss_search(TreeState& tree, DataSet& ds,
     double sector_current = score_tree(rd.subtree, rd.data);
 
     // Search the sector
-    double sector_best = search_sector(rd, params.ras_starts,
-                                       params.internal_max_hits, params.clip_order,
-                                       params.accept_equal, rng);
+    double sector_best = search_sector(rd, params, rng, check_timeout);
     ++result.n_sectors_searched;
     // Propagate reduced-dataset candidates to the parent (diagnostics).
     ds.n_candidates_evaluated += rd.data.n_candidates_evaluated - sector_cand0;
@@ -1544,9 +1677,7 @@ SectorResult xss_search(TreeState& tree, DataSet& ds,
       const long long sector_cand0 = rd.data.n_candidates_evaluated;
 
       double sector_current = score_tree(rd.subtree, rd.data);
-      double sector_best = search_sector(
-          rd, params.ras_starts, params.internal_max_hits,
-          params.clip_order, params.accept_equal, rng);
+      double sector_best = search_sector(rd, params, rng, check_timeout);
       ++result.n_sectors_searched;
       // Propagate reduced-dataset candidates to the parent (diagnostics).
       ds.n_candidates_evaluated += rd.data.n_candidates_evaluated - sector_cand0;

--- a/src/ts_sector.h
+++ b/src/ts_sector.h
@@ -34,6 +34,30 @@ struct SectorParams {
                                  // into ~this many composite first-pass terminals
                                  // (Goloboff 1999 coarse-grained sector). 0 = off.
 
+  // TNT-style in-sector drifting / combined analysis for LARGE sectors.
+  // Small sectors are cheap to solve with RAS+TBR; big sectors have more reach
+  // but need drift/combined to escape their own local optima (TNT `sectsch`
+  // godrift/gocomb/drift/gocomb/combstarts). Thresholds are measured against the
+  // sector's real-tip count (n_real_tips), matching how max_sector_size is
+  // measured (count_clade_tips). Both default 0 = off (RAS+TBR only).
+  int sector_go_drift = 0;       // solve sectors with >= this many real tips by
+                                 // drift_search instead of plain RAS+TBR (TNT
+                                 // `godrift N`). 0 = off.
+  int sector_go_comb = 0;        // solve sectors with >= this many real tips by
+                                 // COMBINED analysis (TNT `gocomb N`): here,
+                                 // sector_comb_starts RAS+drift starts, keep best.
+                                 // (TNT also fuses the starts; that fuse sub-step
+                                 // is deferred — see ts_sector.cpp header note.)
+                                 // Takes precedence over go_drift. 0 = off.
+  int sector_drift_cycles = 5;   // drift cycles for drifted/combined sectors
+                                 // (TNT `drift N`).
+  int sector_drift_afd = 3;      // AFD limit for in-sector drift (steps).
+  double sector_drift_rfd = 0.1; // RFD limit for in-sector drift.
+  int sector_comb_starts = 3;    // RAS+drift starts per combined sector, keep
+                                 // best (TNT `combstarts N`).
+  int sector_fuse_rounds = 3;    // reserved for the deferred combined-analysis
+                                 // fuse sub-step (TNT `fuse F`); currently unused.
+
   // Conflict-guided sector selection.
   // When non-null, RSS uses weighted random selection that biases toward
   // sectors containing splits absent from the pool consensus.


### PR DESCRIPTION
## What

Adds TNT `sectsch godrift`/`gocomb` in-sector drifting for large sectorial sub-problems, behind two new size thresholds (`sectorGoDrift`, `sectorGoComb`), **default-OFF** — every current search is byte-identical.

- Sectors with `>= sectorGoDrift` real tips are re-solved by tree-drifting instead of plain RAS+TBR.
- Sectors with `>= sectorGoComb` run `sectorCombStarts` RAS+drift starts, keep-best (`gocomb` takes precedence when both fire).
- Reuses the existing `drift_search`; no new scoring code.

## Why

Large sectors have more reach but get stuck in their own local optima under RAS+TBR (TNT's motivation for `godrift`). This is a candidate reach lever from the TNT feature-gap audit.

## Anchoring fix (the interesting part)

An *unmasked* drift on the HTU-anchored reduced sector tree floats the HTU (re-roots the sector against the rest of the tree) in ~80% of solves; the existing root-structure check then reverts those to a **non-TBR'd** topology → net-negative. Fixed by threading an optional `sector_mask` through `drift_search → drift_phase` and its internal `tbr_search` calls (additive, default `nullptr`; top-level `driven_search` drift is unaffected). `search_sector` pins the synthetic root, HTU, content root and its two children per RAS start, cutting the HTU-float revert rate **~80% → ~12%**. Residual reverts stay safe via the existing `root_ok` check.

## Validation

Hamilton matched-wall A/B (SLURM 17832946): 4 EW sector-resolve datasets × 5 seeds, `rasStarts=3` both arms, `sectorMaxSize=80`. Pinned godrift **wins-or-ties every dataset with zero regressions** for 3-cycle arms; gains concentrate on hard data (Zanol2014 −2.4..−4.0, Zhu2013 −1.0..−1.6), easy data ties. Harness: `dev/benchmarks/sector_drift_ab.R`.

## Scope / follow-ups

- **Opt-in only.** The recipe-**default** flip is deliberately *not* in this PR: the validated config depends on `rasStarts>=3`, which no preset runs (`thorough` is `rasStarts=1`), so enabling in a preset would ship an untested combination. That flip is gated on a separate preset-level (rasStarts-matched) A/B.
- The `gocomb` **fuse** recombination sub-step is deferred (`sectorFuseRounds` reserved/unused) — coming as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)