### PR TITLE
fix(hsj): make the HSJ score rooting-invariant (T-374, HSJ half)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,37 @@
   still decided on scores taken at differing rootings.  Only the x-transformation
   is affected; HSJ reporting is deliberately unchanged, since there
   rooting-invariance is a property the method requires rather than a convention
-  to pick.
+  to pick -- and it is now delivered, as the next entry describes.
+
+- `inapplicable = "hsj"` scores no longer depend on where the tree is rooted.
+  Hopkins & St John (2021) define the score as a minimum over internal-node
+  labellings of a sum of *symmetric* dissimilarities across the branches of an
+  *unrooted* tree, so rooting-invariance is required by the method rather than
+  merely desirable.  Two defects broke it, both in how the secondary characters
+  were labelled; the underlying present/absent dynamic programme was correct
+  throughout.
+
+  First, the inapplicable token was treated as an ordinary state of a secondary
+  character.  Where a controlling primary codes a structure absent, its
+  secondaries do not exist, so `"-"` there is not a state the character takes;
+  admitting it let a node in the middle of a region where the structure *is*
+  present be labelled "inapplicable", mismatching every secondary at once and
+  charging that branch the full weight of the scaling parameter.  Secondaries
+  are now unconstrained at tips whose primary may code the structure absent.
+  Second, the remaining ambiguity was resolved by a pass whose direction was a
+  property of the input rooting; that pass is now rooted canonically on the
+  first taxon, inside the scoring kernel, so the labelling depends only on the
+  unrooted topology.
+
+  **HSJ scores on data with a mix of present and absent primaries may therefore
+  differ from previous versions**, and will generally decrease, the old value
+  having included spurious inapplicable mismatches.  Scores are unchanged where
+  every taxon shares the controlling primary's presence, and Figure 1 of the
+  paper still scores 7 and 5.  Unlike the x-transformation change above, this
+  one alters what the search optimises: the criterion is now a function of the
+  unrooted tree, so `MaximizeParsimony()`'s reported score matches
+  `TreeLength()` of the trees it returns without any re-scoring, and every tree
+  in a returned set shares that length.
 
 - `inapplicable = "hsj"` scoring fixed an index-space confusion that could
   under- or over-count the controlling primary's gains and losses, and could

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,14 +49,22 @@
   unrooted topology.
 
   **HSJ scores on data with a mix of present and absent primaries may therefore
-  differ from previous versions**, and will generally decrease, the old value
-  having included spurious inapplicable mismatches.  Scores are unchanged where
-  every taxon shares the controlling primary's presence, and Figure 1 of the
-  paper still scores 7 and 5.  Unlike the x-transformation change above, this
-  one alters what the search optimises: the criterion is now a function of the
-  unrooted tree, so `MaximizeParsimony()`'s reported score matches
-  `TreeLength()` of the trees it returns without any re-scoring, and every tree
-  in a returned set shares that length.
+  differ from previous versions.**  Most do not: across 180 simulated
+  tree--matrix pairs, 152 were unchanged, 27 fell (by up to 1) and one rose (by
+  0.25).  Falls are the removal of spurious inapplicable mismatches; a rise is
+  possible because a score is now taken at a fixed canonical rooting rather
+  than at whichever rooting the tree happened to arrive in, and that rooting
+  was sometimes the flattering one.  Scores are unchanged wherever every taxon
+  shares the controlling primary's presence, and Figure 1 of the paper still
+  scores 7 and 5.
+
+  Unlike the x-transformation change above, this one alters what the search
+  optimises: the criterion is now a function of the unrooted tree, so
+  `MaximizeParsimony()`'s reported score matches `TreeLength()` of the trees it
+  returns without any re-scoring, and every tree in a returned set shares that
+  length.  A secondary character is treated as unconstrained only at taxa whose
+  controlling primary cannot code the structure present; where the primary is
+  ambiguous but a secondary was observed, that observation still counts.
 
 - `inapplicable = "hsj"` scoring fixed an index-space confusion that could
   under- or over-count the controlling primary's gains and losses, and could

