### PR TITLE
feat(sector): implement the gocomb fuse recombination sub-step (default-off)

### DIFF
--- a/R/SearchControl.R
+++ b/R/SearchControl.R
@@ -99,11 +99,11 @@
 #'   `godrift`/`gocomb`.  Small sectors are cheap to optimise exhaustively; large
 #'   sectors have more reach but need drift to escape their own local optima.
 #'   `sectorGoComb` solves the sector with `sectorCombStarts` \acronym{RAS}+drift
-#'   starts, keeping the best (\acronym{TNT}'s combined analysis also *fuses* the
-#'   starts; that recombination sub-step is not yet implemented).  `sectorGoComb`
-#'   takes precedence when both trigger.  `0` (default) disables each, leaving all
-#'   sectors on \acronym{RAS}+\acronym{TBR}.  To exercise these, also raise
-#'   `sectorMaxSize` so large sectors are selected.
+#'   starts and then *fuses* them (recombines shared clades across the starts over
+#'   `sectorFuseRounds` rounds), keeping the fused tree only if it beats the best
+#'   start.  `sectorGoComb` takes precedence when both trigger.  `0` (default)
+#'   disables each, leaving all sectors on \acronym{RAS}+\acronym{TBR}.  To
+#'   exercise these, also raise `sectorMaxSize` so large sectors are selected.
 #' @param sectorDriftCycles Integer; drift cycles used when a sector is solved by
 #'   drift or combined analysis (\acronym{TNT} `drift`).
 #' @param sectorDriftAfd Integer; absolute-fit-difference limit (steps) for
@@ -112,8 +112,8 @@
 #'   drift.
 #' @param sectorCombStarts Integer; \acronym{RAS}+drift starts per combined
 #'   sector (\acronym{TNT} `combstarts`).
-#' @param sectorFuseRounds Integer; reserved for the deferred combined-analysis
-#'   fuse sub-step (\acronym{TNT} `fuse`); currently unused.
+#' @param sectorFuseRounds Integer; max fuse rounds for the combined-analysis
+#'   recombination sub-step (\acronym{TNT} `fuse`).
 #' @param postRatchetSectorial Logical; when `TRUE`, run XSS+RSS+CSS again
 #'   after ratchet perturbation using the same round counts.  Approximates
 #'   TNT's interleaved sectorial pattern.  Default: `FALSE`.

