### PR TITLE
CI: clear the three check blockers + fix a covr-fragile stopPatience assertion

### DIFF
--- a/R/MaximizeParsimony.R
+++ b/R/MaximizeParsimony.R
@@ -867,6 +867,13 @@
 #' the true optimum, so reporting them would look like erratic progress.  Any
 #' score the heartbeat prints is therefore directly comparable with the final
 #' tree score.
+#' @param .rung Internal.  Pins a named entry of the effort ladder
+#'   (`"sprint"`, `"default"`, `"thorough"`, `"large"`), or `"none"` to apply no
+#'   preset at all; `NULL` (default) selects the rung from `effort` and the
+#'   dataset's size, which is what every ordinary call should do.  Exists for
+#'   controlled experiments and the preset smoke tests, which need to name a rung
+#'   absolutely rather than relative to the automatic choice.  Not part of the
+#'   stable interface: prefer `effort`.
 #' @param control A [`SearchControl`] object (or a named list) of low-level
 #'   search parameters.  Most users can rely on `effort` and
 #'   ignore this argument; see [`SearchControl()`] for full documentation

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -40,7 +40,6 @@ MaddisonSlatkin_clear_cache <- function() {
 #' @param nj Integer vector giving the block sizes of the second partition
 #'   (also summing to `N`).
 #' @return The expected mutual information, in bits.
-#' @references \insertAllCited{}
 #' @seealso [`SiteConcordance`]
 #' @examples
 #' # Expected MI between a 3|4 split and a 2|5 split of 7 items:

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -191,6 +191,7 @@ XPIWE
 XSS
 YU
 ZANOL
+Zanol
 Zoologica
 abcd
 ac

--- a/man/MaximizeParsimony.Rd
+++ b/man/MaximizeParsimony.Rd
@@ -317,6 +317,14 @@ collapse, so an enforced-but-unsupported clade (a zero-length branch) stays
 visible (a constraint encodes external evidence the matrix does not
 capture); unsupported non-constraint branches still collapse.}
 
+\item{.rung}{Internal.  Pins a named entry of the effort ladder
+(\code{"sprint"}, \code{"default"}, \code{"thorough"}, \code{"large"}), or \code{"none"} to apply no
+preset at all; \code{NULL} (default) selects the rung from \code{effort} and the
+dataset's size, which is what every ordinary call should do.  Exists for
+controlled experiments and the preset smoke tests, which need to name a rung
+absolutely rather than relative to the automatic choice.  Not part of the
+stable interface: prefer \code{effort}.}
+
 \item{...}{Backward compatibility.}
 }
 \value{

--- a/man/expected_mi.Rd
+++ b/man/expected_mi.Rd
@@ -35,9 +35,6 @@ the hypergeometric distribution of cell overlaps, and is returned in bits
 # Expected MI between a 3|4 split and a 2|5 split of 7 items:
 expected_mi(c(3L, 4L), c(2L, 5L))
 }
-\references{
-\insertAllCited{}
-}
 \seealso{
 \code{\link{SiteConcordance}}
 }

--- a/src/expected_mi.cpp
+++ b/src/expected_mi.cpp
@@ -47,7 +47,6 @@ inline double l2factorial(int n) {
 //' @param nj Integer vector giving the block sizes of the second partition
 //'   (also summing to `N`).
 //' @return The expected mutual information, in bits.
-//' @references \insertAllCited{}
 //' @seealso [`SiteConcordance`]
 //' @examples
 //' # Expected MI between a 3|4 split and a 2|5 split of 7 items:

--- a/tests/testthat/test-stop-patience.R
+++ b/tests/testthat/test-stop-patience.R
@@ -124,7 +124,19 @@ test_that("stopPatience also stops the parallel search", {
   expect_equal(attr(full, "replicates"), cap)      # nothing else ends the search
   expect_lt(attr(short, "replicates"), cap)
   expect_true(attr(short, "perturb_stop"))
-  expect_equal(min(attr(short, "score")), min(attr(full, "score")))
+  # Deliberately NOT `expect_equal(short score, full score)`.  That assertion held on
+  # this matrix but is not a property the rule guarantees, and it broke under covr:
+  # instrumentation slows every replicate, the parallel path evaluates the dry spell on a
+  # 200 ms monitor poll over replicates completed into the shared pool, so far fewer
+  # replicates land per poll and patience 3 fires genuinely earlier in the search
+  # (13.063 against 12.988).  Stopping sooner is *allowed* to cost score -- that is the
+  # trade-off the parameter exists to offer -- so equality was asserting a coincidence of
+  # this machine's timing.  What the rule does guarantee is asserted above: the search
+  # stops before the cap, and it stops for the no-improvement reason.  The score is only
+  # checked for being a valid, finite improvement over a random start, which holds at any
+  # speed.  See [[parallel-stop-rules-poll-granularity]].
+  expect_true(is.finite(min(attr(short, "score"))))
+  expect_lt(min(attr(short, "score")), min(attr(full, "score")) * 1.5)
 })
 
 # ---- the shipped implied-weights operating point --------------------------------------------


### PR DESCRIPTION
Clears `R CMD check` to `Status: OK` on `cpp-search`, which let **Wave 2 (covr + macOS) run for the first time**, and then fixes the one test the coverage wave caught.

## Check blockers (commit `21b08006`)

| Level | Cause | Fix |
|---|---|---|
| ERROR | `spelling::spell_check_package()` — 9 unlisted words | `inst/WORDLIST` additions; `erroring` reworded to `throwing an error` (it isn't a word) |
| WARNING | `.rung` undocumented in `MaximizeParsimony()` | `@param .rung` block marking it internal, pointing users at `effort` |
| NOTE | empty `\references` in `man/expected_mi.Rd` | dropped the `\insertAllCited{}` tag from `src/expected_mi.cpp` — it cited nothing |

The `expected_mi.Rd` fix also ends the repeated regeneration churn in that file, since the empty section was being re-emitted on every roxygen run.

## The coverage-wave failure (follow-up commit)

Wave 2's first run went red on `windows-latest (release)` step 9. Under `covr::codecov()` the suite was `FAIL 1 | PASS 11627`; the *same commit's* plain check was `FAIL 0 | PASS 11628` — so the test was wrong about the environment, not about the code.

The assertion was mine, from `998891e4`: `expect_equal(min(attr(short, "score")), min(attr(full, "score")))` in `test-stop-patience.R`, giving 13.063 against 12.988. Mechanism is the one documented in that same commit — on the parallel path the dry spell is counted over replicates completed into the shared pool and evaluated on a 200 ms monitor poll, so covr's instrumentation means fewer replicates land per poll and `stopPatience = 3` fires genuinely earlier in the search.

Stopping sooner is *allowed* to cost score — that is the trade-off the parameter exists to offer — so equality was asserting a coincidence of machine timing, and contradicted the feature's own documented behaviour. Replaced with what the rule actually guarantees (finite score, loose bound); the parallel-path caveat is recorded in the test comment.

## Validation

All 8 jobs green on [run 30620073511](https://github.com/ms609/TreeSearch/actions/runs/30620073511), including the coverage job and the two macOS jobs that had never previously run:

```
sense-check (ubuntu-24.04-arm, release)  success    ubuntu-24.04 (4.1)       success
windows-latest (release)   success (covr)          ubuntu-24.04-arm (devel) success
macos-15-intel (release)   success                 macOS-latest (release)   success
EasyTrees shinytest2       success                 detect app changes       success
```

No behaviour change: docs, wordlist, one comment tag, one test assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)