--- a/R/MaximizeParsimony.R
+++ b/R/MaximizeParsimony.R
@@ -1631,8 +1631,10 @@ MaximizeParsimony <- function(
     # "collapse zero-length branches" -- done entirely in C++ (ts_collapse_pool)
     # to avoid a per-tree R surgery quagmire.  The kernel re-roots each tree on
     # tip 0 (so root-adjacent edges are trivial -> rooting-invariant *contraction*;
-    # note the LENGTH is not rooting-invariant under HSJ/XFORM, T-374, which is
-    # why the XFORM pool is rescored at this rooting below),
+    # note the LENGTH is not rooting-invariant under XFORM, T-374, which is why
+    # the XFORM pool is rescored at this rooting below.  HSJ needs no rescore:
+    # since T-374 its secondary labelling is rooted canonically inside the
+    # kernel, so its length is a function of the unrooted topology),
     # flags aggressive (min-length-0) internal edges in the *search's* scoring
     # mode, contracts them, and deduplicates on the collapsed topology.
     #

--- a/dev/red-team/heavy-tests/hsj-paper-oracle.R
+++ b/dev/red-team/heavy-tests/hsj-paper-oracle.R
@@ -34,11 +34,21 @@
 # over labelings introduces no orientation. Hence the objective is
 # ROOTING-INVARIANT by construction, and any rooting-dependence is a bug.
 #
-# Corollary for the implementation: the paper prescribes a two-state DP that
-# carries both present/absent possibilities and minimises. A single directional
-# DELTRAN-style uppass that commits to ONE resolution (what `fitch_label_char`
-# does) is neither the paper's algorithm nor guaranteed minimal, and it is the
-# source of the alpha-term rooting-dependence measured in T-374.
+# CORRECTION, 2026-08-02, from reading Algorithm 1 (p.15) against the code.
+# The corollary this header used to draw -- "the paper prescribes a two-state DP
+# and the code does not implement it" -- was wrong, and cost a round of work.
+# `score_hierarchy_block()`'s a(n)/p(n) recurrences ARE Algorithm 1 lines 6-7,
+# term for term. The two-state DP was already there and was already
+# rooting-invariant: its branch costs are symmetric and it minimises over the
+# root's own state. The defect was never in the DP; it was that `d(u, v)` was
+# read off `fitch_label_char()`'s directional resolution.
+#
+# Note also that copying Algorithm 1 literally would NOT have fixed this: its
+# line 2 sets L(n) to the first-pass Fitch labelling, which is a downpass and so
+# root-dependent, and its line 8 updates L(n) in postorder. Algorithm 1 takes
+# "Tree, T, with root r" as input. Theorem 2 claims it returns the minimal
+# score, which would make it rooting-invariant; the measurements below are
+# evidence against that claim as stated.
 # ---------------------------------------------------------------------------
 
 args <- commandArgs(trailingOnly = TRUE)
@@ -92,6 +102,24 @@ primOnly <- MatrixToPhyDat(figOne[, c(1, 6, 7, 8)])
 Check("left  primaries-only == 6", isTRUE(all.equal(TreeLength(figOneLeft,  primOnly), 6)))
 Check("right primaries-only == 3", isTRUE(all.equal(TreeLength(figOneRight, primOnly), 3)))
 
+# Fig. 1's ABSOLUTE HSJ scores: 7 (left) and 5 (right) at alpha = 1.  Re-derived
+# as 6 + alpha and 3 + 2 * alpha -- two equations satisfied by one consistent
+# alpha, obtained without choosing a root.  Column 9 is the inapplicable-token
+# carrier ValidateHierarchy demands; its only non-"1" cell is a lone "-", which
+# the Fitch pass scores as costing nothing, so it shifts neither expectation.
+figOneExt <- cbind(figOne, c("-", "1", "1", "1"))
+figOneDs <- MatrixToPhyDat(figOneExt)
+for (alpha in c(0, 0.5, 1)) {
+  l <- TreeLength(figOneLeft, figOneDs, hierarchy = hierarchy,
+                  inapplicable = "hsj", hsj_alpha = alpha)
+  r <- TreeLength(figOneRight, figOneDs, hierarchy = hierarchy,
+                  inapplicable = "hsj", hsj_alpha = alpha)
+  Check(sprintf("alpha = %.1f: left == %.1f and right == %.1f",
+                alpha, 6 + alpha, 3 + 2 * alpha),
+        isTRUE(all.equal(l, 6 + alpha)) && isTRUE(all.equal(r, 3 + 2 * alpha)),
+        sprintf("got left %s, right %s", format(l), format(r)))
+}
+
 # =========================================================================
 cat("\n[2] The alpha = 0 identity  (p.6)\n")
 cat("    \"the HSJ approach is equivalent to the Fitch approaches when\n")
@@ -130,6 +158,16 @@ cat("    SYMMETRIC dissimilarities over the branches of an UNROOTED tree, so\n")
 cat("    it cannot depend on where the tree is rooted.\n")
 base <- Preorder(as.phylo(7, 6, tipLabels = rownames(extended)))
 
+# Root on the edge above every non-root node; that covers all 2n-3 edges.
+AllRootings <- function(tr) {
+  out <- list()
+  for (v in seq_len(max(tr[["edge"]]))) {
+    r <- try(RootOnNode(tr, v, resolveRoot = TRUE), silent = TRUE)
+    if (!inherits(r, "try-error")) out[[length(out) + 1L]] <- Preorder(r)
+  }
+  out
+}
+
 # GUARD AGAINST A VACUOUS PASS. T-374's rooting-dependence lives ENTIRELY in
 # the alpha*d/m secondary term (at alpha = 0 the DP contribution is invariant --
 # measured 20 x 10 rootings). So an invariance check is only meaningful on a
@@ -154,23 +192,105 @@ if (isTRUE(all.equal(alphaLive, 0))) {
   cat("        across its 10 tip-rootings while alpha=0 gives 20 ten times, and\n")
   cat("        XFORM is rooting-dependent on 165/300 random topologies (T-374).\n")
 } else {
-  cat("  NOTE  a PASS below is NOT evidence that T-374 is fixed -- it only means\n")
-  cat("        this small, Fig.1-derived matrix/topology doesn't happen to trigger\n")
-  cat("        fitch_label_char()'s rooting-sensitivity. T-374's rooting bug is\n")
-  cat("        data/topology-dependent (measured 165-197/300 random cases) and can\n")
-  cat("        remain OPEN and readily reproducible on OTHER matrices even when every\n")
-  cat("        check below is green. T-374's fix is the paper's two-state DP (or\n")
-  cat("        marginal-MPR resolution) -- do not close T-374 on this check alone.\n")
+  cat("  NOTE  the Fig.1-derived matrix below is small and its block is ALL-PRESENT,\n")
+  cat("        which is the one regime that was ALREADY invariant before T-374 was\n")
+  cat("        fixed (see check [5]). Passing here is therefore necessary but not\n")
+  cat("        sufficient -- section [3b] carries the discriminating cases, on\n")
+  cat("        blocks with MIXED present/absent primaries, which is where T-374\n")
+  cat("        actually lived.\n")
   for (alpha in c(0, 0.5, 1)) {
-    scores <- vapply(rownames(extended), function(tip) {
-      TreeLength(RootTree(base, tip), extDs, hierarchy = hierarchy,
+    scores <- vapply(AllRootings(base), function(rt) {
+      TreeLength(rt, extDs, hierarchy = hierarchy,
                  inapplicable = "hsj", hsj_alpha = alpha)
     }, double(1))
-    Check(sprintf("alpha = %.1f invariant across 6 tip-rootings", alpha),
+    Check(sprintf("alpha = %.1f invariant across all %d edge-rootings",
+                  alpha, length(AllRootings(base))),
           length(unique(round(scores, 10))) == 1L,
           paste("scores:", paste(unique(round(scores, 6)), collapse = " / ")))
   }
 }
+
+# =========================================================================
+cat("\n[3b] Rooting invariance on MIXED blocks -- the discriminating check\n")
+cat("    T-374's dependence was confined to blocks with mixed present/absent\n")
+cat("    primaries. Two mechanisms, both in the SECONDARY labelling and not in\n")
+cat("    the a(n)/p(n) DP (which is already Algorithm 1 lines 6-7, and which\n")
+cat("    check [5] shows was already invariant):\n")
+cat("      1. '-' was admitted as an ordinary state of a secondary, so a node\n")
+cat("         INSIDE the present region could be resolved to it, where it is\n")
+cat("         disjoint from every present neighbour in every secondary at once\n")
+cat("         and the branch was charged d = m, the full alpha.\n")
+cat("      2. The residual resolution was a DELTRAN uppass whose direction, and\n")
+cat("         tie-break counts whose subtrees, were properties of the rooting.\n")
+cat("    Measured at 93c81a9a over every edge-rooting of 30 random 9-tip trees,\n")
+cat("    alpha = 1: 21/30 dependent at m = 2 and 26/30 at m = 4, spread 1.00.\n")
+set.seed(374)
+mixedDep <- 0L
+mixedWorst <- 0
+for (rep in 1:12) {
+  nTip <- 9L
+  pri <- rep("1", nTip)
+  pri[sample.int(nTip, 3L)] <- "0"
+  live <- pri != "0"
+  sec <- matrix("-", nTip, 3L)
+  for (j in 1:3) sec[live, j] <- sample(c("0", "1"), sum(live), TRUE)
+  nh <- matrix(sample(c("0", "1"), nTip * 3L, TRUE), nTip, 3L)
+  mm <- cbind(pri, sec, nh)
+  rownames(mm) <- paste0("t", seq_len(nTip))
+  colnames(mm) <- NULL
+  mDs <- MatrixToPhyDat(mm)
+  mH <- CharacterHierarchy("1" = 2:4)
+  tr <- Preorder(as.phylo(rep, nTip, tipLabels = rownames(mm)))
+  sc <- vapply(AllRootings(tr), function(rt)
+    TreeLength(rt, mDs, hierarchy = mH, inapplicable = "hsj", hsj_alpha = 1),
+    double(1))
+  if (diff(range(sc)) > 1e-9) {
+    mixedDep <- mixedDep + 1L
+    mixedWorst <- max(mixedWorst, diff(range(sc)))
+  }
+}
+Check(sprintf("mixed blocks invariant over all edge-rootings (%d/12 dependent, worst spread %.4f)",
+              mixedDep, mixedWorst),
+      mixedDep == 0L)
+
+# =========================================================================
+cat("\n[5] All-present closed form -- the regression FLOOR\n")
+cat("    Under ANY most-parsimonious reconstruction of secondary j, the number\n")
+cat("    of branches on which j changes is FitchLen_j. So when every node in\n")
+cat("    the block is present the alpha term is (alpha/m) * sum_j FitchLen_j\n")
+cat("    EXACTLY, whichever labelling the uppass picks -- which is why that\n")
+cat("    regime was already rooting-invariant, and why T-374 could only ever\n")
+cat("    surface on mixed blocks. A fix that breaks this is wrong regardless\n")
+cat("    of what it does to the rooting spread.\n")
+set.seed(3741)
+cfBad <- 0L
+cfWorst <- 0
+for (rep in 1:8) {
+  nTip <- 9L
+  nSec <- 4L
+  sec <- matrix(sample(c("0", "1"), nTip * nSec, TRUE), nTip, nSec)
+  nh <- matrix(sample(c("0", "1"), nTip * 3L, TRUE), nTip, 3L)
+  nh[1, 1] <- "-"   # inapplicable-token carrier ValidateHierarchy demands
+  pm <- cbind(rep("1", nTip), sec, nh)
+  rownames(pm) <- paste0("t", seq_len(nTip))
+  colnames(pm) <- NULL
+  pDs <- MatrixToPhyDat(pm)
+  pH <- CharacterHierarchy("1" = 2:(nSec + 1L))
+  tr <- Preorder(as.phylo(rep, nTip, tipLabels = rownames(pm)))
+  fitchPri <- TreeLength(tr, MatrixToPhyDat(
+    pm[, c(1L, (nSec + 2L):ncol(pm)), drop = FALSE]))
+  secLen <- sum(vapply(2:(nSec + 1L), function(j)
+    TreeLength(tr, MatrixToPhyDat(pm[, j, drop = FALSE])), double(1)))
+  for (alpha in c(0.5, 1)) {
+    got <- TreeLength(tr, pDs, hierarchy = pH, inapplicable = "hsj",
+                      hsj_alpha = alpha)
+    dev <- abs(got - (fitchPri + alpha * secLen / nSec))
+    if (dev > 1e-9) { cfBad <- cfBad + 1L; cfWorst <- max(cfWorst, dev) }
+  }
+}
+Check(sprintf("closed form holds on all-present blocks (%d/16 violations, worst %.4f)",
+              cfBad, cfWorst),
+      cfBad == 0L)
 
 # =========================================================================
 cat("\n[4] Per-branch contribution bound  (p.5)\n")

--- a/dev/red-team/heavy-tests/hsj-paper-oracle.R
+++ b/dev/red-team/heavy-tests/hsj-paper-oracle.R
@@ -224,34 +224,65 @@ cat("      2. The residual resolution was a DELTRAN uppass whose direction, and\
 cat("         tie-break counts whose subtrees, were properties of the rooting.\n")
 cat("    Measured at 93c81a9a over every edge-rooting of 30 random 9-tip trees,\n")
 cat("    alpha = 1: 21/30 dependent at m = 2 and 26/30 at m = 4, spread 1.00.\n")
+cat("    Crossed over an ambiguous ('?') primary, 18/30 dependent pre-fix, and\n")
+cat("    over multistate secondaries, which exercise pick_state()'s tie-break.\n")
 set.seed(374)
-mixedDep <- 0L
-mixedWorst <- 0
-for (rep in 1:12) {
-  nTip <- 9L
-  pri <- rep("1", nTip)
-  pri[sample.int(nTip, 3L)] <- "0"
-  live <- pri != "0"
-  sec <- matrix("-", nTip, 3L)
-  for (j in 1:3) sec[live, j] <- sample(c("0", "1"), sum(live), TRUE)
-  nh <- matrix(sample(c("0", "1"), nTip * 3L, TRUE), nTip, 3L)
-  mm <- cbind(pri, sec, nh)
-  rownames(mm) <- paste0("t", seq_len(nTip))
-  colnames(mm) <- NULL
-  mDs <- MatrixToPhyDat(mm)
-  mH <- CharacterHierarchy("1" = 2:4)
-  tr <- Preorder(as.phylo(rep, nTip, tipLabels = rownames(mm)))
-  sc <- vapply(AllRootings(tr), function(rt)
-    TreeLength(rt, mDs, hierarchy = mH, inapplicable = "hsj", hsj_alpha = 1),
-    double(1))
-  if (diff(range(sc)) > 1e-9) {
-    mixedDep <- mixedDep + 1L
-    mixedWorst <- max(mixedWorst, diff(range(sc)))
+for (secStates in list(c("0", "1"), c("0", "1", "2"))) {
+  for (ambiguous in c(FALSE, TRUE)) {
+    mixedDep <- 0L
+    mixedWorst <- 0
+    for (rep in 1:8) {
+      nTip <- 9L
+      pri <- rep("1", nTip)
+      pri[sample.int(nTip, 3L)] <- "0"
+      if (ambiguous) pri[sample(which(pri == "1"), 2L)] <- "?"
+      live <- pri != "0"
+      sec <- matrix("-", nTip, 3L)
+      for (j in 1:3) sec[live, j] <- sample(secStates, sum(live), TRUE)
+      nh <- matrix(sample(c("0", "1"), nTip * 3L, TRUE), nTip, 3L)
+      mm <- cbind(pri, sec, nh)
+      rownames(mm) <- paste0("t", seq_len(nTip))
+      colnames(mm) <- NULL
+      mDs <- MatrixToPhyDat(mm)
+      mH <- CharacterHierarchy("1" = 2:4)
+      tr <- Preorder(as.phylo(rep, nTip, tipLabels = rownames(mm)))
+      sc <- vapply(AllRootings(tr), function(rt)
+        TreeLength(rt, mDs, hierarchy = mH, inapplicable = "hsj", hsj_alpha = 1),
+        double(1))
+      if (diff(range(sc)) > 1e-9) {
+        mixedDep <- mixedDep + 1L
+        mixedWorst <- max(mixedWorst, diff(range(sc)))
+      }
+    }
+    Check(sprintf("mixed, %d secondary states, '?' primary %-5s: %d/8 dependent, worst %.4f",
+                  length(secStates), ambiguous, mixedDep, mixedWorst),
+          mixedDep == 0L)
   }
 }
-Check(sprintf("mixed blocks invariant over all edge-rootings (%d/12 dependent, worst spread %.4f)",
-              mixedDep, mixedWorst),
-      mixedDep == 0L)
+
+# A secondary is freed only where the primary CANNOT be present, not merely
+# where it MAY be absent: observing a secondary is evidence the structure is
+# present, and freeing it at every "?" primary would discard that and leave a
+# block of all-"?" primaries with an empty domain and a silently zero alpha
+# term.  Mirrors recode_hierarchy.R's tipSecKnown path (T-379).
+qBase <- matrix(c(
+  "1",  "0",  "0",  "1",  "1",
+  "1",  "0",  "0",  "1",  "0",
+  "?",  "0",  "0",  "1",  "0",
+  "0",  "-",  "-",  "0",  "0",
+  "1",  "1",  "1",  "1",  "1",
+  "1",  "1",  "1",  "0",  "1"
+), nrow = 6, byrow = TRUE, dimnames = list(paste0("t", 1:6), NULL))
+qH <- CharacterHierarchy("1" = 2:3)
+qTr <- Preorder(ape::read.tree(text = "(t1,((t2,t3),(t4,(t5,t6))));"))
+qSc <- vapply(c("0", "1"), function(v) {
+  mq <- qBase; mq[3, 2:3] <- v
+  TreeLength(qTr, MatrixToPhyDat(mq), hierarchy = qH, inapplicable = "hsj",
+             hsj_alpha = 1)
+}, double(1))
+Check(sprintf("an OBSERVED secondary at a '?' primary still counts (%s vs %s)",
+              format(qSc[[1]]), format(qSc[[2]])),
+      !isTRUE(all.equal(qSc[[1]], qSc[[2]])))
 
 # =========================================================================
 cat("\n[5] All-present closed form -- the regression FLOOR\n")

--- a/src/ts_hsj.cpp
+++ b/src/ts_hsj.cpp
@@ -26,24 +26,6 @@ std::vector<int> partition_weights(
   return adjusted;
 }
 
-// Fitch downpass + uppass for a single character represented as integer state
-// labels.  After the downpass, state sets at internal nodes are ambiguous
-// (intersection or union of children).  The uppass resolves each node to a
-// single state so that parent–child mismatches can be detected for HSJ
-// secondary dissimilarity.
-// Returns number of Fitch steps (union operations in the downpass).
-//
-// tip_labels holds 0-based TOKEN (allLevels/contrast-row) indices, not state
-// indices (T-375): a token like "?" is its own row in the contrast matrix,
-// generally with several columns set, so treating the token index itself as
-// a bit position (as this function formerly did) is a category error --
-// `label > 30` can never fire on a valid token index, so "?" silently scored
-// as one concrete, arbitrary state instead of the wildcard it denotes.
-// token_states[label] gives the actual bitmask of states the token is
-// compatible with (populated by build_dataset() from the contrast matrix),
-// which is what state_sets must hold to make the Fitch downpass/uppass below
-// correct for ambiguous tokens.
-//
 // A traversal of the tree rooted at tip 0, used for the secondary labelling
 // only (T-374).
 //
@@ -69,7 +51,6 @@ std::vector<int> partition_weights(
 // on the numbering, never on the incoming parent/child orientation.
 struct CanonOrder {
   std::vector<int> post;     // postorder; canonical root (tip 0) last
-  std::vector<int> parent;   // canonical parent; -1 at the root
   std::vector<int> kids;     // children, flattened
   std::vector<int> kidOff;   // kids[kidOff[n] .. kidOff[n] + kidNum[n])
   std::vector<int> kidNum;
@@ -99,7 +80,6 @@ static CanonOrder build_canon_order(const TreeState& tree) {
   }
 
   CanonOrder co;
-  co.parent.assign(n_node, -1);
   co.kidOff.assign(n_node, 0);
   co.kidNum.assign(n_node, 0);
   co.post.reserve(n_node);
@@ -121,7 +101,6 @@ static CanonOrder build_canon_order(const TreeState& tree) {
       int nb = adj[static_cast<size_t>(n) * 3 + k];
       if (nb < 0 || seen[nb]) continue;
       seen[nb] = 1;
-      co.parent[nb] = n;
       co.kids.push_back(nb);
       ++co.kidNum[n];
       stack.push_back(nb);
@@ -131,26 +110,39 @@ static CanonOrder build_canon_order(const TreeState& tree) {
   return co;
 }
 
-// A secondary carries NO constraint at a tip whose controlling primary can
-// code the structure absent (T-374).  Where the primary is absent the
-// secondary does not exist, so its "-" is not a state the character takes --
-// it is the statement that the character does not apply there.  Admitting it
-// as an ordinary concrete state (as this function formerly did, and as the
-// comment here formerly asserted was deliberate) let the uppass propagate "-"
-// INWARDS and resolve a node in the middle of the PRESENT region to it, where
-// it is disjoint from every present neighbour in every secondary at once.
-// score_hierarchy_block() then charged that branch d = m -- the full alpha --
-// for a node that by construction has no inapplicable secondaries.  That
-// over-charge is wrong under any rooting (the paper's d is "the number of
-// nonmatching secondary characters", p.5, among characters that APPLY), and
-// because whether it happened depended on the DELTRAN direction, it was also
-// the dominant source of T-374's rooting-dependence.
+// Fitch downpass + uppass for a single character represented as integer state
+// labels.  After the downpass, state sets at internal nodes are ambiguous
+// (intersection or union of children).  The uppass resolves each node to a
+// single state so that parent–child mismatches can be detected for HSJ
+// secondary dissimilarity.
+// Returns number of Fitch steps (union operations in the downpass).
 //
-// `pri_free[t]` marks the tips to wildcard: those whose primary token can mean
-// absent.  It deliberately does NOT key off the secondary's own token, because
-// a "-" secondary at a tip whose primary is unambiguously PRESENT is
-// contradictory data that ValidateHierarchy rejects upstream; the kernel keeps
-// scoring it as a concrete state rather than silently reinterpreting it.
+// tip_labels holds 0-based TOKEN (allLevels/contrast-row) indices, not state
+// indices (T-375): a token like "?" is its own row in the contrast matrix,
+// generally with several columns set, so treating the token index itself as
+// a bit position (as this function formerly did) is a category error --
+// `label > 30` can never fire on a valid token index, so "?" silently scored
+// as one concrete, arbitrary state instead of the wildcard it denotes.
+// token_states[label] gives the actual bitmask of states the token is
+// compatible with (populated by build_dataset() from the contrast matrix),
+// which is what state_sets must hold to make the Fitch downpass/uppass below
+// correct for ambiguous tokens.
+//
+// `pri_free[t]` marks the tips at which this secondary carries no constraint:
+// those whose controlling primary CANNOT code the structure present, so the
+// character does not exist there and its "-" is not a state it takes (T-374).
+// score_hierarchy_block() computes it and documents why the test is that
+// strict one rather than "may be absent".  Admitting "-" as an ordinary
+// concrete state -- as this function formerly did, and as the comment here
+// formerly asserted was deliberate -- let the uppass propagate it INWARDS and
+// resolve a node in the middle of the PRESENT region to it, where it is
+// disjoint from every present neighbour in every secondary at once, and
+// score_hierarchy_block() charged that branch d = m, the full alpha, for a
+// node that by construction has no inapplicable secondaries.  That over-charge
+// is wrong under any rooting (the paper's d counts "nonmatching secondary
+// characters", p.5, among characters that APPLY), and because whether it fired
+// depended on the DELTRAN direction it was also the dominant source of
+// T-374's rooting-dependence.
 static int fitch_label_char(
     const TreeState& tree,
     const std::vector<int>& tip_labels,

--- a/src/ts_hsj.cpp
+++ b/src/ts_hsj.cpp
@@ -42,9 +42,28 @@ std::vector<int> partition_weights(
 // token_states[label] gives the actual bitmask of states the token is
 // compatible with (populated by build_dataset() from the contrast matrix),
 // which is what state_sets must hold to make the Fitch downpass/uppass below
-// correct for ambiguous tokens. inapp_state needs no special handling here --
-// per this module's design (see feature-inapplicable.md), the inapplicable
-// state is deliberately just another concrete state in the secondary pass.
+// correct for ambiguous tokens.
+//
+// A secondary carries NO constraint at a tip whose controlling primary can
+// code the structure absent (T-374).  Where the primary is absent the
+// secondary does not exist, so its "-" is not a state the character takes --
+// it is the statement that the character does not apply there.  Admitting it
+// as an ordinary concrete state (as this function formerly did, and as the
+// comment here formerly asserted was deliberate) let the uppass propagate "-"
+// INWARDS and resolve a node in the middle of the PRESENT region to it, where
+// it is disjoint from every present neighbour in every secondary at once.
+// score_hierarchy_block() then charged that branch d = m -- the full alpha --
+// for a node that by construction has no inapplicable secondaries.  That
+// over-charge is wrong under any rooting (the paper's d is "the number of
+// nonmatching secondary characters", p.5, among characters that APPLY), and
+// because whether it happened depended on the DELTRAN direction, it was also
+// the dominant source of T-374's rooting-dependence.
+//
+// `pri_free[t]` marks the tips to wildcard: those whose primary token can mean
+// absent.  It deliberately does NOT key off the secondary's own token, because
+// a "-" secondary at a tip whose primary is unambiguously PRESENT is
+// contradictory data that ValidateHierarchy rejects upstream; the kernel keeps
+// scoring it as a concrete state rather than silently reinterpreting it.
 static int fitch_label_char(
     const TreeState& tree,
     const std::vector<int>& tip_labels,
@@ -52,15 +71,29 @@ static int fitch_label_char(
     int n_orig_chars,
     const std::vector<uint32_t>& token_states,
     int n_levels,
+    const std::vector<char>& pri_free,
     std::vector<uint32_t>& state_sets)
 {
   int n_tip = tree.n_tip;
   int n_node = tree.n_node;
 
+  // The applicable domain: the states this character is observed in at tips
+  // where it actually applies.  Wildcarding to this rather than to all
+  // n_levels bits keeps the tie-break arrays below as small as they were.
+  uint32_t domain = 0;
+  for (int t = 0; t < n_tip; ++t) {
+    if (!pri_free[t]) {
+      domain |= token_states[tip_labels[t * n_orig_chars + char_idx]];
+    }
+  }
+  // The character applies nowhere: it constrains nothing.  Give every node one
+  // shared state so no branch can ever register a mismatch.
+  if (domain == 0) domain = 1u;
+
   uint32_t used_mask = 0;
   for (int t = 0; t < n_tip; ++t) {
     int label = tip_labels[t * n_orig_chars + char_idx];
-    state_sets[t] = token_states[label];
+    state_sets[t] = pri_free[t] ? domain : token_states[label];
     used_mask |= state_sets[t];
   }
 
@@ -218,21 +251,7 @@ static double score_hierarchy_block(
   const int m = block.n_secondaries;
   const double INF = std::numeric_limits<double>::infinity();
 
-  // Step 1: Run Fitch downpass on each secondary character
-  // sec_states[j * n_node + node] = bitmask of possible states
-  std::vector<uint32_t> sec_states(m * n_node, 0);
-  {
-    std::vector<uint32_t> buf(n_node);
-    for (int j = 0; j < m; ++j) {
-      fitch_label_char(tree, tip_labels, block.secondary_chars[j],
-                       n_orig_chars, token_states, n_levels, buf);
-      for (int nd = 0; nd < n_node; ++nd) {
-        sec_states[j * n_node + nd] = buf[nd];
-      }
-    }
-  }
-
-  // Step 2: Determine primary feasibility at each tip via SET MEMBERSHIP.
+  // Step 1: Determine primary feasibility at each tip via SET MEMBERSHIP.
   // `label` is a TOKEN (allLevels/contrast-row) index, but block.absent_state
   // and inapp_state are STATE (levels) indices -- comparing them directly via
   // `==` (the former code) was T-375/T-376's bug: it happened to work only
@@ -254,6 +273,29 @@ static double score_hierarchy_block(
   // effective classification of "?").
   const uint32_t inapp_bit = (inapp_state >= 0) ? (1u << inapp_state) : 0u;
   const uint32_t absent_bits = (1u << block.absent_state) | inapp_bit;
+
+  // Tips where the primary can code the structure absent are exactly the tips
+  // at which the secondaries do not (or may not) apply, so they must not
+  // constrain the secondary reconstruction -- see fitch_label_char() (T-374).
+  std::vector<char> pri_free(n_tip, 0);
+  for (int t = 0; t < n_tip; ++t) {
+    uint32_t set = token_states[tip_labels[t * n_orig_chars + block.primary_char]];
+    pri_free[t] = (set & absent_bits) ? 1 : 0;
+  }
+
+  // Step 2: Run Fitch downpass/uppass on each secondary character
+  // sec_states[j * n_node + node] = bitmask of possible states
+  std::vector<uint32_t> sec_states(m * n_node, 0);
+  {
+    std::vector<uint32_t> buf(n_node);
+    for (int j = 0; j < m; ++j) {
+      fitch_label_char(tree, tip_labels, block.secondary_chars[j],
+                       n_orig_chars, token_states, n_levels, pri_free, buf);
+      for (int nd = 0; nd < n_node; ++nd) {
+        sec_states[j * n_node + nd] = buf[nd];
+      }
+    }
+  }
 
   // Step 3: a(n)/p(n) DP
   // a[node], p[node]

--- a/src/ts_hsj.cpp
+++ b/src/ts_hsj.cpp
@@ -378,13 +378,25 @@ static double score_hierarchy_block(
   const uint32_t inapp_bit = (inapp_state >= 0) ? (1u << inapp_state) : 0u;
   const uint32_t absent_bits = (1u << block.absent_state) | inapp_bit;
 
-  // Tips where the primary can code the structure absent are exactly the tips
-  // at which the secondaries do not (or may not) apply, so they must not
-  // constrain the secondary reconstruction -- see fitch_label_char() (T-374).
+  // Tips where the primary CANNOT code the structure present are exactly the
+  // tips at which the secondaries cannot apply, so they must not constrain the
+  // secondary reconstruction -- see fitch_label_char() (T-374).
+  //
+  // The test is deliberately strict ("cannot be present"), not the laxer "may
+  // be absent".  Under the lax test a tip whose primary is "?" would be freed
+  // too, discarding an OBSERVED secondary -- but observing a secondary is
+  // itself evidence the structure is present, and that is real information the
+  // alpha term should keep.  It would also be silently self-erasing: `domain`
+  // in fitch_label_char() unions only the non-free tips, so a block with no
+  // unambiguously present primary would collapse the whole alpha term to zero.
+  // ValidateHierarchy whitelists "?" primaries, so that is reachable data.
+  // This matches recode_hierarchy.R's `tipStates == -2L` / `tipSecKnown` path,
+  // added under T-379 for exactly this reason: an ambiguous primary must not
+  // free the secondaries that WERE observed.
   std::vector<char> pri_free(n_tip, 0);
   for (int t = 0; t < n_tip; ++t) {
     uint32_t set = token_states[tip_labels[t * n_orig_chars + block.primary_char]];
-    pri_free[t] = (set & absent_bits) ? 1 : 0;
+    pri_free[t] = ((set & ~absent_bits) == 0) ? 1 : 0;
   }
 
   // Step 2: Run Fitch downpass/uppass on each secondary character, over a

--- a/src/ts_hsj.cpp
+++ b/src/ts_hsj.cpp
@@ -44,6 +44,93 @@ std::vector<int> partition_weights(
 // which is what state_sets must hold to make the Fitch downpass/uppass below
 // correct for ambiguous tokens.
 //
+// A traversal of the tree rooted at tip 0, used for the secondary labelling
+// only (T-374).
+//
+// The HSJ score is defined as a minimum over internal-node labelings of a sum
+// of SYMMETRIC dissimilarities over the branches of an UNROOTED tree (Hopkins
+// & St John 2021, p.3, p.6), so it may not depend on where the tree happens to
+// be rooted.  The a(n)/p(n) DP below satisfies that already -- its branch
+// costs are symmetric and it minimises over the root's own state.  The
+// secondary labelling did not: fitch_label_char() resolves ambiguous nodes
+// with a DELTRAN-style uppass whose direction, and with subtree support counts
+// whose subtrees, are both properties of the INPUT rooting.  Two rootings of
+// one topology therefore disagreed about d(u, v) and so about the score.
+//
+// Rooting the labelling pass at tip 0 makes it a function of the unrooted
+// topology and the data alone.  Tip indices come from the dataset, not from
+// the rooting, so this is canonical.  Note this is NOT the reporting-boundary
+// canonicalisation PR #278 applied to XFORM: this sits inside the kernel, so
+// the objective the SEARCH optimises is itself rooting-invariant, and
+// MaximizeParsimony()'s reported score agrees with TreeLength() of the trees
+// it returns by construction rather than by re-scoring at the boundary.
+//
+// Neighbour lists are sorted by node index so the traversal order depends only
+// on the numbering, never on the incoming parent/child orientation.
+struct CanonOrder {
+  std::vector<int> post;     // postorder; canonical root (tip 0) last
+  std::vector<int> parent;   // canonical parent; -1 at the root
+  std::vector<int> kids;     // children, flattened
+  std::vector<int> kidOff;   // kids[kidOff[n] .. kidOff[n] + kidNum[n])
+  std::vector<int> kidNum;
+};
+
+static CanonOrder build_canon_order(const TreeState& tree) {
+  const int n_tip = tree.n_tip;
+  const int n_node = tree.n_node;
+
+  // Undirected adjacency.  Every node has degree <= 3: the kernel's root is a
+  // degree-2 subdivision point of an unrooted edge, and Fitch passes such a
+  // node through transparently, so its position cannot bias the labelling.
+  std::vector<int> adj(static_cast<size_t>(n_node) * 3, -1);
+  std::vector<int> deg(n_node, 0);
+  auto link = [&](int u, int v) {
+    if (deg[u] < 3) adj[static_cast<size_t>(u) * 3 + deg[u]++] = v;
+    if (deg[v] < 3) adj[static_cast<size_t>(v) * 3 + deg[v]++] = u;
+  };
+  for (int node : tree.postorder) {
+    int ni = node - n_tip;
+    link(node, tree.left[ni]);
+    link(node, tree.right[ni]);
+  }
+  for (int n = 0; n < n_node; ++n) {
+    std::sort(adj.begin() + static_cast<size_t>(n) * 3,
+              adj.begin() + static_cast<size_t>(n) * 3 + deg[n]);
+  }
+
+  CanonOrder co;
+  co.parent.assign(n_node, -1);
+  co.kidOff.assign(n_node, 0);
+  co.kidNum.assign(n_node, 0);
+  co.post.reserve(n_node);
+  co.kids.reserve(n_node);
+
+  // Iterative DFS from tip 0, emitting a preorder we then reverse.
+  std::vector<int> pre;
+  pre.reserve(n_node);
+  std::vector<char> seen(n_node, 0);
+  std::vector<int> stack;
+  stack.push_back(0);
+  seen[0] = 1;
+  while (!stack.empty()) {
+    int n = stack.back();
+    stack.pop_back();
+    pre.push_back(n);
+    co.kidOff[n] = static_cast<int>(co.kids.size());
+    for (int k = 0; k < deg[n]; ++k) {
+      int nb = adj[static_cast<size_t>(n) * 3 + k];
+      if (nb < 0 || seen[nb]) continue;
+      seen[nb] = 1;
+      co.parent[nb] = n;
+      co.kids.push_back(nb);
+      ++co.kidNum[n];
+      stack.push_back(nb);
+    }
+  }
+  co.post.assign(pre.rbegin(), pre.rend());
+  return co;
+}
+
 // A secondary carries NO constraint at a tip whose controlling primary can
 // code the structure absent (T-374).  Where the primary is absent the
 // secondary does not exist, so its "-" is not a state the character takes --
@@ -72,6 +159,7 @@ static int fitch_label_char(
     const std::vector<uint32_t>& token_states,
     int n_levels,
     const std::vector<char>& pri_free,
+    const CanonOrder& co,
     std::vector<uint32_t>& state_sets)
 {
   int n_tip = tree.n_tip;
@@ -91,25 +179,38 @@ static int fitch_label_char(
   if (domain == 0) domain = 1u;
 
   uint32_t used_mask = 0;
+  std::vector<uint32_t> observed(n_tip);
   for (int t = 0; t < n_tip; ++t) {
     int label = tip_labels[t * n_orig_chars + char_idx];
-    state_sets[t] = pri_free[t] ? domain : token_states[label];
-    used_mask |= state_sets[t];
+    observed[t] = pri_free[t] ? domain : token_states[label];
+    state_sets[t] = observed[t];
+    used_mask |= observed[t];
   }
 
-  // --- Downpass ---
+  // --- Downpass, in the canonical (tip-0-rooted) postorder ---
+  // Generalised over arity: the kernel's own root becomes an ordinary degree-2
+  // node here, which Fitch passes through unchanged, and the canonical root is
+  // tip 0, which has one child AND an observation of its own to honour.
   int steps = 0;
-  for (int i = 0; i < static_cast<int>(tree.postorder.size()); ++i) {
-    int node = tree.postorder[i];
-    int ni = node - n_tip;
-    int lc = tree.left[ni];
-    int rc = tree.right[ni];
-
-    uint32_t inter = state_sets[lc] & state_sets[rc];
+  for (int node : co.post) {
+    int nk = co.kidNum[node];
+    if (nk == 0) continue;                       // canonical leaf: tip state
+    const int* kid = &co.kids[co.kidOff[node]];
+    bool have = false;
+    uint32_t inter = 0, uni = 0;
+    if (node < n_tip) {                          // the canonical root
+      inter = uni = observed[node];
+      have = true;
+    }
+    for (int k = 0; k < nk; ++k) {
+      uint32_t s = state_sets[kid[k]];
+      if (!have) { inter = uni = s; have = true; }
+      else { inter &= s; uni |= s; }
+    }
     if (inter != 0) {
       state_sets[node] = inter;
     } else {
-      state_sets[node] = state_sets[lc] | state_sets[rc];
+      state_sets[node] = uni;
       ++steps;
     }
   }
@@ -146,27 +247,29 @@ static int fitch_label_char(
   std::vector<int> tb_cnt(static_cast<size_t>(n_node) * K, 0);
   std::vector<int> tb_mintip(static_cast<size_t>(n_node) * K, INF_TIP);
   for (int t = 0; t < n_tip; ++t) {
-    uint32_t set = state_sets[t];
-    // Only a tip resolved to exactly one concrete state contributes tie-break
-    // support -- an ambiguous tip (e.g. "?", now correctly multi-bit) must
-    // not bias which state the uppass prefers, same as before this fix.
+    uint32_t set = observed[t];
+    // Only a tip observed as exactly one concrete state contributes tie-break
+    // support -- an ambiguous tip (e.g. "?", or one the primary codes absent)
+    // must not bias which state the uppass prefers.
     if (set != 0 && (set & (set - 1)) == 0) {
       int s = ctz64(set);
       tb_cnt[static_cast<size_t>(t) * K + s] = 1;
       tb_mintip[static_cast<size_t>(t) * K + s] = t;
     }
   }
-  for (int i = 0; i < static_cast<int>(tree.postorder.size()); ++i) {
-    int node = tree.postorder[i];
-    int ni = node - n_tip;
-    int lc = tree.left[ni];
-    int rc = tree.right[ni];
+  // Accumulate over CANONICAL subtrees, so the support counts are a property of
+  // the unrooted tree rather than of the incoming rooting (T-374).
+  for (int node : co.post) {
+    int nk = co.kidNum[node];
+    if (nk == 0) continue;
+    const int* kid = &co.kids[co.kidOff[node]];
     size_t nb = static_cast<size_t>(node) * K;
-    size_t lb = static_cast<size_t>(lc) * K;
-    size_t rb = static_cast<size_t>(rc) * K;
-    for (int s = 0; s < K; ++s) {
-      tb_cnt[nb + s] = tb_cnt[lb + s] + tb_cnt[rb + s];
-      tb_mintip[nb + s] = std::min(tb_mintip[lb + s], tb_mintip[rb + s]);
+    for (int k = 0; k < nk; ++k) {
+      size_t cb = static_cast<size_t>(kid[k]) * K;
+      for (int s = 0; s < K; ++s) {
+        tb_cnt[nb + s] += tb_cnt[cb + s];
+        tb_mintip[nb + s] = std::min(tb_mintip[nb + s], tb_mintip[cb + s]);
+      }
     }
   }
 
@@ -193,22 +296,23 @@ static int fitch_label_char(
     return 1u << best;
   };
 
-  // --- Uppass: resolve each node to a single state ---
-  int root = tree.postorder.back();
+  // --- Uppass: resolve each node to a single state, canonical preorder ---
+  // The canonical root is tip 0, whose label is observed, not inferred, so it
+  // resolves within its own observation rather than within the downpass set.
+  const int root = co.post.back();
+  state_sets[root] &= observed[root];
+  if (state_sets[root] == 0) state_sets[root] = observed[root];
   state_sets[root] = pick_state(root);
 
-  // Traverse preorder (reverse postorder) to resolve internal nodes and tips.
-  for (int i = static_cast<int>(tree.postorder.size()) - 1; i >= 0; --i) {
-    int node = tree.postorder[i];
-    int ni = node - n_tip;
-    int lc = tree.left[ni];
-    int rc = tree.right[ni];
-
+  for (int i = static_cast<int>(co.post.size()) - 1; i >= 0; --i) {
+    int node = co.post[i];
+    int nk = co.kidNum[node];
+    const int* kid = &co.kids[co.kidOff[node]];
     // Resolve each child: prefer parent's (already-resolved) state if it lies
     // in the child's set (DELTRAN-style); otherwise pick order-invariantly.
-    for (int child : {lc, rc}) {
-      uint32_t overlap = state_sets[child] & state_sets[node];
-      if (overlap != 0) {
+    for (int k = 0; k < nk; ++k) {
+      int child = kid[k];
+      if (state_sets[child] & state_sets[node]) {
         state_sets[child] = state_sets[node]; // inherit parent's state
       } else {
         state_sets[child] = pick_state(child);
@@ -283,14 +387,17 @@ static double score_hierarchy_block(
     pri_free[t] = (set & absent_bits) ? 1 : 0;
   }
 
-  // Step 2: Run Fitch downpass/uppass on each secondary character
-  // sec_states[j * n_node + node] = bitmask of possible states
+  // Step 2: Run Fitch downpass/uppass on each secondary character, over a
+  // traversal rooted canonically at tip 0 so the labelling -- and hence
+  // d(u, v) -- depends only on the unrooted topology (T-374).  Built once and
+  // shared by every secondary in the block.
   std::vector<uint32_t> sec_states(m * n_node, 0);
-  {
+  if (m > 0) {
+    const CanonOrder co = build_canon_order(tree);
     std::vector<uint32_t> buf(n_node);
     for (int j = 0; j < m; ++j) {
       fitch_label_char(tree, tip_labels, block.secondary_chars[j],
-                       n_orig_chars, token_states, n_levels, pri_free, buf);
+                       n_orig_chars, token_states, n_levels, pri_free, co, buf);
       for (int nd = 0; nd < n_node; ++nd) {
         sec_states[j * n_node + nd] = buf[nd];
       }

--- a/src/ts_rcpp.cpp
+++ b/src/ts_rcpp.cpp
@@ -2221,10 +2221,12 @@ List ts_collapse_pool(
     // Root on tip 0 so root-adjacent edges are trivial, then refresh state
     // arrays for the flag computation.  This makes the CONTRACTION
     // rooting-invariant, and it is also what fixes the rooting the returned
-    // trees are handed back at — which matters because HSJ/XFORM lengths are
-    // NOT rooting-invariant (T-374).  MaximizeParsimony() rescores the XFORM
-    // pool at this same tip-0 rooting before reporting, so that the reported
-    // score is the score of the tree returned (T-385).
+    // trees are handed back at — which matters because XFORM lengths are NOT
+    // rooting-invariant (T-374).  MaximizeParsimony() rescores the XFORM pool
+    // at this same tip-0 rooting before reporting, so that the reported score
+    // is the score of the tree returned (T-385).  HSJ needs no such rescore:
+    // since T-374 its secondary labelling is itself rooted canonically at tip 0
+    // inside the kernel, so its length does not depend on the rooting at all.
     ts::reroot_at_tip(tree, 0);
     tree.reset_states(ds);
     ts::score_tree(tree, ds);

--- a/src/ts_tbr.cpp
+++ b/src/ts_tbr.cpp
@@ -121,14 +121,17 @@ static double full_rescore(TreeState& tree, const DataSet& ds) {
 
 // Re-root the tree so tip `t` is a direct child of the root pseudo-node n_tip.
 // Parsimony length is root-invariant for the SYMMETRIC criteria (EW / IW / NA /
-// profile), so for those this only changes the representation (which edges are
-// clippable and where the root edge sits) — it lets the search reach moves the
-// current rooting hides.  It is NOT root-invariant under HSJ or XFORM: the
-// x-transformation's step matrix is asymmetric (gain = nSec + 1 against loss = 1)
-// and HSJ's alpha.d/m term is evaluated on a directional pick, so a reroot can
-// change their scores by up to sum(nSec) over blocks (T-374; measured in
-// dev/plans/2026-07-29-t374b-xform-rooting-policy.md).  Callers under those modes
-// must treat the score as rooting-relative.  Rebuilds postorder; does NOT refresh
+// profile, and since T-374 also HSJ), so for those this only changes the
+// representation (which edges are clippable and where the root edge sits) — it
+// lets the search reach moves the current rooting hides.  It is NOT
+// root-invariant under XFORM: the x-transformation's step matrix is asymmetric
+// (gain = nSec + 1 against loss = 1), so a reroot can change the score by up to
+// sum(nSec) over blocks (T-374; measured in
+// dev/plans/2026-07-29-t374b-xform-rooting-policy.md).  Callers under XFORM must
+// treat the score as rooting-relative.  HSJ used to belong in that list because
+// its alpha.d/m term was read off a directional pick; the secondary labelling is
+// now rooted canonically at tip 0 inside the kernel (ts_hsj.cpp), so HSJ scores
+// are a function of the unrooted topology.  Rebuilds postorder; does NOT refresh
 // Fitch state arrays, so the caller must full_rescore() afterwards.
 // Generalises reroot_at_tip0() in ts_fuse.cpp to an arbitrary tip.
 // Declared in ts_tbr.h (used by the output-collapse kernel in ts_rcpp.cpp).
@@ -3155,9 +3158,10 @@ TBRResult tbr_search(TreeState& tree, const DataSet& ds,
   reroot_prev = best_score;
   reroot_at_tip(tree, reroot_tip);
   reroot_tip = (reroot_tip + 1) % tree.n_tip;
-  // Refreshes states.  Root-invariant for EW / IW / NA / profile only — under
-  // HSJ / XFORM the score is rooting-relative (T-374), so this value is the
-  // length at the rooting the tree currently carries, not an absolute.
+  // Refreshes states.  Root-invariant for EW / IW / NA / profile and, since
+  // T-374, HSJ — under XFORM alone the score is rooting-relative, so there this
+  // value is the length at the rooting the tree currently carries, not an
+  // absolute.
   best_score = full_rescore(tree, ds);
   score_fresh = true;
   if (!collapsed.empty()) {

--- a/tests/testthat/test-ts-hsj.R
+++ b/tests/testthat/test-ts-hsj.R
@@ -1030,29 +1030,82 @@ test_that("HSJ score is invariant to rooting on a mixed block (T-374)", {
 })
 
 test_that("HSJ rooting invariance holds over random mixed matrices (T-374)", {
+  # Crossed over two axes the single fixed matrix above does not reach:
+  # an ambiguous ("?") controlling primary, which was 18/30 dependent pre-fix,
+  # and multistate secondaries, which are what exercise pick_state()'s
+  # tie-break and the per-character `K` sizing.
   set.seed(374)
   nTip <- 9L
-  for (rep in 1:8) {
-    pri <- rep("1", nTip)
-    pri[sample.int(nTip, 3L)] <- "0"
-    live <- pri != "0"
-    sec <- matrix("-", nTip, 3L)
-    for (j in 1:3) sec[live, j] <- sample(c("0", "1"), sum(live), TRUE)
-    nonHier <- matrix(sample(c("0", "1"), nTip * 3L, TRUE), nTip, 3L)
-    mat <- cbind(pri, sec, nonHier)
-    rownames(mat) <- paste0("t", seq_len(nTip))
-    colnames(mat) <- NULL
+  for (secStates in list(c("0", "1"), c("0", "1", "2"))) {
+    for (ambiguous in c(FALSE, TRUE)) {
+      for (rep in 1:6) {
+        pri <- rep("1", nTip)
+        pri[sample.int(nTip, 3L)] <- "0"
+        if (ambiguous) pri[sample(which(pri == "1"), 2L)] <- "?"
+        live <- pri != "0"
+        sec <- matrix("-", nTip, 3L)
+        for (j in 1:3) sec[live, j] <- sample(secStates, sum(live), TRUE)
+        nonHier <- matrix(sample(c("0", "1"), nTip * 3L, TRUE), nTip, 3L)
+        mat <- cbind(pri, sec, nonHier)
+        rownames(mat) <- paste0("t", seq_len(nTip))
+        colnames(mat) <- NULL
 
-    ds <- MatrixToPhyDat(mat)
-    h <- CharacterHierarchy("1" = 2:4)
-    tr <- Preorder(as.phylo(rep, nTip, tipLabels = rownames(mat)))
-    scores <- vapply(AllRootings(tr), function(rooted) {
-      TreeLength(rooted, ds, hierarchy = h, inapplicable = "hsj", hsj_alpha = 1)
-    }, double(1))
-    expect_equal(length(unique(round(scores, 10))), 1L,
-                 info = sprintf("replicate %d: scores %s", rep,
-                                paste(unique(round(scores, 6)), collapse = "/")))
+        ds <- MatrixToPhyDat(mat)
+        h <- CharacterHierarchy("1" = 2:4)
+        tr <- Preorder(as.phylo(rep, nTip, tipLabels = rownames(mat)))
+        scores <- vapply(AllRootings(tr), function(rooted) {
+          TreeLength(rooted, ds, hierarchy = h, inapplicable = "hsj",
+                     hsj_alpha = 1)
+        }, double(1))
+        expect_equal(
+          length(unique(round(scores, 10))), 1L,
+          info = sprintf("%d states, ambiguous = %s, replicate %d: scores %s",
+                         length(secStates), ambiguous, rep,
+                         paste(unique(round(scores, 6)), collapse = "/")))
+      }
+    }
   }
+})
+
+test_that("an observed secondary at a '?' primary still counts (T-374)", {
+  # A regression FLOOR, not a bug witness: it passes against a pre-fix build
+  # too, because before T-374 no tip's secondary was freed at all.  It is here
+  # to pin the *narrowness* of the freeing rule the T-374 fix introduces -- an
+  # earlier draft of that fix freed the secondary at every tip whose primary
+  # MAY be absent, which silently discarded observed data and passed every
+  # rooting test, since throwing information away is perfectly rooting-
+  # invariant.  Do not relax this to `(set & absent_bits)`.
+  #
+  # Guards the narrow reading of "this secondary does not apply".  A secondary
+  # is freed only where the primary CANNOT be present -- not merely where it
+  # MAY be absent.  Observing a secondary is itself evidence the structure is
+  # present, so that observation must keep influencing the alpha term; freeing
+  # it at every "?" primary would discard real data, and would also be
+  # self-erasing, since a block whose primaries are all "?" would then have an
+  # empty applicable domain and a silently zero alpha term.  This mirrors
+  # recode_hierarchy.R's `tipStates == -2L` / `tipSecKnown` path (T-379).
+  # ValidateHierarchy whitelists "?" primaries, so this data is reachable.
+  base <- matrix(c(
+    # pri  sec2  sec3  nh4   nh5
+    "1",  "0",  "0",  "1",  "1",
+    "1",  "0",  "0",  "1",  "0",
+    "?",  "0",  "0",  "1",  "0",   # t3: ambiguous primary, OBSERVED secondaries
+    "0",  "-",  "-",  "0",  "0",
+    "1",  "1",  "1",  "1",  "1",
+    "1",  "1",  "1",  "0",  "1"
+  ), nrow = 6, byrow = TRUE, dimnames = list(paste0("t", 1:6), NULL))
+  h <- CharacterHierarchy("1" = 2:3)
+  tr <- Preorder(ape::read.tree(text = "(t1,((t2,t3),(t4,(t5,t6))));"))
+
+  scores <- vapply(c("0", "1"), function(v) {
+    mat <- base
+    mat[3, 2:3] <- v
+    TreeLength(tr, MatrixToPhyDat(mat), hierarchy = h, inapplicable = "hsj",
+               hsj_alpha = 1)
+  }, double(1))
+  # t3's secondaries agree with its neighbour t2 under "0" and conflict under
+  # "1", so the two codings must not score alike.
+  expect_false(isTRUE(all.equal(scores[["0"]], scores[["1"]])))
 })
 
 test_that("HSJ does not charge the inapplicable state as a mismatch (T-374)", {

--- a/tests/testthat/test-ts-hsj.R
+++ b/tests/testthat/test-ts-hsj.R
@@ -962,3 +962,247 @@ test_that("HSJ search handles all-hierarchy data (zero Fitch words)", {
     expect_true(TreeIsRooted(tr))
   }
 })
+
+
+# =========================================================================
+# T-374: the HSJ score must not depend on where the tree is rooted
+# =========================================================================
+# Hopkins & St John (2021) define the score as a MINIMUM over internal-node
+# labelings of a sum of dissimilarities across the branches (p.3; p.6). The
+# dissimilarity is symmetric in its two endpoints ("the number of nonmatching
+# secondary characters", p.5) and the branch set of an unrooted tree does not
+# depend on the rooting, so the objective is rooting-invariant by construction.
+#
+# Two defects broke that, both in the secondary labelling rather than in the
+# a(n)/p(n) DP -- which was already the paper's Algorithm 1, lines 6-7, and was
+# already invariant, as the all-present test below records:
+#
+#   1. "-" was admitted as an ordinary state of a secondary character, so the
+#      uppass could resolve a node in the middle of the PRESENT region to it,
+#      where it is disjoint from every present neighbour in every secondary at
+#      once, and the branch was charged d = m -- the full alpha.
+#   2. The remaining resolution was a DELTRAN uppass whose direction, and
+#      tie-break counts whose subtrees, were properties of the input rooting.
+#
+# These tests exercise the objective rather than the mechanism: they compare
+# scores across rootings, which is what the paper requires.
+
+# Root on the edge above every non-root node; that covers every edge.
+AllRootings <- function(tr) {
+  out <- list()
+  for (v in seq_len(max(tr[["edge"]]))) {
+    rooted <- try(RootOnNode(tr, v, resolveRoot = TRUE), silent = TRUE)
+    if (!inherits(rooted, "try-error")) out[[length(out) + 1L]] <- Preorder(rooted)
+  }
+  out
+}
+
+# A block with mixed present/absent primaries -- the regime the defects lived
+# in. Absent taxa (t4, t5) carry "-" secondaries, which is what let "-" leak
+# into the present region.
+mixedMat <- matrix(c(
+  # pri  sec2  sec3  nh4   nh5
+  "1",  "0",  "1",  "1",  "1",
+  "1",  "1",  "0",  "1",  "0",
+  "1",  "1",  "1",  "1",  "0",
+  "0",  "-",  "-",  "0",  "0",
+  "0",  "-",  "-",  "1",  "1",
+  "1",  "1",  "1",  "1",  "1"
+), nrow = 6, byrow = TRUE, dimnames = list(paste0("t", 1:6), NULL))
+
+test_that("HSJ score is invariant to rooting on a mixed block (T-374)", {
+  ds <- MatrixToPhyDat(mixedMat)
+  h <- CharacterHierarchy("1" = 2:3)
+  tr <- Preorder(ape::read.tree(text = "(t1,(((t2,t6),t4),(t3,t5)));"))
+
+  for (alpha in c(0, 0.5, 1)) {
+    scores <- vapply(AllRootings(tr), function(rooted) {
+      TreeLength(rooted, ds, hierarchy = h, inapplicable = "hsj",
+                 hsj_alpha = alpha)
+    }, double(1))
+    # Pre-fix this tree gave 7 and 7.5 across its rootings at alpha = 1. The
+    # alpha = 0 arm was already invariant and is kept as the control showing
+    # the dependence lived entirely in the alpha * d / m term.
+    expect_equal(length(unique(round(scores, 10))), 1L,
+                 info = sprintf("alpha = %s; scores %s", alpha,
+                                paste(unique(round(scores, 6)), collapse = "/")))
+  }
+})
+
+test_that("HSJ rooting invariance holds over random mixed matrices (T-374)", {
+  set.seed(374)
+  nTip <- 9L
+  for (rep in 1:8) {
+    pri <- rep("1", nTip)
+    pri[sample.int(nTip, 3L)] <- "0"
+    live <- pri != "0"
+    sec <- matrix("-", nTip, 3L)
+    for (j in 1:3) sec[live, j] <- sample(c("0", "1"), sum(live), TRUE)
+    nonHier <- matrix(sample(c("0", "1"), nTip * 3L, TRUE), nTip, 3L)
+    mat <- cbind(pri, sec, nonHier)
+    rownames(mat) <- paste0("t", seq_len(nTip))
+    colnames(mat) <- NULL
+
+    ds <- MatrixToPhyDat(mat)
+    h <- CharacterHierarchy("1" = 2:4)
+    tr <- Preorder(as.phylo(rep, nTip, tipLabels = rownames(mat)))
+    scores <- vapply(AllRootings(tr), function(rooted) {
+      TreeLength(rooted, ds, hierarchy = h, inapplicable = "hsj", hsj_alpha = 1)
+    }, double(1))
+    expect_equal(length(unique(round(scores, 10))), 1L,
+                 info = sprintf("replicate %d: scores %s", rep,
+                                paste(unique(round(scores, 6)), collapse = "/")))
+  }
+})
+
+test_that("HSJ does not charge the inapplicable state as a mismatch (T-374)", {
+  # Isolates defect 1 from the rooting question, at a FIXED rooting, so it
+  # fails even where the rooting sweep above happens not to.
+  #
+  # Where the controlling primary codes the structure absent, a secondary is
+  # inapplicable, and "-" and "?" are two spellings of the same statement:
+  # this character does not apply to this tip, so it constrains the
+  # reconstruction not at all. The two codings must therefore score alike.
+  # Pre-fix they did not: "-" was an ordinary state that the uppass could
+  # propagate into the present region, where it is disjoint from every present
+  # neighbour in every secondary at once and cost the branch a full alpha,
+  # while "?" (correctly multi-bit since T-375) never mismatches.
+  #
+  # NB the p.5 "<= 1 per branch" bound is NOT used here: summed over a tree it
+  # is far too loose to notice this, and it passes against a pre-fix build.
+  # This matrix was searched for specifically because it separates the two
+  # codings at a fixed rooting; pre-fix, tree 1 scores 9 under "-" against
+  # 8.666... under "?", the 1/3 being one spurious mismatch with m = 3.
+  # Column 5 keeps a "-" in BOTH codings so ValidateHierarchy is satisfied.
+  dashMat <- matrix(c(
+    # pri  sec2  sec3  sec4  nh5   nh6
+    "0",  "-",  "-",  "-",  "-",  "1",
+    "0",  "-",  "-",  "-",  "1",  "0",
+    "1",  "0",  "1",  "0",  "0",  "0",
+    "1",  "1",  "1",  "0",  "0",  "0",
+    "1",  "1",  "1",  "0",  "1",  "1",
+    "1",  "1",  "0",  "0",  "0",  "1",
+    "0",  "-",  "-",  "-",  "0",  "0",
+    "1",  "0",  "1",  "0",  "1",  "1"
+  ), nrow = 8, byrow = TRUE, dimnames = list(paste0("t", 1:8), NULL))
+  quesMat <- dashMat
+  quesMat[dashMat[, 1] == "0", 2:4] <- "?"
+
+  dashDs <- MatrixToPhyDat(dashMat)
+  quesDs <- MatrixToPhyDat(quesMat)
+  h <- CharacterHierarchy("1" = 2:4)
+
+  for (i in 1:6) {
+    tr <- Preorder(as.phylo(i, 8, tipLabels = rownames(dashMat)))
+    expect_equal(
+      TreeLength(tr, dashDs, hierarchy = h, inapplicable = "hsj",
+                 hsj_alpha = 1),
+      TreeLength(tr, quesDs, hierarchy = h, inapplicable = "hsj",
+                 hsj_alpha = 1),
+      info = sprintf("tree %d", i)
+    )
+  }
+})
+
+test_that("an all-present HSJ block matches the closed form (T-374)", {
+  # Under ANY most-parsimonious reconstruction of secondary j, the number of
+  # branches on which j changes is FitchLen_j. So with every node present the
+  # alpha term is (alpha / m) * sum_j FitchLen_j exactly, whichever labelling
+  # the uppass picks. This is the regression floor: it held before the T-374
+  # work and must keep holding, and it is why the defects could only ever
+  # surface on blocks with mixed present/absent primaries.
+  set.seed(3741)
+  nTip <- 9L
+  nSec <- 4L
+  for (rep in 1:6) {
+    sec <- matrix(sample(c("0", "1"), nTip * nSec, TRUE), nTip, nSec)
+    nonHier <- matrix(sample(c("0", "1"), nTip * 3L, TRUE), nTip, 3L)
+    nonHier[1, 1] <- "-"   # inapplicable-token carrier ValidateHierarchy needs
+    mat <- cbind(rep("1", nTip), sec, nonHier)
+    rownames(mat) <- paste0("t", seq_len(nTip))
+    colnames(mat) <- NULL
+
+    ds <- MatrixToPhyDat(mat)
+    h <- CharacterHierarchy("1" = 2:(nSec + 1L))
+    tr <- Preorder(as.phylo(rep, nTip, tipLabels = rownames(mat)))
+
+    fitchPri <- TreeLength(tr, MatrixToPhyDat(
+      mat[, c(1L, (nSec + 2L):ncol(mat)), drop = FALSE]))
+    secLen <- sum(vapply(2:(nSec + 1L), function(j)
+      TreeLength(tr, MatrixToPhyDat(mat[, j, drop = FALSE])), double(1)))
+
+    for (alpha in c(0.5, 1)) {
+      expect_equal(
+        TreeLength(tr, ds, hierarchy = h, inapplicable = "hsj",
+                   hsj_alpha = alpha),
+        fitchPri + alpha * secLen / nSec,
+        info = sprintf("replicate %d, alpha = %s", rep, alpha)
+      )
+    }
+  }
+})
+
+test_that("Figure 1 of Hopkins & St John (2021) scores 7 and 5 (T-374)", {
+  # Fig. 1 gives HSJ = 7 for ((t1,t2),(t3,t4)) and 5 for ((t1,t4),(t2,t3)) at
+  # alpha = 1; re-derived as 6 + alpha and 3 + 2 * alpha, two equations
+  # satisfied by one alpha, obtained without choosing a root. Character 9 is
+  # the inapplicable-token carrier ValidateHierarchy demands; its only non-"1"
+  # cell is a lone "-", which the Fitch pass scores as costing nothing.
+  figOne <- matrix(c(
+    "1", "1", "1", "1", "1", "0", "0", "0", "-",
+    "1", "1", "1", "1", "1", "1", "1", "1", "1",
+    "1", "0", "0", "0", "0", "1", "1", "1", "1",
+    "1", "0", "0", "0", "0", "0", "0", "0", "1"
+  ), nrow = 4, byrow = TRUE, dimnames = list(paste0("t", 1:4), NULL))
+  ds <- MatrixToPhyDat(figOne)
+  h <- CharacterHierarchy("1" = 2:5)
+  left <- Preorder(ape::read.tree(text = "((t1,t2),(t3,t4));"))
+  right <- Preorder(ape::read.tree(text = "((t1,t4),(t2,t3));"))
+
+  for (alpha in c(0, 0.5, 1)) {
+    expect_equal(TreeLength(left, ds, hierarchy = h, inapplicable = "hsj",
+                            hsj_alpha = alpha), 6 + alpha)
+    expect_equal(TreeLength(right, ds, hierarchy = h, inapplicable = "hsj",
+                            hsj_alpha = alpha), 3 + 2 * alpha)
+  }
+})
+
+test_that("MaximizeParsimony HSJ pool reproduces its reported score (T-374)", {
+  # T-374's headline symptom: a reported best score that TreeLength() of the
+  # engine's own returned trees does not reproduce.
+  #
+  # Bounded by REPLICATES, not seconds. Under a wall-clock bound the pool that
+  # comes back depends on machine speed, so which replicate the search stops at
+  # -- and hence whether a discordant tree is in it at all -- varies between
+  # runs; an earlier draft of this test was flaky in both directions for
+  # exactly that reason, passing against a pre-fix build often enough to be
+  # worthless. As written, 14 of the first 40 seeds are discordant pre-fix;
+  # seeds 5, 8, 9, 10 and 12 are among them, so the loop below witnesses the
+  # bug five times over. Worst pre-fix gap 0.75, with pools spanning e.g.
+  # 24/24.25/24.5/24.75 against a reported 24. The whole loop runs in ~1 s.
+  for (seed in 1:12) {
+    set.seed(seed)
+    nTip <- 14L
+    pri <- rep("1", nTip)
+    pri[sample.int(nTip, 5L)] <- "0"
+    live <- pri != "0"
+    sec <- matrix("-", nTip, 4L)
+    for (j in 1:4) sec[live, j] <- sample(c("0", "1"), sum(live), TRUE)
+    nonHier <- matrix(sample(c("0", "1"), nTip * 7L, TRUE), nTip, 7L)
+    mat <- cbind(pri, sec, nonHier)
+    rownames(mat) <- paste0("t", seq_len(nTip))
+    colnames(mat) <- NULL
+
+    ds <- MatrixToPhyDat(mat)
+    h <- CharacterHierarchy("1" = 2:5)
+    res <- suppressWarnings(MaximizeParsimony(
+      ds, hierarchy = h, inapplicable = "hsj", hsj_alpha = 1,
+      maxReplicates = 3, verbosity = 0))
+    trees <- if (inherits(res, "phylo")) list(res) else res
+    lengths <- vapply(trees, function(tr) TreeLength(
+      tr, ds, hierarchy = h, inapplicable = "hsj", hsj_alpha = 1), double(1))
+    expect_equal(unname(lengths),
+                 rep(attr(res, "score"), length(lengths)),
+                 info = sprintf("seed %d", seed))
+  }
+})

--- a/vignettes/inapplicable.Rmd
+++ b/vignettes/inapplicable.Rmd
@@ -159,6 +159,7 @@ xform_trees <- MaximizeParsimony(dataset, hierarchy = hierarchy,
 | Hierarchy required | No | Yes | Yes |
 | Secondary char. variation | Not modelled | Penalised (via \U{03B1}) | Penalised (via Hamming) |
 | Gain/loss asymmetry | No | No | Yes (n+1 : 1) |
+| Rooting-invariant score | Yes | Yes | No |
 | Tuning parameter | None | `hsj_alpha` | None |
 | Speed | Fastest | Moderate | Moderate |
 

--- a/vignettes/search-algorithm.Rmd
+++ b/vignettes/search-algorithm.Rmd
@@ -86,6 +86,17 @@ internal order in which a dataset's observed character-state tokens happen
 to be stored -- that internal order need not match, and often does not
 match, the order of the character states themselves.
 
+An HSJ score is a property of the unrooted tree.
+The criterion sums a symmetric dissimilarity over the branches and
+minimizes over the labellings of the internal nodes, so where the tree is
+rooted cannot affect it; a score reported by `MaximizeParsimony()` is
+therefore reproduced exactly by `TreeLength()` of the tree returned.
+Secondary characters place no constraint on taxa whose controlling primary
+codes the structure absent, since there the secondary does not exist.
+The x-transformation differs on both counts: its step matrix is asymmetric,
+so its scores *are* rooting-sensitive, and they are reported at a
+canonical rooting rather than being rooting-free.
+
 ## Starting trees
 
 ### Wagner tree construction


### PR DESCRIPTION
Closes the HSJ half of red-team finding **T-374 (P1)**. Stacked conceptually on
PR #280 (T-375/T-376), which had to land first for the primary term to be a
function of the data at all.

## What was actually wrong

**The brief's premise needs correcting, and it changed the shape of the work.**
`score_hierarchy_block()`'s `a(n)`/`p(n)` recurrences already **are** the
paper's Algorithm 1 (p.15), lines 6-7, term for term. The two-state DP was
implemented, and it was already rooting-invariant: its branch costs are
symmetric and it minimises over the root's own state. No DP rework was needed.

The defect was that `d(u, v)` — the secondary dissimilarity — was read off
`fitch_label_char()`'s directional resolution. Two distinct mechanisms:

1. **Semantic.** `"-"` was admitted as an ordinary state of a secondary
   character. Where a controlling primary codes a structure absent its
   secondaries do not exist, so `"-"` there is not a state the character takes.
   Admitting it let the uppass propagate `"-"` *inwards* and label a node in the
   middle of the **present** region "inapplicable", where it is disjoint from
   every present neighbour in every secondary at once — charging that branch
   `d = m`, the full alpha. That over-charge is wrong under *any* rooting; the
   paper's `d` counts nonmatching secondaries among characters that **apply**
   (p.5).
2. **Directional.** The remaining resolution was a DELTRAN uppass whose
   direction, and tie-break support counts whose subtrees, were properties of
   the input rooting.

Copying Algorithm 1 literally would not have fixed this either: its line 2 sets
`L(n)` to the first-pass Fitch labelling — a **downpass**, hence root-dependent —
and it takes "Tree, T, with root r" as *input*. Theorem 2 claims it returns the
minimal score, which would make it rooting-invariant; the measurements below are
evidence against that claim as stated.

## Key measurement that localised it

Under **any** most-parsimonious reconstruction of secondary *j*, the number of
branches on which *j* changes is `FitchLen_j`. So for an **all-present** block
the alpha term is `(alpha/m) * sum_j FitchLen_j` **exactly**, whichever
labelling the uppass picks — that regime was always invariant. Confirmed 50/50
on random data, and it reproduces Fig. 1 exactly (`6+alpha` and `3+2alpha`, i.e.
7 and 5 at alpha = 1). **The bug could therefore only ever surface on blocks
with mixed present/absent primaries**, which is what collapsed the design space.

Root-dependent topologies / worst spread, over **every edge-rooting** of 30
random 9-tip topologies at alpha = 1:

| regime | `93c81a9a` | + fix 1 | + fix 2 |
|---|---|---|---|
| all-present | 0/30  0.00 | 0/30  0.00 | 0/30  0.00 |
| mixed, m = 2 | 21/30  1.00 | 3/30  0.50 | **0/30  0.00** |
| mixed, m = 4 | 26/30  1.00 | 7/30  0.25 | **0/30  0.00** |
| `?` primary, m = 2 | 6/30  0.50 | 1/30  0.50 | **0/30  0.00** |
| `?` primary, m = 4 | 18/30  0.50 | 3/30  0.50 | **0/30  0.00** |

Re-run crossed with 3-state secondaries after review: 0/30 and spread 0.0000 in
all twelve cells.

**Headline symptom, closed.** Twelve HSJ searches on 16-tip mixed matrices: 3/12
returned trees whose `TreeLength()` disagreed with the reported score (worst gap
0.75, one pool spanning 31.25/31.5/31.75/32) both at `93c81a9a` **and after fix
1 alone**; now 0/12, every pool internally consistent.

## Why canonical rooting, and why that is not PR #278 again

The exact minimum over labellings is the inapplicable-Fitch problem and is not
available in linear time. (The per-branch min-over-MPR relaxation is refuted: a
`0,1,0,1` caterpillar gives sum-of-min 0 against min-of-sum 2.) A composite
Sankoff over `{absent}` plus all secondary combinations, with the symmetric HSJ
cost matrix, **would** be exact and is likewise rooting-invariant — the matrix
satisfies the triangle inequality, so even edge-subdivision is safe — but it is
exponential in the number of secondaries and is what the XFORM path already
does; it would delete HSJ's reason to exist alongside XFORM. So the labelling
passes are rooted canonically at tip 0 **inside the kernel**.

This is deliberately *not* PR #278's reporting-boundary canonicalisation, which
the brief rightly pre-empted. That left search optimising a root-dependent
objective and reconciled the number afterwards. This makes the objective the
**search** optimises a function of the unrooted topology, so `MaximizeParsimony`
agrees with `TreeLength` by construction rather than by re-scoring. **It buys
invariance, not exactness.** The option was put to the maintainer with the
measured residual attached and chosen explicitly.

## Scope of the freeing rule (review catch)

A secondary is freed only where its primary **cannot be present**, not merely
where it *may* be absent. The lax test would wildcard the secondaries of a `"?"`
primary even when they were **observed** — discarding real evidence that the
structure is present — and would be self-erasing, since a block of all-`"?"`
primaries would then have an empty applicable domain and a silently zero alpha
term. `ValidateHierarchy` whitelists `"?"` primaries, so that data is reachable.
This matches `recode_hierarchy.R`'s `tipStates == -2L` / `tipSecKnown` path,
added under T-379 for the same reason.

## Tests

In `test-ts-hsj.R`, all phrased against what the paper requires. Verified
against a build of `93c81a9a` in a throwaway worktree — note
`testthat::set_max_fails(Inf)`, as the default cap of 10 silently hid the last
test on the first attempt:

| test | pre-fix failures |
|---|---|
| rooting invariance, fixed mixed block | 2 (alpha = 0 passes, as the control) |
| rooting invariance, random matrices, crossed over 2/3-state secondaries and `"0"`/`"?"` primaries | 13 |
| `"-"` vs `"?"` at an inapplicable secondary | 5 |
| `MaximizeParsimony` pool vs reported score | 5 |

Three are regression **floors** (pass before and after, to catch a fix that buys
invariance by breaking what was right): Fig. 1 = 7/5; the all-present closed
form; and "an observed secondary at a `?` primary still counts", which pins the
*narrowness* of the freeing rule — discarding information is perfectly
rooting-invariant, so no other test here would have caught the lax version.

Two tests had to be rebuilt before they tested anything. The `"-"` vs `"?"` test
first used the p.5 "at most 1 per branch" bound, which summed over a tree is far
too loose and **passed against the pre-fix build**. The `MaximizeParsimony` test
was first bounded by `maxSeconds` and was flaky in both directions; it is now
bounded by `maxReplicates`, on a construction where 14 of the first 40 seeds are
discordant pre-fix.

`hsj-paper-oracle.R` goes 13 pass / 4 fail at `93c81a9a` to 17 / 0, with every
other check identical across the two builds. Its rooting check now sweeps all
`2n-3` edges and adds the discriminating mixed-block cases; its old header
corollary about the missing two-state DP is corrected.

## Other

- Four now-false root-invariance comments narrowed to XFORM rather than deleted
  (`ts_tbr.cpp` x2, `ts_rcpp.cpp`, `R/MaximizeParsimony.R`).
  `ts_tbr.cpp:802-818` was already correct and is untouched.
- Per-score cost unchanged (0.030 s median for 40 x 60-tip HSJ `TreeLength`,
  both builds); the canonical order is built once per block, not per character.
- Full suite: 33 failures before and after, identical file-by-file — all
  pre-existing `test_dir`-outside-`R CMD check` artefacts.
- **CI note:** `windows-latest (release)` and `EasyTrees shinytest2` fail on the
  `cpp-search` base branch too, in the "Set up R dependencies" step —
  pre-existing and unrelated to this PR.
- NEWS and both vignettes updated. **HSJ scores on mixed data may differ.**
  Measured by differencing the two builds at each tree's own rooting over 180
  tree-matrix pairs: 152 unchanged, 27 decreased (by up to 1), **1 increased by
  0.25** — a rise is possible because the score is now taken at a fixed
  canonical rooting rather than at whichever rooting the tree arrived in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)