--- a/dev/benchmarks/sector_fuse_ab.R
+++ b/dev/benchmarks/sector_fuse_ab.R
@@ -1,0 +1,81 @@
+#!/usr/bin/env Rscript
+# Matched-wall A/B isolating the MARGINAL value of the gocomb FUSE sub-step over
+# drift-only combined analysis. Pre-committed decision rule (set BEFORE running, to
+# avoid open-ended tuning -- cf. the auto-tuner NO-GO):
+#   * fuse arm moves the anytime curve below its matched drift-only arm (lower score
+#     at equal wall, no dataset regressing) -> KEEP gocomb-fuse opt-in.
+#   * fuse arm ties/does-not-improve its drift-only arm -> mechanism stays IN,
+#     default-OFF, documented "implemented, no measured benefit over drift-only".
+# Given pool>=2 is ~1/20 comb solves locally (RAS+drift starts converge), the tie
+# outcome is the expectation, not a surprise.
+#
+# The comparison is clean regardless of engagement: within a combStarts level the
+# fuse/drift arms are IDENTICAL except TS_SECT_FUSE, so any delta is fuse alone.
+# Two combStarts levels (3, 6): more starts -> more start-diversity -> more chances
+# for fuse to find >=2 distinct donors, at higher per-sector cost (matched wall
+# absorbs the cost -> the anytime curve is the honest judge).
+#
+# Hamilton SLURM array, one cell per (dataset x seed x arm). No %throttle.
+# Env per arm sets TS_SECT_FUSE / TS_SECT_DRIFT; rasStarts=3 in ALL arms.
+# Usage (one array cell): Rscript sector_fuse_ab.R <cell_index>
+suppressMessages({ library("TreeTools"); library("TreeSearch", lib.loc = Sys.getenv("TS_LIB")) })
+
+datasets <- c("Zanol2014", "Zhu2013", "Wortley2006", "Giles2015")  # sector-resolve corpus
+seeds    <- 1:5
+# arm: goComb (0 => base/off), combStarts, fuse (TS_SECT_FUSE), forceOff (TS_SECT_DRIFT=0)
+arms <- rbind(
+  data.frame(name = "base",           goComb =  0L, combStarts = 3L, fuse = FALSE, forceOff = TRUE),
+  data.frame(name = "comb_drift_s3",  goComb = 30L, combStarts = 3L, fuse = FALSE, forceOff = FALSE),
+  data.frame(name = "comb_fuse_s3",   goComb = 30L, combStarts = 3L, fuse = TRUE,  forceOff = FALSE),
+  data.frame(name = "comb_drift_s6",  goComb = 30L, combStarts = 6L, fuse = FALSE, forceOff = FALSE),
+  data.frame(name = "comb_fuse_s6",   goComb = 30L, combStarts = 6L, fuse = TRUE,  forceOff = FALSE)
+)
+grid <- expand.grid(dataset = datasets, seed = seeds, arm = seq_len(nrow(arms)),
+                    KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE)
+
+cell <- as.integer(commandArgs(trailingOnly = TRUE)[[1]])
+stopifnot(cell >= 1L, cell <= nrow(grid))
+g   <- grid[cell, ]
+arm <- arms[g$arm, ]
+
+dat <- ReadAsPhyDat(file.path("data-raw", paste0(g$dataset, ".nex")))
+
+ctrl <- SearchControl(
+  xssRounds = 3L, rssRounds = 2L, cssRounds = 0L,
+  sectorMinSize = 6L, sectorMaxSize = 80L,   # large sectors allowed in all arms
+  rasStarts = 3L,
+  sectorGoComb = arm$goComb, sectorCombStarts = arm$combStarts,
+  sectorDriftCycles = 3L, sectorFuseRounds = 3L
+)
+
+# Env gates: force-off drift in base; disable only the fuse step in the drift arms.
+if (isTRUE(arm$forceOff)) Sys.setenv(TS_SECT_DRIFT = "0") else Sys.unsetenv("TS_SECT_DRIFT")
+if (isTRUE(arm$fuse)) Sys.unsetenv("TS_SECT_FUSE") else Sys.setenv(TS_SECT_FUSE = "0")
+set.seed(g$seed)
+
+traj <- list()
+cb <- function(info) {
+  traj[[length(traj) + 1L]] <<- data.frame(t = as.double(info$elapsed),
+                                            score = as.double(info$best_score))
+  invisible(TRUE)
+}
+t0 <- Sys.time()
+tr <- MaximizeParsimony(dat, maxReplicates = 200L, maxSeconds = 90,
+                        nThreads = 1L, verbosity = 0L, strategy = "none",
+                        control = ctrl, progressCallback = cb)
+wall <- as.double(difftime(Sys.time(), t0, units = "secs"))
+
+out <- data.frame(cell = cell, dataset = g$dataset, seed = g$seed,
+                  arm = arm$name, goComb = arm$goComb, combStarts = arm$combStarts,
+                  fuse = arm$fuse, final_score = attr(tr, "score")[1], wall = wall)
+outDir <- Sys.getenv("AB_OUT", "dev/benchmarks/sector_fuse/out")
+dir.create(outDir, showWarnings = FALSE, recursive = TRUE)
+write.csv(out, file.path(outDir, sprintf("cell_%03d_%s_s%d_%s.csv",
+          cell, g$dataset, g$seed, arm$name)), row.names = FALSE)
+if (length(traj)) {
+  tj <- do.call(rbind, traj); tj$cell <- cell; tj$arm <- arm$name
+  write.csv(tj, file.path(outDir, sprintf("traj_%03d_%s_s%d_%s.csv",
+            cell, g$dataset, g$seed, arm$name)), row.names = FALSE)
+}
+cat(sprintf("cell %d %s s%d [%s] final=%.1f wall=%.1fs\n",
+            cell, g$dataset, g$seed, arm$name, out$final_score, wall))

--- a/src/ts_sector.cpp
+++ b/src/ts_sector.cpp
@@ -7,6 +7,7 @@
 #include "ts_splits.h"
 #include "ts_pool.h"
 #include "ts_drift.h"
+#include "ts_fuse.h"
 
 #include <algorithm>
 #include <random>
@@ -1013,14 +1014,15 @@ static void build_ras_sector(ReducedDataset& rd, std::mt19937& rng) {
 // force-disables regardless of params (baseline arm).
 //
 // godrift: solve the sector with a single drift_search per RAS start.
-// gocomb : run `combstarts` HTU-anchored RAS+drift starts and keep the best
-//          (TNT's combined analysis is RAS+drift+FUSE; the fuse recombination
-//          sub-step is DEFERRED — tree_fuse re-roots the reduced tree at tip 0
-//          every round, which drops it out of the (HTU, sr_mapped) synthetic-root
-//          layout that reinsert_sector requires, so a fused result is not
-//          reinsertable without a root-agnostic reinsertion path. Validate
-//          godrift first, then add the fuse step behind that work). Every
-//          candidate kept here stays HTU-anchored, so reinsert_sector is unchanged.
+// gocomb : run `combstarts` HTU-anchored RAS+drift starts, then FUSE them (TNT's
+//          combined analysis = RAS+drift+fuse). tree_fuse re-roots the reduced
+//          tree at tip 0, dropping the (HTU, sr_mapped) synthetic-root layout
+//          reinsert_sector needs; reanchor_fused_at_htu re-roots the fused tree
+//          at the HTU (rooting-invariance) so it is reinsertable whenever fuse
+//          left the HTU on the sector boundary. The fused tree is accepted only
+//          if it beats the best
+//          start, through the same root_ok gate + reinsert path as the drift
+//          starts. Env TS_SECT_FUSE=0 disables the fuse step (drift-only comb).
 //
 // The env gates are read via FUNCTION-LOCAL statics inside search_sector (like
 // _free_htu_probe), NOT namespace-scope statics: a namespace-scope dynamic
@@ -1055,6 +1057,37 @@ static double drift_solve_reduced(ReducedDataset& rd, const SectorParams& params
   return dr.best_score;
 }
 
+// gocomb-fuse engagement counters (env TS_SECT_DRIFT_STATS): fused sectors
+// tried / fused sectors that improved on the best RAS+drift start.
+static long long g_sect_fuse_tries = 0;
+static long long g_sect_fuse_wins  = 0;
+
+// Re-anchor a FUSED reduced sector tree so reinsert_sector can use it.
+//
+// tree_fuse combines the RAS+drift starts over the full reduced tip set
+// (including the HTU pseudo-tip) and re-roots at tip 0, so the result is NOT in
+// the (HTU, sr_mapped) synthetic-root layout reinsert_sector requires. Parsimony
+// is rooting-invariant, so we simply re-root the fused tree at the HTU pseudo-tip:
+// the HTU represents the rest of the tree at the sector boundary, so it stays
+// structurally adjacent to the content root -- re-rooting at it makes its sibling
+// the whole non-HTU clade (the sector arrangement as seen "hanging from the rest-
+// of-tree direction"), exactly the clade reinsert_sector grafts back.
+//
+// Whenever fuse leaves the HTU on the sector boundary -- the common case, since
+// fuse never exchanges the trivial {HTU} split and its interior TBR does not
+// regraft a lone boundary pseudo-tip -- the content clade stays rooted at node id
+// sr_mapped, so the root's children are {HTU, sr_mapped} and the caller's root_ok
+// check accepts the tree. In the rare case fuse floats the HTU into the interior
+// (the same move the drift path deliberately reverts), the content root would
+// carry a different id, root_ok fails, and the caller keeps the best RAS+drift
+// start. So a fused tree is reinserted only when its id mapping is already valid
+// -- never via a speculative relabel (empirically the float case never occurs; a
+// permutation-remap to force it was implemented, found unreachable, and removed).
+static void reanchor_fused_at_htu(TreeState& t, int htu_idx) {
+  reroot_at_tip(t, htu_idx);   // root's children now {htu_idx, content root}
+  t.build_postorder();
+}
+
 // Search the reduced dataset and return the best score found.
 // Modifies rd.subtree in place, leaving the best sector topology ready for
 // reinsertion.
@@ -1084,6 +1117,13 @@ static double search_sector(ReducedDataset& rd, const SectorParams& params,
   }();
   static const bool kSectDriftStats =
       std::getenv("TS_SECT_DRIFT_STATS") != nullptr;
+  // TS_SECT_FUSE=0 disables ONLY the gocomb fuse recombination sub-step, leaving
+  // the RAS+drift keep-best comb behaviour intact -- isolates fuse's contribution
+  // in the A/B (gocomb-with-fuse vs gocomb-drift-only).
+  static const bool kSectFuseOff = []{
+    const char* e = std::getenv("TS_SECT_FUSE");
+    return e != nullptr && e[0] == '0';
+  }();
 
   // Solve-mode escalation by sector size (real tips, as count_clade_tips
   // measures max_sector_size). Both godrift and gocomb solve the sector with
@@ -1111,6 +1151,12 @@ static double search_sector(ReducedDataset& rd, const SectorParams& params,
   double best_score = 0.0;
   bool have_best = false;
   std::vector<int> best_left, best_right, best_parent;
+
+  // gocomb fuse: collect the valid (HTU-anchored) per-start topologies so they
+  // can be recombined after the loop (TNT combined analysis = RAS+drift+FUSE).
+  // Only populated in comb_mode with fuse enabled; the pool dedups by split hash.
+  const bool do_fuse = comb_mode && !kSectFuseOff;
+  TreePool fuse_pool(ras_starts + 1);
 
   // search_sector runs once per sector pick (1000s of times/search). std::getenv
   // is µs-scale on Windows/ucrt (linear env scan), so the per-pick D1-probe gate
@@ -1249,6 +1295,12 @@ static double search_sector(ReducedDataset& rd, const SectorParams& params,
         have_best = true;
       }
     }
+
+    // Stash this start's (valid, HTU-anchored) topology as a fuse donor. Whatever
+    // rd.subtree holds now is reinsertable -- either the solved tree (root_ok) or
+    // the reverted pre-solve one -- so every donor is a legitimate recombination
+    // input. The pool dedups identical starts by split hash.
+    if (do_fuse) fuse_pool.add(rd.subtree, this_score);
   }
 
   // Restore the best topology found across starts, ready for reinsertion.
@@ -1258,6 +1310,58 @@ static double search_sector(ReducedDataset& rd, const SectorParams& params,
     rd.subtree.right = best_right;
     rd.subtree.parent = best_parent;
     rd.subtree.build_postorder();
+  }
+
+  // gocomb FUSE (TNT combined analysis): recombine the RAS+drift starts. With the
+  // best start as recipient, tree_fuse exchanges shared clades from the other
+  // starts (and runs a cleanup TBR) -- reaching arrangements no single start held,
+  // INCLUDING ones that float the HTU (its interior TBR is unmasked). We re-anchor
+  // the fused tree at the HTU (reanchor_fused_at_htu) so it is reinsertable when
+  // fuse kept the HTU on the boundary, then accept it only if it beats the best
+  // start -- and only via the SAME reduced
+  // score + root_ok gate + reinsert path as the drift starts (no reduced-score
+  // shortcut: the reduced length is an HTU APPROXIMATION, so a lower reduced score
+  // is necessary but the full-tree gain is realised through reinsertion exactly as
+  // for godrift). Requires >= 2 distinct donors; on converged starts fuse is a
+  // no-op and best-of-starts stands.
+  if (do_fuse && fuse_pool.size() >= 2) {
+    if (kSectDriftStats) {
+      ++g_sect_fuse_tries;
+      if (g_sect_fuse_tries == 1 || (g_sect_fuse_tries % 20) == 0)
+        REprintf("SECT_FUSE tries=%lld wins=%lld (pool=%d)\n",
+                 g_sect_fuse_tries, g_sect_fuse_wins, fuse_pool.size());
+    }
+    // Recipient = best-of-starts (rd.subtree holds it). tree_fuse mutates in place,
+    // so work on a copy and only commit if it wins.
+    TreeState fused = rd.subtree;
+    FuseParams fp;
+    fp.max_rounds = params.sector_fuse_rounds > 0 ? params.sector_fuse_rounds : 1;
+    fp.accept_equal = accept_equal;
+    tree_fuse(fused, rd.data, fuse_pool, fp);
+    reanchor_fused_at_htu(fused, htu_idx);
+
+    // Same root_ok post-condition as the drift path: HTU and sr_mapped must be the
+    // synthetic root's two children (canonicalize guarantees this; guard anyway --
+    // a failure means keep best-of-starts, never reinsert a mis-anchored tree).
+    const int flc = fused.left[root_i], frc = fused.right[root_i];
+    const bool fused_ok = (flc == htu_idx && frc == sr_mapped) ||
+                          (flc == sr_mapped && frc == htu_idx);
+    if (fused_ok) {
+      const double fused_score = score_tree(fused, rd.data);
+      if (fused_score < best_score) {
+        rd.subtree.left = fused.left;
+        rd.subtree.right = fused.right;
+        rd.subtree.parent = fused.parent;
+        rd.subtree.build_postorder();
+        best_score = fused_score;
+        if (kSectDriftStats) {
+          ++g_sect_fuse_wins;
+          if (g_sect_fuse_wins == 1 || (g_sect_fuse_wins % 20) == 0)
+            REprintf("SECT_FUSE tries=%lld wins=%lld\n",
+                     g_sect_fuse_tries, g_sect_fuse_wins);
+        }
+      }
+    }
   }
 
   // D1 SCORING-ONLY CONFIRM (env TS_FREE_HTU_PROBE), NO reinsertion: does an


### PR DESCRIPTION
Stacks on #266 (base is that branch, so this diff is just the fuse commit — retarget to `cpp-search` once #266 merges).

## What

Completes TNT combined analysis for large sectors: after the `sectorCombStarts` RAS+drift starts, recombine them with `tree_fuse` (best start = recipient, the others as donors) and keep the fused tree **only if it beats every start**. Previously `gocomb` was RAS+drift keep-best; the fuse step was deferred because `tree_fuse` re-roots the reduced tree at tip 0, dropping the `(HTU, sr_mapped)` synthetic-root layout `reinsert_sector` needs.

## Re-anchoring (the deferral obstacle, resolved)

Parsimony is rooting-invariant, and the HTU pseudo-tip represents the rest of the tree at the sector boundary — so it stays structurally adjacent to the content root. `reanchor_fused_at_htu` just re-roots the fused tree at the HTU (reusing ts_tbr's existing `reroot_at_tip`); its sibling is then the whole non-HTU clade, with the content still rooted at `sr_mapped`. The existing `root_ok` gate accepts it, and the fused tree is reinserted through the **same** gate + path as the drift starts (no reduced-score shortcut). If fuse ever floats the HTU into the interior — the move the drift path already reverts — `root_ok` fails and the best RAS+drift start stands, so a fused tree is reinserted only when its id mapping is already valid. An initial permutation-remap for the float case was implemented, found empirically unreachable, and removed to keep untested pointer surgery out of the merge.

## Validation

- **Correctness (local, Zanol 74t + Giles 78t — the wps≥2 / fuse-reroot regime):** fuse fires and wins, and every reinserted tree's C++ score equals an independent by-label `TreeLength`.
- **Marginal A/B (Hamilton 17833725, 100 cells, matched-wall, rasStarts=3):** fuse adds **no** measured benefit over drift-only — `comb_fuse − comb_drift` = +0.00 (1/18/1) at combStarts=3, −0.15 (4/14/2) at combStarts=6. The drift path carries the whole gain (`comb_drift − base` = −1.55). Cause: fuse gets ≥2 distinct donors only ~1/20 comb solves — the RAS+drift starts converge, so there is usually nothing to recombine.

## Scope

**Default-OFF** (needs `sectorGoComb > 0`); env `TS_SECT_FUSE=0` disables only the fuse step. Landed for TNT combined-analysis parity / completeness — **not** a wall-clock lever, and deliberately not enabled in any recipe. The wall-clock lever is godrift (#266). Reuses `tree_fuse` and `reroot_at_tip`; no new scoring code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)